### PR TITLE
adds the old `hashRate` field to the info reponse because swarm uses it

### DIFF
--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -19,6 +19,7 @@ const defaultInfo: ISystemInfo = {
   temp: 60,
   vrTemp: 45,
   hashRateTimestamp: 1724398272483,
+  hashRate: 475,
   hashRate_10m: 475,
   hashRate_1h: 475,
   hashRate_1d: 475,

--- a/main/http_server/axe-os/src/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/models/ISystemInfo.ts
@@ -16,6 +16,7 @@ export interface ISystemInfo {
     temp: number,
     vrTemp: number,
     hashRateTimestamp: number,
+    hashRate: number,
     hashRate_10m: number,
     hashRate_1h: number,
     hashRate_1d: number,

--- a/main/http_server/http_server.cpp
+++ b/main/http_server/http_server.cpp
@@ -497,6 +497,7 @@ static esp_err_t GET_system_info(httpd_req_t *req)
     cJSON_AddNumberToObject(root, "temp", POWER_MANAGEMENT_MODULE.getAvgChipTemp());
     cJSON_AddNumberToObject(root, "vrTemp", POWER_MANAGEMENT_MODULE.getVrTemp());
     cJSON_AddNumberToObject(root, "hashRateTimestamp", history->getCurrentTimestamp());
+    cJSON_AddNumberToObject(root, "hashRate", history->getCurrentHashrate10m());
     cJSON_AddNumberToObject(root, "hashRate_10m", history->getCurrentHashrate10m());
     cJSON_AddNumberToObject(root, "hashRate_1h", history->getCurrentHashrate1h());
     cJSON_AddNumberToObject(root, "hashRate_1d", history->getCurrentHashrate1d());


### PR DESCRIPTION
adds back the `hashRate` field to the info response that is used by swarm