### PR TITLE
use asicVoltage for initialization if it's higher than initVoltage

### DIFF
--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -100,8 +100,8 @@ bool NerdQaxePlus::initAsics()
     // init buck and enable output
     TPS53647_init(m_numPhases, m_imax, m_ifault);
 
-     // set the init voltage
-    setVoltage(m_initVoltage ? m_initVoltage : m_asicVoltage);
+    // set the init voltage
+    setVoltage((m_initVoltage > m_asicVoltage) ? m_initVoltage : m_asicVoltage);
 
     // wait 500ms
     vTaskDelay(500 / portTICK_PERIOD_MS);

--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -1,3 +1,5 @@
+#include <math.h>
+
 #include "nvs_flash.h"
 #include "esp_log.h"
 
@@ -101,7 +103,8 @@ bool NerdQaxePlus::initAsics()
     TPS53647_init(m_numPhases, m_imax, m_ifault);
 
     // set the init voltage
-    setVoltage((m_initVoltage > m_asicVoltage) ? m_initVoltage : m_asicVoltage);
+    // use the higher voltage for initialization
+    setVoltage(fmaxf(m_initVoltage, m_asicVoltage));
 
     // wait 500ms
     vTaskDelay(500 / portTICK_PERIOD_MS);


### PR DESCRIPTION
The `initVoltage` was intended to have proper initialization on underclocked devices.

But the BM1368s seem to have quite some variance and some ASICs need higher voltage to run properly.

This PR fixes it by using the higher voltage of both initVoltage and asicVoltage.