### PR TITLE
passed deviceModel to web UI for usage as prefix on the esp-miner.bin…

### DIFF
--- a/main/http_server/axe-os/src/app/components/logs/logs.component.html
+++ b/main/http_server/axe-os/src/app/components/logs/logs.component.html
@@ -5,7 +5,7 @@
             <table *ngIf="info$ | async as info">
                 <tr>
                     <td>Model:</td>
-                    <td>{{info.ASICModel}}</td>
+                    <td>{{info.deviceModel}} ({{info.ASICModel}})</td>
                 </tr>
                 <tr>
                     <td>Uptime:</td>

--- a/main/http_server/axe-os/src/app/components/settings/settings.component.ts
+++ b/main/http_server/axe-os/src/app/components/settings/settings.component.ts
@@ -21,7 +21,7 @@ export class SettingsComponent {
   public firmwareUpdateProgress: number | null = null;
   public websiteUpdateProgress: number | null = null;
 
-
+  public deviceModel: string = "";
   public devToolsOpen: boolean = false;
   public eASICModel = eASICModel;
   public ASICModel!: eASICModel;
@@ -54,6 +54,7 @@ export class SettingsComponent {
 
       this.info$.pipe(this.loadingService.lockUIUntilComplete())
       .subscribe(info => {
+        this.deviceModel = info.deviceModel;
         this.ASICModel = info.ASICModel;
         this.form = this.fb.group({
           flipscreen: [info.flipscreen == 1],
@@ -142,9 +143,10 @@ export class SettingsComponent {
 
   otaUpdate(event: FileUploadHandlerEvent) {
     const file = event.files[0];
+    const expectedFileName = `esp-miner-${this.deviceModel}.bin`;
 
-    if (file.name != 'esp-miner.bin') {
-      this.toastrService.error('Incorrect file, looking for esp-miner.bin.', 'Error');
+    if (file.name !== expectedFileName) {
+      this.toastrService.error(`Incorrect file, looking for ${expectedFileName}.`, 'Error');
       return;
     }
 
@@ -157,13 +159,10 @@ export class SettingsComponent {
           } else if (event.type === HttpEventType.Response) {
             if (event.ok) {
               this.toastrService.success('Firmware updated', 'Success!');
-
             } else {
               this.toastrService.error(event.statusText, 'Error');
             }
-          }
-          else if (event instanceof HttpErrorResponse)
-          {
+          } else if (event instanceof HttpErrorResponse) {
             this.toastrService.error(event.error, 'Error');
           }
         },

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -37,6 +37,7 @@ const defaultInfo: ISystemInfo = {
   asicCount: 1,
   smallCoreCount: 672,
   ASICModel: eASICModel.BM1368,
+  deviceModel: "NerdQAxe+",
   stratumURL: "public-pool.io",
   stratumPort: 21496,
   stratumUser: "bc1q99n3pu025yyu0jlywpmwzalyhm36tg5u37w20d.bitaxe-U1",

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -33,6 +33,7 @@ export interface ISystemInfo {
     asicCount: number,
     smallCoreCount: number,
     ASICModel: eASICModel,
+    deviceModel: string,
     stratumURL: string,
     stratumPort: number,
     stratumUser: string,

--- a/main/http_server/http_server.cpp
+++ b/main/http_server/http_server.cpp
@@ -508,6 +508,7 @@ static esp_err_t GET_system_info(httpd_req_t *req)
     cJSON_AddNumberToObject(root, "asicCount", board->getAsicCount());
     cJSON_AddNumberToObject(root, "smallCoreCount", (board->getAsics()) ? board->getAsics()->getSmallCoreCount() : 0);
     cJSON_AddStringToObject(root, "ASICModel", board->getAsicModel());
+    cJSON_AddStringToObject(root, "deviceModel", board->getDeviceModel());
     cJSON_AddStringToObject(root, "stratumURL", stratumURL);
     cJSON_AddNumberToObject(root, "stratumPort", nvs_config_get_u16(NVS_CONFIG_STRATUM_PORT, CONFIG_STRATUM_PORT));
     cJSON_AddStringToObject(root, "stratumUser", stratumUser);


### PR DESCRIPTION
passed deviceModel to the frontend to use it for the esp-miner binary like

`esp-miner-NerdQAxe+.bin` instead of always insisting on `esp-miner.bin`