### PR TITLE
use slightly higher init voltage

### DIFF
--- a/components/bm1397/include/asic.h
+++ b/components/bm1397/include/asic.h
@@ -22,9 +22,11 @@
 #define CMD_READ 0x02
 #define CMD_INACTIVE 0x03
 
-#define CMD_WRITE_SINGLE (TYPE_CMD | GROUP_SINGLE | CMD_WRITE)
-#define CMD_WRITE_ALL    (TYPE_CMD | GROUP_ALL | CMD_WRITE)
-#define CMD_READ_ALL    (TYPE_CMD | GROUP_ALL | CMD_READ)
+#define CMD_WRITE_SINGLE (TYPE_CMD | GROUP_SINGLE | CMD_WRITE) // 0x41
+#define CMD_WRITE_ALL (TYPE_CMD | GROUP_ALL | CMD_WRITE)       // 0x51
+#define CMD_READ_ALL (TYPE_CMD | GROUP_ALL | CMD_READ)         // 0x52
+#define CMD_READ_SINGLE (TYPE_CMD | GROUP_SINGLE | CMD_READ)   // 0x42
+#define CMD_INACTIVE_ALL (TYPE_CMD | GROUP_ALL | CMD_INACTIVE) // 0x53
 
 
 #define RESPONSE_CMD 0x00
@@ -64,7 +66,7 @@ typedef struct __attribute__((__packed__))
 } asic_result_t;
 
 class Asic {
-protected:
+  protected:
     float m_current_frequency;
 
     void send(uint8_t header, uint8_t *data, uint8_t data_len, bool debug);
@@ -80,11 +82,11 @@ protected:
     bool receiveWork(asic_result_t *result);
 
     // asic model specific
-    virtual const uint8_t* getChipId() = 0;
+    virtual const uint8_t *getChipId() = 0;
     virtual uint8_t jobToAsicId(uint8_t job_id) = 0;
     virtual uint8_t asicToJobId(uint8_t asic_id) = 0;
 
-public:
+  public:
     Asic();
     uint8_t sendWork(uint32_t job_id, bm_job *next_bm_job);
     bool processWork(task_result *result);

--- a/main/boards/drivers/TPS53647.cpp
+++ b/main/boards/drivers/TPS53647.cpp
@@ -346,7 +346,6 @@ int TPS53647_init(int num_phases)
 
     /* set ON_OFF config, make sure the buck is switched off */
     smb_write_byte(PMBUS_ON_OFF_CONFIG, ON_OFF_CONFIG);
-    // smb_write_byte(PMBUS_OPERATION, OPERATION_OFF);
 
     // Switch frequency, 500kHz
     smb_write_byte(PMBUS_MFR_SPECIFIC_12, 0x20); // default value
@@ -380,13 +379,6 @@ int TPS53647_init(int num_phases)
     smb_write_word(PMBUS_IOUT_OC_WARN_LIMIT, float_2_slinear11(TPS53647_INIT_IOUT_OC_WARN_LIMIT));
     smb_write_word(PMBUS_IOUT_OC_FAULT_LIMIT, float_2_slinear11(TPS53647_INIT_IOUT_OC_FAULT_LIMIT));
 
-    /* vout voltage */
-    // smb_write_word(PMBUS_VOUT_COMMAND, (uint16_t) volt_to_vid(0.75));//TPS53647_INIT_VOUT_COMMAND));
-    // smb_write_byte(PMBUS_OPERATION, OPERATION_ON);
-    //   smb_write_word(PMBUS_VOUT_COMMAND, (uint16_t) volt_to_vid(1.15));//TPS53647_INIT_VOUT_COMMAND));
-
-    /* Show voltage settings */
-    //TPS53647_show_voltage_settings();
     is_initialized = true;
 
     return 0;

--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -62,8 +62,8 @@ bool NerdQaxePlus::init()
     // disable LDO
     LDO_disable();
 
-    // set reset high
-    gpio_set_level(BM1368_RST_PIN, 1);
+    // set reset low
+    gpio_set_level(BM1368_RST_PIN, 0);
 
     // wait 250ms
     vTaskDelay(250 / portTICK_PERIOD_MS);
@@ -76,7 +76,9 @@ bool NerdQaxePlus::init()
 
     // init buck and enable output
     TPS53647_init(m_numPhases);
-    setVoltage(m_asicVoltage / 1000.0);
+
+    // give the asics a slight but-kick
+    setVoltage(1.25);
 
     // wait 500ms
     vTaskDelay(500 / portTICK_PERIOD_MS);
@@ -85,7 +87,7 @@ bool NerdQaxePlus::init()
     gpio_set_level(BM1368_RST_PIN, 1);
 
     // delay for 100ms
-    vTaskDelay(100 / portTICK_PERIOD_MS);
+    vTaskDelay(250 / portTICK_PERIOD_MS);
 
     SERIAL_clear_buffer();
     if (!asics.init(m_asicFrequency, m_asicCount, m_asicMaxDifficulty)) {
@@ -96,6 +98,10 @@ bool NerdQaxePlus::init()
     SERIAL_clear_buffer();
 
     vTaskDelay(500 / portTICK_PERIOD_MS);
+
+    // set final output voltage
+    setVoltage(m_asicVoltage / 1000.0);
+
     return true;
 }
 


### PR DESCRIPTION
Sometimes initialization seems to not work clean and somewhere are some hundred GHs missing

In this cases the miner consumes 1W more. Not sure why.

It seems to fix it during mining when changing the ASIC voltage to 1.25V and back to 1.20V in the web UI.

Maybe it has something to do with voltage drop on the 4L board (from 1200mV actually only 1136mV reach the ASIC) and the voltage drop causes randomly to not initialize the ASICs properly.

This is the try to fix it by initialize with 1.25V and switch afterwards to the set voltage.

Let's see ... :crossed_fingers: 

--
on the piaxe-miner it seems that after the device specific initialization I added a 500ms delay - not sure why ... maybe I had such problems before on the QAxe? :face_with_spiral_eyes: 