### PR TITLE
show custom value on settings page

### DIFF
--- a/main/http_server/axe-os/src/app/components/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/components/edit/edit.component.html
@@ -60,61 +60,23 @@
             </div>
         </div>
 
-        <ng-container *ngIf="!devToolsOpen && ASICModel == eASICModel.BM1366">
-
+        <ng-container *ngIf="!devToolsOpen">
             <div class="field grid p-fluid">
                 <label class="col-12 mb-2 md:col-2 md:mb-0" htmlFor="frequency">Frequency</label>
                 <div class="col-12 md:col-10">
-                    <p-dropdown [options]="BM1366DropdownFrequency" optionLabel="name" optionValue="value"
-                        formControlName="frequency"></p-dropdown>
-                </div>
-            </div>
-
-
-            <div class="field grid p-fluid">
-                <label class="col-12 mb-2 md:col-2 md:mb-0" htmlFor="coreVoltage">Core Voltage</label>
-                <p-dropdown class="col-12 md:col-10" [options]="BM1366CoreVoltage" optionLabel="name"
-                    optionValue="value" formControlName="coreVoltage"></p-dropdown>
-            </div>
-
-        </ng-container>
-
-        <ng-container *ngIf="!devToolsOpen && ASICModel == eASICModel.BM1368">
-
-            <div class="field grid p-fluid">
-                <label class="col-12 mb-2 md:col-2 md:mb-0" htmlFor="frequency">Frequency</label>
-                <div class="col-12 md:col-10">
-                    <p-dropdown [options]="BM1368DropdownFrequency" optionLabel="name" optionValue="value"
+                    <p-dropdown [options]="frequencyOptions" optionLabel="name" optionValue="value"
                         formControlName="frequency"></p-dropdown>
                 </div>
             </div>
 
             <div class="field grid p-fluid">
                 <label class="col-12 mb-2 md:col-2 md:mb-0" htmlFor="coreVoltage">Core Voltage</label>
-                <p-dropdown class="col-12 md:col-10" [options]="BM1368CoreVoltage" optionLabel="name"
-                    optionValue="value" formControlName="coreVoltage"></p-dropdown>
-            </div>
-        </ng-container>
-
-        <ng-container *ngIf="!devToolsOpen && ASICModel == eASICModel.BM1370">
-
-            <div class="field grid p-fluid">
-                <label class="col-12 mb-2 md:col-2 md:mb-0" htmlFor="frequency">Frequency</label>
-                <div class="col-12 md:col-10">
-                    <p-dropdown [options]="BM1370DropdownFrequency" optionLabel="name" optionValue="value"
-                        formControlName="frequency"></p-dropdown>
-                </div>
-            </div>
-
-            <div class="field grid p-fluid">
-                <label class="col-12 mb-2 md:col-2 md:mb-0" htmlFor="coreVoltage">Core Voltage</label>
-                <p-dropdown class="col-12 md:col-10" [options]="BM1370CoreVoltage" optionLabel="name"
+                <p-dropdown class="col-12 md:col-10" [options]="voltageOptions" optionLabel="name"
                     optionValue="value" formControlName="coreVoltage"></p-dropdown>
             </div>
         </ng-container>
 
         <ng-container *ngIf="devToolsOpen === true">
-
             <div class="field grid p-fluid">
                 <label htmlFor="frequency" class="col-12 mb-2 md:col-2 md:mb-0">Frequency</label>
                 <div class="col-12 md:col-10">


### PR DESCRIPTION
Pro mode is entered when opening the dev-tools in the browser.

Drop-Down lists become free-text fields then. You can enter values that are not present as predefined value in the drop down lists.

The previous behavior was that when returning into normal mode the field was empty because there was no value in the predefined drop down list. 

Now the value is displayed as eg "1210 (custom)"

![image](https://github.com/user-attachments/assets/921a426c-5614-4799-a568-b5ea02e3a8c6)
