### PR TITLE
Add ASICs High temp to power management task

### DIFF
--- a/main/tasks/asic_result_task.cpp
+++ b/main/tasks/asic_result_task.cpp
@@ -17,6 +17,8 @@ void ASIC_result_task(void *pvParameters)
     Asic* asics = board->getAsics();
 
     char *user = nvs_config_get_string(NVS_CONFIG_STRATUM_USER, STRATUM_USER);
+    float asic_temp = 0.0f;
+    int asic_count = board->getAsicCount() - 1;
 
     while (1) {
         //ESP_LOGI("Memory", "%lu", esp_get_free_heap_size()); test
@@ -31,8 +33,16 @@ void ASIC_result_task(void *pvParameters)
             switch (asic_result.reg) {
                 case 0xb4: {
                     if (asic_result.data & 0x80000000) {
-                        float ftemp = (float) (asic_result.data & 0x0000ffff) * 0.171342f - 299.5144f;;
-                        ESP_LOGI(TAG, "asic %d temp: %.3f", (int) asic_result.asic_nr, ftemp);
+                        float ftemp = (float) (asic_result.data & 0x0000ffff) * 0.171342f - 299.5144f;
+                        int asic_nr = (int) asic_result.asic_nr;
+                        ESP_LOGI(TAG, "asic %d temp: %.3f", asic_nr, ftemp);
+                        if (ftemp > asic_temp) {
+                            POWER_MANAGEMENT_MODULE.setAsicHighTemp(ftemp);
+                            asic_temp = ftemp;                                         
+                        }
+                        if ( asic_count == asic_nr){
+                                asic_temp = 0.0f;                                
+                        }
                     }
                     break;
                 }

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -111,10 +111,17 @@ void PowerManagementTask::task()
 
         m_chipTempAvg = board->readTemperature(0);
         m_vrTemp = board->readTemperature(1);
+        ESP_LOGI(TAG, "asic high temp: %.3f", m_asic_high_temp);
+
+        // to show the high temp in dashboard
+        if (m_asic_high_temp > m_chipTempAvg) m_chipTempAvg = m_asic_high_temp;
+
         influx_task_set_temperature(m_chipTempAvg, m_vrTemp);
 
         if (overheat_temp &&
-            (m_chipTempAvg > overheat_temp || m_vrTemp > overheat_temp)) {
+            // To keep the sensor and asic temp separated, comment the if above and uncomment below
+            // (m_chipTempAvg > overheat_temp || m_vrTemp > overheat_temp || m_asic_high_temp > overheat_temp)) {
+            (m_chipTempAvg > overheat_temp || m_vrTemp > overheat_temp )) {
             // over temperature
             SYSTEM_MODULE.setOverheated(true);
             // disables the buck

--- a/main/tasks/power_management_task.h
+++ b/main/tasks/power_management_task.h
@@ -17,6 +17,7 @@ class PowerManagementTask {
     void task();
 
   public:
+    float m_asic_high_temp;
     PowerManagementTask();
 
     static void taskWrapper(void *pvParameters);
@@ -49,4 +50,7 @@ class PowerManagementTask {
     {
         return m_fanPerc;
     };
+    void setAsicHighTemp(float asic_h_temp){
+        m_asic_high_temp = asic_h_temp;
+    }
 };


### PR DESCRIPTION
Take the high temperature into the power management task, to deal with differences in temperature readings.
I have a "lazy" ASIC (#0), it doesn't return any nonce, and its temperature is always lower than the others. So the temperature sensor returns almost 10 degrees lower than the other ASIC IC.