### PR TITLE
Using AsicTemp to get more realistic temp work values

### DIFF
--- a/components/bm1397/asic.cpp
+++ b/components/bm1397/asic.cpp
@@ -35,6 +35,14 @@ const static char* TAG = "asic";
 
 Asic::Asic() {
     m_current_frequency = 56.25;
+    m_maxAsic_temp = 0.0;
+    m_tempRequest_ACK = false;
+}
+
+//Returns the readed MaxChipTemp of all chained chips
+//requires a previous call to requestChipTemp()
+float Asic::getMaxChipTemp(){
+    return m_maxAsic_temp;
 }
 
 uint16_t Asic::reverseUint16(uint16_t num)

--- a/components/bm1397/bm1368.cpp
+++ b/components/bm1397/bm1368.cpp
@@ -26,7 +26,7 @@ static const char *TAG = "bm1368Module";
 static const uint8_t chip_id[6] = {0xaa, 0x55, 0x13, 0x68, 0x00, 0x00};
 
 BM1368::BM1368() : Asic() {
-    // NOP
+    //NOP
 }
 
 const uint8_t* BM1368::getChipId() {
@@ -120,6 +120,13 @@ int BM1368::setMaxBaud(void)
 }
 
 void BM1368::requestChipTemp() {
+
+    //Reset new initial temp measurement
+    if(m_tempRequest_ACK) {
+        m_maxAsic_temp = 0.0;
+        m_tempRequest_ACK = false;
+    }
+
     send2(CMD_READ_ALL, 0x00, 0xB4);
     send6(CMD_WRITE_ALL, 0x00, 0xB0, 0x80, 0x00, 0x00, 0x00);
     send6(CMD_WRITE_ALL, 0x00, 0xB0, 0x00, 0x02, 0x00, 0x00);

--- a/components/bm1397/include/asic.h
+++ b/components/bm1397/include/asic.h
@@ -85,12 +85,16 @@ protected:
     virtual uint8_t asicToJobId(uint8_t asic_id) = 0;
 
 public:
+    bool m_tempRequest_ACK;  
+    float m_maxAsic_temp;
+    
     Asic();
     virtual const char* getName() = 0;
     uint8_t sendWork(uint32_t job_id, bm_job *next_bm_job);
     bool processWork(task_result *result);
     void setJobDifficultyMask(int difficulty);
     bool setAsicFrequency(float frequency);
+    float getMaxChipTemp();
     virtual void requestChipTemp() = 0;
     virtual uint16_t getSmallCoreCount() = 0;
     virtual uint8_t nonceToAsicNr(uint32_t nonce) = 0;

--- a/main/tasks/asic_result_task.cpp
+++ b/main/tasks/asic_result_task.cpp
@@ -31,6 +31,8 @@ void ASIC_result_task(void *pvParameters)
                     if (asic_result.data & 0x80000000) {
                         float ftemp = (float) (asic_result.data & 0x0000ffff) * 0.171342f - 299.5144f;;
                         ESP_LOGI(TAG, "asic %d temp: %.3f", (int) asic_result.asic_nr, ftemp);
+                        asics->m_tempRequest_ACK = true;
+                        if(ftemp > asics->m_maxAsic_temp) asics->m_maxAsic_temp = ftemp;
                     }
                     break;
                 }

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -110,6 +110,11 @@ void PowerManagementTask::task()
             board->requestBuckTelemtry();
             last_temp_request = esp_timer_get_time();
         }
+        //Get the readed MaxChipTemp of all chainged chips after
+        //calling requestChipTemp() 
+        //IMPORTANT: this value only makes sense with BM1368 ASIC, with other Asics will remain at 0
+        float m_MaxChipTemp = 0.0;
+        if (asics) m_MaxChipTemp = asics->getMaxChipTemp();
 
         float vin = board->getVin();
         float iin = board->getIin();
@@ -152,6 +157,9 @@ void PowerManagementTask::task()
             }
         }
         m_chipTempAvg = tempCount ? (tempSum / (float) tempCount) : 0.0f;
+
+        // Uses the worst case between board temp sensor or Asic temp read command
+        m_chipTempAvg = std::max(m_chipTempAvg, m_MaxChipTemp);
 
         influx_task_set_temperature(m_chipTempAvg, m_vrTemp);
 


### PR DESCRIPTION
- Use worst case between board temp sensor or Asic temp read command
- Makes it ASIC/Board agnostic, only takes effect if board is using BM1368 (nerdQaxe+, NerdOctaxe+)
- A new high temp is calculated for each new Asic Temp request
- This is a new implementation of this idea [[gh pr checkout 60](https://github.com/shufps/ESP-Miner-NerdQAxePlus/pull/60)](url)