### PR TITLE
changes on hashrate, not sure if this is so great

### DIFF
--- a/main/displays/displayDriver.cpp
+++ b/main/displays/displayDriver.cpp
@@ -423,9 +423,9 @@ void DisplayDriver::updateHashrate(System *module, float power)
 {
     char strData[20];
 
-    float efficiency = power / (module->getCurrentHashrate10m() / 1000.0);
+    float efficiency = power / (module->getCurrentHashrate() / 1000.0);
 
-    snprintf(strData, sizeof(strData), "%.1f", module->getCurrentHashrate10m());
+    snprintf(strData, sizeof(strData), "%.1f", module->getCurrentHashrate());
     lv_label_set_text(m_ui->ui_lbHashrate, strData);    // Update hashrate
     lv_label_set_text(m_ui->ui_lbHashrateSet, strData); // Update hashrate
     lv_label_set_text(m_ui->ui_lblHashPrice, strData);  // Update hashrate

--- a/main/history.h
+++ b/main/history.h
@@ -20,11 +20,14 @@ class NonceDistribution {
     void toLog();
 };
 
+// timespan is fixed, used sample count is variable
 class HistoryAvg {
+  private:
+    uint64_t m_timespan = 0;
+
   protected:
     int m_firstSample = 0;
     int m_lastSample = 0;
-    uint64_t m_timespan = 0;
     uint64_t m_diffSum = 0;
     double m_avg = 0;
     double m_avgGh = 0;
@@ -50,7 +53,18 @@ class HistoryAvg {
     {
         return m_preliminary;
     };
-    void update();
+    virtual void update();
+};
+
+// timespan is variable, numer of samples is capped
+class HistoryAvgMaxSamples : public HistoryAvg {
+  private:
+    uint32_t m_numMaxSamples = 0;
+
+  public:
+    HistoryAvgMaxSamples(History *history, uint64_t numMaxSamples);
+
+    virtual void update();
 };
 
 class History {
@@ -64,6 +78,7 @@ class History {
 
     pthread_mutex_t m_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+    HistoryAvgMaxSamples m_avg;
     HistoryAvg m_avg10m;
     HistoryAvg m_avg1h;
     HistoryAvg m_avg1d;
@@ -84,6 +99,7 @@ class History {
     float getHashrate1hSample(int index);
     float getHashrate1dSample(int index);
     uint64_t getCurrentTimestamp(void);
+    double getCurrentHashrate();
     double getCurrentHashrate10m();
     double getCurrentHashrate1h();
     double getCurrentHashrate1d();

--- a/main/http_server/axe-os/src/app/components/home/home.component.html
+++ b/main/http_server/axe-os/src/app/components/home/home.component.html
@@ -12,7 +12,7 @@
                             <div class="flex justify-content-between mb-3">
                                 <div>
                                     <span class="block text-500 font-medium mb-3">Hash Rate</span>
-                                    <div class="text-900 font-medium text-xl">{{info.hashRate_10m | number: '1.2-2'}}
+                                    <div class="text-900 font-medium text-xl">{{info.hashRate | number: '1.2-2'}}
                                         <small>Gh/s</small>
                                     </div>
                                 </div>
@@ -50,7 +50,7 @@
                                 <div>
                                     <span class="block text-500 font-medium mb-3">Efficiency</span>
                                     <div class="text-900 font-medium text-xl">
-                                        <td>{{info.power / (info.hashRate_10m/1000) | number: '1.2-2'}} <small>J/Th</small>
+                                        <td>{{info.power / (info.hashRate/1000) | number: '1.2-2'}} <small>J/Th</small>
                                         </td>
                                     </div>
                                 </div>

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -15,6 +15,7 @@ const defaultInfo: ISystemInfo = {
   temp: 60,
   vrTemp: 45,
   hashRateTimestamp: 1724398272483,
+  hashRate: 475,
   hashRate_10m: 475,
   hashRate_1h: 475,
   hashRate_1d: 475,

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -12,6 +12,7 @@ export interface ISystemInfo {
     temp: number,
     vrTemp: number,
     hashRateTimestamp: number,
+    hashRate: number,
     hashRate_10m: number,
     hashRate_1h: number,
     hashRate_1d: number,

--- a/main/http_server/http_server.cpp
+++ b/main/http_server/http_server.cpp
@@ -486,6 +486,7 @@ static esp_err_t GET_system_info(httpd_req_t *req)
     cJSON_AddNumberToObject(root, "temp", POWER_MANAGEMENT_MODULE.getAvgChipTemp());
     cJSON_AddNumberToObject(root, "vrTemp", POWER_MANAGEMENT_MODULE.getVrTemp());
     cJSON_AddNumberToObject(root, "hashRateTimestamp", history->getCurrentTimestamp());
+    cJSON_AddNumberToObject(root, "hashRate", history->getCurrentHashrate());
     cJSON_AddNumberToObject(root, "hashRate_10m", history->getCurrentHashrate10m());
     cJSON_AddNumberToObject(root, "hashRate_1h", history->getCurrentHashrate1h());
     cJSON_AddNumberToObject(root, "hashRate_1d", history->getCurrentHashrate1d());

--- a/main/system.cpp
+++ b/main/system.cpp
@@ -33,7 +33,6 @@ System::System() {
 }
 
 void System::initSystem() {
-    m_currentHashrate10m = 0.0;
     m_screenPage = 0;
     m_sharesAccepted = 0;
     m_sharesRejected = 0;
@@ -294,6 +293,5 @@ void System::notifyFoundNonce(double poolDiff, int asicNr) {
 
     m_history->pushShare(poolDiff, timestamp, asicNr);
 
-    m_currentHashrate10m = m_history->getCurrentHashrate10m();
     updateHashrate();
 }

--- a/main/system.h
+++ b/main/system.h
@@ -3,10 +3,10 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "boards/board.h"
 #include "displays/displayDriver.h"
 #include "esp_netif.h"
 #include "freertos/queue.h"
-#include "boards/board.h"
 #include "history.h"
 
 // Configuration and constants
@@ -18,8 +18,7 @@
 class System {
   protected:
     // Hashrate and timing
-    double m_currentHashrate10m; // Current hashrate averaged over 10 minutes
-    int64_t m_startTime;         // System start time (in milliseconds)
+    int64_t m_startTime;      // System start time (in milliseconds)
 
     // Share statistics
     uint64_t m_sharesAccepted; // Number of accepted shares
@@ -50,7 +49,7 @@ class System {
     int m_poolErrors;  // Count of errors related to the mining pool
     bool m_overheated; // Flag to indicate if the system is overheated
 
-    const char* m_lastResetReason;
+    const char *m_lastResetReason;
 
     // Clock synchronization
     uint32_t m_lastClockSync; // Last clock synchronization timestamp
@@ -127,9 +126,14 @@ class System {
     {
         return m_startTime;
     }
+    double getCurrentHashrate() const
+    {
+        return m_history->getCurrentHashrate();
+    }
+
     double getCurrentHashrate10m() const
     {
-        return m_currentHashrate10m;
+        return m_history->getCurrentHashrate10m();
     }
 
     // Pool-related getters and setters
@@ -198,22 +202,25 @@ class System {
         m_startupDone = true;
     }
 
-    void setBoard(Board* board) {
+    void setBoard(Board *board)
+    {
         m_board = board;
     }
 
-    Board* getBoard() {
+    Board *getBoard()
+    {
         return m_board;
     }
 
-    History* getHistory() {
+    History *getHistory()
+    {
         return m_history;
     }
 
     void showLastResetReason();
 
-    const char* getLastResetReason() {
+    const char *getLastResetReason()
+    {
         return m_lastResetReason;
     }
-
 };


### PR DESCRIPTION
uses a fixed buffer size and variable timespan for the "faster" hashrate calculation of the "base hashrate" (shown on the display and as hashrate in AxeOS)

Not sure if this is so great ... maybe it should be possible to choose which hashrate to use via some config setting