### PR TITLE
Add sha256 to release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,15 +118,15 @@ jobs:
         echo "VERSION_TAG=${version}"
 
     - name: Download SHA-256 Artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v3
       with:
-        path: ./sha256
-        merge-multiple: true
+        path: ./artifacts
 
     - name: Combine SHA-256 Sums
       run: |
         echo "### Factory files SHA-256 Checksums" > sha256-summary.txt
-        cat ./sha256/*.sha256 | sort -k2 >> sha256-summary.txt
+        files="$( find ./artifacts -name "*.sha256" | xargs )"
+        cat $files | sort -k2 >> sha256-summary.txt
 
     - name: Install GitHub CLI
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,10 +141,13 @@ jobs:
     - name: Append to Release Body
       run: |
         # Fetch the current release body
-        existing_notes=$(gh release view ${{ env.VERSION_TAG }} --json body -q '.body')
+        existing_notes="$(gh release view ${{ env.VERSION_TAG }} --json body -q '.body')"
 
         # Append the new content
-        new_notes="$existing_notes\n<\!--\n$(cat sha256-summary.txt)\n-->\n"
+        new_notes="$existing_notes\n"
+        new_notes+='<!--\n'
+        new_notes+="$(cat sha256-summary.txt)\n"
+        new_notes+='-->\n'
 
         # Update the release body
         gh release edit ${{ env.VERSION_TAG }} --notes "$(echo -e "$new_notes")"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -112,12 +112,8 @@ jobs:
 
     - name: Combine SHA-256 Sums
       run: |
-        echo "### Firmware SHA-256 Checksums" > sha256-summary.txt
-        for file in ./sha256/*.sha256; do
-          echo "#### $(basename $file .sha256)" >> sha256-summary.txt
-          cat "$file" >> sha256-summary.txt
-          echo "" >> sha256-summary.txt
-        done
+        echo "### Factory files SHA-256 Checksums" > sha256-summary.txt
+        cat *.sha256 | sort -k2 > sha256-summary.txt
 
     - name: Update Release Body
       uses: github/gh-cli@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,9 @@ jobs:
         cat ./sha256/*.sha256 | sort -k2 >> sha256-summary.txt
 
     - name: Install GitHub CLI
-      uses: cli/gh-cli@v1
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y gh
 
     - name: Update Release Body
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: ./sha256
-        pattern: *.sha256
+        pattern: "*.sha256"
         merge-multiple: true
 
     - name: Combine SHA-256 Sums

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -113,11 +113,13 @@ jobs:
     - name: Combine SHA-256 Sums
       run: |
         echo "### Factory files SHA-256 Checksums" > sha256-summary.txt
-        cat *.sha256 | sort -k2 > sha256-summary.txt
+        cat ./sha256/*.sha256 | sort -k2 >> sha256-summary.txt
+
+    - name: Install GitHub CLI
+      uses: cli/gh-cli@v1
 
     - name: Update Release Body
-      uses: github/gh-cli@v2
-      with:
-        command: |
-          gh release edit ${{ needs.build-and-release.outputs.VERSION_TAG }} \
-          --notes-file sha256-summary.txt
+      run: |
+        gh release edit ${{ needs.build-and-release.outputs.VERSION_TAG }} --notes-file sha256-summary.txt
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
         existing_notes=$(gh release view ${{ env.VERSION_TAG }} --json body -q '.body')
 
         # Append the new content
-        new_notes="$existing_notes\n<!--\n$(cat sha256-summary.txt)\n-->\n"
+        new_notes="$existing_notes\n<\!--\n$(cat sha256-summary.txt)\n-->\n"
 
         # Update the release body
         echo -e "$new_notes" | gh release edit ${{ env.VERSION_TAG }} --notes -

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,11 +124,10 @@ jobs:
 
     - name: Combine SHA-256 Sums
       run: |
-        echo "### Factory files SHA-256 Checksums" > sha256-summary.txt
-        echo '```' >> sha256-summary.txt  # Add opening code block
+        echo '<!--' >> sha256-summary.txt  # Add opening code block
         files="$( find ./artifacts -name "*.sha256" | xargs )"
         cat $files | sort -k2 >> sha256-summary.txt
-        echo '```' >> sha256-summary.txt  # Add opening code block
+        echo '-->' >> sha256-summary.txt  # Add opening code block
 
     - name: Install GitHub CLI
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,10 +124,8 @@ jobs:
 
     - name: Combine SHA-256 Sums
       run: |
-        echo '<!--' >> sha256-summary.txt  # Add opening code block
         files="$( find ./artifacts -name "*.sha256" | xargs )"
-        cat $files | sort -k2 >> sha256-summary.txt
-        echo '-->' >> sha256-summary.txt  # Add opening code block
+        cat $files | sort -k2 > sha256-summary.txt
 
     - name: Install GitHub CLI
       run: |
@@ -137,5 +135,18 @@ jobs:
     - name: Update Release Body
       run: |
         gh release edit ${{ env.VERSION_TAG }} --notes-file sha256-summary.txt
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Append to Release Body
+      run: |
+        # Fetch the current release body
+        existing_notes=$(gh release view ${{ env.VERSION_TAG }} --json body -q '.body')
+
+        # Append the new content
+        new_notes="$existing_notes\n<!--\n$(cat sha256-summary.txt)\n-->\n"
+
+        # Update the release body
+        echo -e "$new_notes" | gh release edit ${{ env.VERSION_TAG }} --notes -
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -147,6 +147,6 @@ jobs:
         new_notes="$existing_notes\n<\!--\n$(cat sha256-summary.txt)\n-->\n"
 
         # Update the release body
-        echo -e "$new_notes" | gh release edit ${{ env.VERSION_TAG }} --notes -
+        gh release edit ${{ env.VERSION_TAG }} --notes "$(echo -e "$new_notes")"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,12 +132,6 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y gh
 
-    - name: Update Release Body
-      run: |
-        gh release edit ${{ env.VERSION_TAG }} --notes-file sha256-summary.txt
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
     - name: Append to Release Body
       run: |
         # Fetch the current release body

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,6 @@ jobs:
       uses: actions/download-artifact@v4
       with:
         path: ./sha256
-        pattern: "*.sha256"
         merge-multiple: true
 
     - name: Combine SHA-256 Sums

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,9 +118,11 @@ jobs:
         echo "VERSION_TAG=${version}"
 
     - name: Download SHA-256 Artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         path: ./sha256
+        pattern: *.sha256
+        merge-multiple: true
 
     - name: Combine SHA-256 Sums
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -125,8 +125,10 @@ jobs:
     - name: Combine SHA-256 Sums
       run: |
         echo "### Factory files SHA-256 Checksums" > sha256-summary.txt
+        echo '```' >> sha256-summary.txt  # Add opening code block
         files="$( find ./artifacts -name "*.sha256" | xargs )"
         cat $files | sort -k2 >> sha256-summary.txt
+        echo '```' >> sha256-summary.txt  # Add opening code block
 
     - name: Install GitHub CLI
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,6 +105,18 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-and-release
     steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Get Version Tag
+      id: version_tag
+      run: |
+        git fetch --tags  # Ensure all tags are fetched
+        version=$(git describe --tags --abbrev=0 2>/dev/null || git rev-parse --short HEAD)
+        echo "VERSION_TAG=${version}" >> $GITHUB_ENV
+        echo "${version}" > version.txt
+        echo "VERSION_TAG=${version}"
+
     - name: Download SHA-256 Artifacts
       uses: actions/download-artifact@v3
       with:
@@ -122,6 +134,6 @@ jobs:
 
     - name: Update Release Body
       run: |
-        gh release edit ${{ needs.build-and-release.outputs.VERSION_TAG }} --notes-file sha256-summary.txt
+        gh release edit ${{ env.VERSION_TAG }} --notes-file sha256-summary.txt
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,16 @@ jobs:
         0xf10000 build/ota_data_initial.bin \
         -o esp-miner-factory-${{ matrix.label }}-${{ env.VERSION_TAG }}.bin
 
+    - name: Generate SHA-256 Sum of factory file
+      run: |
+        sha256sum esp-miner-factory-${{ matrix.label }}-${{ env.VERSION_TAG }}.bin > esp-miner-factory-${{ matrix.label }}-${{ env.VERSION_TAG }}.sha256
+
+    - name: Upload SHA-256 Artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: esp-miner-factory-${{ matrix.label }}-${{ env.VERSION_TAG }}.sha256
+        path: esp-miner-factory-${{ matrix.label }}-${{ env.VERSION_TAG }}.sha256
+
     - name: Rename Build Artifacts
       run: |
         sudo mv build/esp-miner.bin build/esp-miner-${{ matrix.label }}.bin
@@ -90,3 +100,28 @@ jobs:
         token: ${{ secrets.GITHUB_TOKEN }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update-release-body:
+    runs-on: ubuntu-latest
+    needs: build-and-release
+    steps:
+    - name: Download SHA-256 Artifacts
+      uses: actions/download-artifact@v3
+      with:
+        path: ./sha256
+
+    - name: Combine SHA-256 Sums
+      run: |
+        echo "### Firmware SHA-256 Checksums" > sha256-summary.txt
+        for file in ./sha256/*.sha256; do
+          echo "#### $(basename $file .sha256)" >> sha256-summary.txt
+          cat "$file" >> sha256-summary.txt
+          echo "" >> sha256-summary.txt
+        done
+
+    - name: Update Release Body
+      uses: github/gh-cli@v2
+      with:
+        command: |
+          gh release edit ${{ needs.build-and-release.outputs.VERSION_TAG }} \
+          --notes-file sha256-summary.txt


### PR DESCRIPTION
Adds hashes of factory files after they were built by the workflow.

They are used for a modified web-flasher that can fetch releases from github.

Unfortunately, assets must be fetched via a CORS proxy, so the generated hashes are used to verify if the proxy manipulated the binary.