### PR TITLE
display PSU error after the buck defaulted to 1.00V

### DIFF
--- a/main/boards/board.h
+++ b/main/boards/board.h
@@ -70,6 +70,10 @@ class Board {
 
     virtual void requestBuckTelemtry() = 0;
 
+    virtual bool getPSUFault() {
+        return false;
+    }
+
     Theme *getTheme()
     {
         return m_theme;

--- a/main/boards/drivers/TPS53647.cpp
+++ b/main/boards/drivers/TPS53647.cpp
@@ -585,5 +585,12 @@ uint16_t TPS53647_get_vout_vid(void) {
     // 0x97 is 1.00V
     uint16_t vid = 0x97;
     smb_read_word(PMBUS_VOUT_COMMAND, &vid);
+    //ESP_LOGI(TAG, "vout_cmd: %02x", vid);
     return vid;
+}
+
+uint8_t TPS53647_get_status_byte(void) {
+    uint8_t status_byte = 0xff;
+    smb_read_byte(PMBUS_STATUS_BYTE, &status_byte);
+    return status_byte;
 }

--- a/main/boards/drivers/TPS53647.cpp
+++ b/main/boards/drivers/TPS53647.cpp
@@ -304,12 +304,13 @@ static uint16_t float_2_slinear11(float value)
 
 void TPS53647_status()
 {
-    uint8_t status_byte;
-    uint16_t status_word;
-    uint8_t status_vout;
-    uint8_t status_iout;
-    uint8_t status_input;
-    uint8_t status_mfr_specific;
+    uint8_t status_byte = 0xff;
+    uint16_t status_word = 0xffff;
+    uint8_t status_vout = 0xff;
+    uint8_t status_iout = 0xff;
+    uint8_t status_input = 0xff;
+    uint8_t status_mfr_specific = 0xff;
+    uint16_t vout_cmd = 0xffff;
 
     smb_read_byte(PMBUS_STATUS_BYTE, &status_byte);
     smb_read_word(PMBUS_STATUS_WORD, &status_word);
@@ -396,8 +397,8 @@ static void TPS53647_power_disable()
 
 int TPS53647_get_temperature(void)
 {
-    uint16_t value;
-    int temp;
+    uint16_t value = 0;
+    int temp = 0;
 
     if (!is_initialized) {
         return 0;
@@ -410,8 +411,8 @@ int TPS53647_get_temperature(void)
 
 float TPS53647_get_pin(void)
 {
-    uint16_t u16_value;
-    float pin;
+    uint16_t u16_value = 0;
+    float pin = 0.0f;
 
     if (!is_initialized) {
         return 0.0f;
@@ -428,8 +429,8 @@ float TPS53647_get_pin(void)
 
 float TPS53647_get_pout(void)
 {
-    uint16_t u16_value;
-    float pout;
+    uint16_t u16_value = 0;
+    float pout = 0.0f;
 
     if (!is_initialized) {
         return 0.0f;
@@ -446,8 +447,8 @@ float TPS53647_get_pout(void)
 
 float TPS53647_get_vin(void)
 {
-    uint16_t u16_value;
-    float vin;
+    uint16_t u16_value = 0;
+    float vin = 0.0f;
 
     if (!is_initialized) {
         return 0.0f;
@@ -464,8 +465,8 @@ float TPS53647_get_vin(void)
 
 float TPS53647_get_vout(void)
 {
-    uint16_t u16_value;
-    float vout;
+    uint16_t u16_value = 0;
+    float vout = 0.0f;
 
     if (!is_initialized) {
         return 0.0f;
@@ -482,8 +483,8 @@ float TPS53647_get_vout(void)
 
 float TPS53647_get_iin(void)
 {
-    uint16_t u16_value;
-    float iin;
+    uint16_t u16_value = 0;
+    float iin = 0.0f;
 
     if (!is_initialized) {
         return 0.0f;
@@ -501,8 +502,8 @@ float TPS53647_get_iin(void)
 
 float TPS53647_get_iout(void)
 {
-    uint16_t u16_value;
-    float iout;
+    uint16_t u16_value = 0;
+    float iout = 0.0f;
 
     if (!is_initialized) {
         return 0.0f;
@@ -578,4 +579,11 @@ void TPS53647_show_voltage_settings(void)
     smb_read_word(PMBUS_VOUT_MARGIN_LOW, &u16_value);
     f_value = vid_to_volt(u16_value);
     ESP_LOGI(TAG, "Vout Margin LOW: %f V", f_value);
+}
+
+uint16_t TPS53647_get_vout_vid(void) {
+    // 0x97 is 1.00V
+    uint16_t vid = 0x97;
+    smb_read_word(PMBUS_VOUT_COMMAND, &vid);
+    return vid;
 }

--- a/main/boards/drivers/TPS53647.h
+++ b/main/boards/drivers/TPS53647.h
@@ -39,5 +39,6 @@ float TPS53647_get_pout(void);
 void TPS53647_set_vout(float volts);
 void TPS53647_show_voltage_settings(void);
 void TPS53647_status();
+uint16_t TPS53647_get_vout_vid(void);
 
 #endif /* TPS53647_H_ */

--- a/main/boards/drivers/TPS53647.h
+++ b/main/boards/drivers/TPS53647.h
@@ -40,5 +40,6 @@ void TPS53647_set_vout(float volts);
 void TPS53647_show_voltage_settings(void);
 void TPS53647_status();
 uint16_t TPS53647_get_vout_vid(void);
+uint8_t TPS53647_get_status_byte(void);
 
 #endif /* TPS53647_H_ */

--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -194,9 +194,12 @@ float NerdQaxePlus::getPout() {
 
 bool NerdQaxePlus::getPSUFault() {
     uint16_t vid = TPS53647_get_vout_vid();
+    uint8_t status_byte = TPS53647_get_status_byte();
 
     // if we have 0x97 it means the buck was reset and
     // restarted with VBOOT. In this case we assume there
     // is a PSU error
-    return (vid == 0x97);
+    // in case of the PSUs over current protection (voltage will drop),
+    // we will see bit 3 "VIN_UV" in the status byte
+    return ((vid == 0x97) || (status_byte & 0x08));
 }

--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -192,3 +192,11 @@ float NerdQaxePlus::getPout() {
     return TPS53647_get_pout();
 }
 
+bool NerdQaxePlus::getPSUFault() {
+    uint16_t vid = TPS53647_get_vout_vid();
+
+    // if we have 0x97 it means the buck was reset and
+    // restarted with VBOOT. In this case we assume there
+    // is a PSU error
+    return (vid == 0x97);
+}

--- a/main/boards/nerdqaxeplus.h
+++ b/main/boards/nerdqaxeplus.h
@@ -35,4 +35,6 @@ class NerdQaxePlus : public Board {
     virtual float getIout();
     virtual float getPout();
     virtual void requestBuckTelemtry();
+
+    virtual bool getPSUFault();
 };

--- a/main/system.cpp
+++ b/main/system.cpp
@@ -54,6 +54,9 @@ void System::initSystem() {
     // Initialize overheat flag
     m_overheated = false;
 
+    // Initialize psu error flag
+    m_psuError = false;
+
     // Initialize shown overlay flag and last error code
     m_showsOverlay = false;
     m_currentErrorCode = 0;
@@ -212,7 +215,7 @@ void System::showError(const char *error_message, uint32_t error_code) {
     if (m_showsOverlay && m_currentErrorCode == error_code) {
         return;
     }
-    m_display->showError("MINER OVERHEATED", 0x14);
+    m_display->showError(error_message, error_code);
     m_showsOverlay = true;
     m_currentErrorCode = error_code;
 }
@@ -272,6 +275,10 @@ void System::task() {
 
         if (m_overheated) {
             showError("MINER OVERHEATED", 0x14);
+        }
+
+        if (m_psuError) {
+            showError("POWER ERROR", 0x15);
         }
 
         m_display->updateGlobalState();

--- a/main/system.cpp
+++ b/main/system.cpp
@@ -278,7 +278,7 @@ void System::task() {
         }
 
         if (m_psuError) {
-            showError("POWER ERROR", 0x15);
+            showError("PSU ERROR", 0x15);
         }
 
         m_display->updateGlobalState();

--- a/main/system.h
+++ b/main/system.h
@@ -50,6 +50,7 @@ class System {
     // Error tracking
     int m_poolErrors;  // Count of errors related to the mining pool
     bool m_overheated; // Flag to indicate if the system is overheated
+    bool m_psuError;   // Flag to indicate that there is some PSU problem
     bool m_showsOverlay;    // Flat if overlay is shown
     uint32_t m_currentErrorCode;
 
@@ -166,6 +167,11 @@ class System {
     void setOverheated(bool status)
     {
         m_overheated = status;
+    }
+
+    void setPSUError(bool status)
+    {
+        m_psuError = status;
     }
 
     // WiFi-related getters and setters

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -104,6 +104,17 @@ void PowerManagementTask::task()
 
         influx_task_set_pwr(vin, iin, pin, vout, iout, pout);
 
+        // currently only implemented for boards with TPS536x7
+        bool psuError = board->getPSUFault();
+        if (psuError) {
+            // when this happens, there is some PSU error
+            // on the nerdqaxes the buck restarted and defaulted to 1.00V
+            // this can happen when the PSU can't deliver enough current
+            // we display the error message and switch the buck off
+            SYSTEM_MODULE.setPSUError(true);
+            board->setVoltage(0.0);
+        }
+
         m_voltage = vin * 1000.0;
         m_current = iin * 1000.0;
         m_power = pin;


### PR DESCRIPTION
On a PSU error, e.g. it switched off during overcurrent condition and restartet, the buck defaults to the factory setting of 1.00V

Second case is current limit of PSU that sets the 3rd bit in the STATUS_BYTE

This PR detects it, shows an error message and switches off the buck.