### PR TITLE
Fix regex check on ckpool

### DIFF
--- a/main/http_server/axe-os/src/app/components/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/components/home/home.component.ts
@@ -179,7 +179,7 @@ export class HomeComponent implements OnInit, OnDestroy {
         } else if (info.stratumURL.includes('solo.d-central.tech')) {
           const address = info.stratumUser.split('.')[0];
           return `https://solo.d-central.tech/#/app/${address}`;
-        } else if (/solo[46]?.ckpool.org/.test(info.stratumURL)) {
+        } else if (/solo[46]?\.ckpool\.org/.test(info.stratumURL)) {
           const address = info.stratumUser.split('.')[0];
           return `https://solo.ckpool.org/users/${address}`;
         } else {


### PR DESCRIPTION
The dots should be escaped, otherwise it matches on things we probably wouldn't want to match on:
![image](https://github.com/user-attachments/assets/d7097e96-5551-414c-b80b-049efe50885e)
