### PR TITLE
Fix bug in DNS code

### DIFF
--- a/main/tasks/stratum_task.c
+++ b/main/tasks/stratum_task.c
@@ -30,13 +30,11 @@ static StratumApiV1Message stratum_api_v1_message = {};
 
 void dns_found_cb(const char *name, const ip_addr_t *ipaddr, void *callback_arg)
 {
-    if ((ipaddr != NULL)) {
+    if (ipaddr != NULL) {
         ip4_addr_t ip4addr = ipaddr->u_addr.ip4; // Obtener la estructura ip4_addr_t
-        if (ip4_addr1(&ip4addr) != 0 && ip4_addr2(&ip4addr) != 0 && ip4_addr3(&ip4addr) != 0 && ip4_addr4(&ip4addr) != 0) {
-            ESP_LOGI(TAG, "IP found : %d.%d.%d.%d", ip4_addr1(&ip4addr), ip4_addr2(&ip4addr), ip4_addr3(&ip4addr),
-                     ip4_addr4(&ip4addr));
-            ip_Addr = *ipaddr;
-        }
+        ESP_LOGI(TAG, "IP found : %d.%d.%d.%d", ip4_addr1(&ip4addr), ip4_addr2(&ip4addr), ip4_addr3(&ip4addr),
+                 ip4_addr4(&ip4addr));
+        ip_Addr = *ipaddr;
     } else {
         bDNSInvalid = true;
     }


### PR DESCRIPTION
This is a fix for the issue with pool records that have a zero in one or more of their IP octets (e.g. 51.81.0.15). https://github.com/skot/ESP-Miner/issues/329

The issue is that we are checking if one of the octets is a zero and if we get at least one we return without setting the DNS valid flag. If we don't get a zero we pass, but a zero in an IP octet is a perfectly valid value, so we should be passing as long as we aren't getting a null value.

Of course we could be more pedantic here as there are invalid values we could be looking for, but those are very unlikely to be received as valid DNS results, unless they are intentional (e.g. 127.0.0.1 or 0.0.0.0).

tl;dr this logic isn't really necessary and it should be enough to just remove it. Tested with a few pools and custom DNS records.