### PR TITLE
improved fan control

### DIFF
--- a/components/stratum/stratum_api.cpp
+++ b/components/stratum/stratum_api.cpp
@@ -121,7 +121,7 @@ char *StratumApi::receiveJsonRpcLine(int sockfd)
         int nbytes = recv(sockfd, m_buffer + m_len, available, 0);
         if (nbytes == -1) {
             if (errno == EWOULDBLOCK || errno == EAGAIN) {
-                ESP_LOGW(TAG, "No transmission from Stratum server. Checking socket ...");
+                ESP_LOGI(TAG, "No transmission from Stratum server. Checking socket ...");
                 if (isSocketConnected(sockfd)) {
                     ESP_LOGI(TAG, "Socket is still connected.");
                     continue; // Retry recv() until data arrives.

--- a/config.cvs.nerdaxe.example
+++ b/config.cvs.nerdaxe.example
@@ -5,12 +5,12 @@ wifissid,data,string,myssid
 wifipass,data,string,mypass
 stratumurl,data,string,public-pool.io
 stratumport,data,u16,21496
-stratumuser,data,string,bc1q29hp4fqtks2wzpmfwtpac64fnr8ujw2nvnra04.nerdqaxe
+stratumuser,data,string,bc1q29hp4fqtks2wzpmfwtpac64fnr8ujw2nvnra04.nerdaxe
 stratumpass,data,string,x
 asicfrequency,data,u16,485
 asicvoltage,data,u16,1200
 flipscreen,data,u16,1
-invertfanpol,data,u16,0
+invertfanpol,data,u16,1
 autofanspeed,data,u16,1
 fanspeed,data,u16,100
 selftest,data,u16,0

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -1,26 +1,4 @@
 menu "Miner Configuration"
-    config INVERT_POLARITY
-        bool "Invert fan polarity"
-        default n
-        help
-            If enabled, the fan PWM polarity will be inverted.
-
-    config INVERT_POLARITY_VALUE
-        int
-        default 1 if INVERT_POLARITY
-        default 0
-
-    config FLIP_SCREEN
-        bool "Flip screen orientation"
-        default n
-        help
-            If enabled, the screen display will be flipped.
-
-    config FLIP_SCREEN_VALUE
-        int
-        default 1 if FLIP_SCREEN
-        default 0
-
     config AUTO_SCREEN_OFF
         bool "Screen auto-off"
         default n

--- a/main/boards/board.cpp
+++ b/main/boards/board.cpp
@@ -74,8 +74,8 @@ bool Board::selfTest(){
     return false;
 }
 
-// Set the fan speed between 20% min and 100% max based on chip temperature as input.
-// The fan speed increases from 20% to 100% proportionally to the temperature increase from 50 and THROTTLE_TEMP
+// Adjust the fan speed based on chip temperature, scaling smoothly from m_afcMinFanSpeed up to 100%.
+// The fan starts ramping up once the temperature exceeds m_afcMinTemp and reaches full speed at m_afcMaxTemp.
 float Board::automaticFanSpeed(float temp)
 {
     float result = 0.0;

--- a/main/boards/board.h
+++ b/main/boards/board.h
@@ -32,11 +32,19 @@ class Board {
     bool m_fanInvertPolarity;
     float m_fanPerc;
 
+    // flip screen
+    bool m_flipScreen;
+
     // max power settings
     float m_maxPin;
     float m_minPin;
     float m_maxVin;
     float m_minVin;
+
+    // automatic fan control settings
+    float m_afcMinTemp;
+    float m_afcMinFanSpeed;
+    float m_afcMaxTemp;
 
     // display m_theme
     Theme *m_theme = nullptr;
@@ -77,6 +85,8 @@ class Board {
     virtual float getPout() = 0;
 
     virtual void requestBuckTelemtry() = 0;
+
+    virtual float automaticFanSpeed(float temp);
 
     virtual void shutdown() = 0;
 
@@ -145,5 +155,13 @@ class Board {
 
     int getNumTempSensors() {
         return m_numTempSensors;
+    }
+
+    bool isFlipScreenEnabled() {
+        return m_flipScreen;
+    }
+
+    bool isInvertFanPolarityEnabled() {
+        return m_fanInvertPolarity;
     }
 };

--- a/main/boards/drivers/TMP1075.cpp
+++ b/main/boards/drivers/TMP1075.cpp
@@ -48,13 +48,9 @@ float TMP1075_read_temperature(int device_index)
     uint16_t temp_raw;
     int ret = TMP1075_smb_read_word(device_index, TMP1075_TEMP_REG, &temp_raw);
 
-    if (ret == ESP_OK) {
-        temp_raw >>= 4;                         // Right-shift to discard the unused bits (12-bit data)
-        float temperature = temp_raw * 0.0625f; // Each bit represents 0.0625°C
-        ESP_LOGI(TAG, "Temperature %d: %.2f C", device_index, temperature);
-        return temperature;
-    } else {
+    if (ret != ESP_OK) {
         ESP_LOGI(TAG, "Failed to read temperature from TMP1075");
         return 0.0f;
     }
+    return (temp_raw >> 4) * 0.0625f; // Each bit represents 0.0625°C
 }

--- a/main/boards/nerdaxe.cpp
+++ b/main/boards/nerdaxe.cpp
@@ -40,8 +40,9 @@ NerdAxe::NerdAxe() : Board() {
     m_asicJobIntervalMs = 1500;
     m_asicFrequency = 485;
     m_asicVoltageMillis = 1200;
-    m_fanInvertPolarity = false;
+    m_fanInvertPolarity = true;
     m_fanPerc = 100;
+    m_flipScreen = true;
     m_numTempSensors = 1;
 
     m_maxPin = 15.0;

--- a/main/boards/nerdaxegamma.cpp
+++ b/main/boards/nerdaxegamma.cpp
@@ -27,11 +27,12 @@ NerdaxeGamma::NerdaxeGamma() : NerdAxe() {
     m_asicCount = 1;
 
     m_asicJobIntervalMs = 1500;
-    m_asicFrequency = 525;
+    m_asicFrequency = 515;
     m_asicVoltageMillis = 1150;
     m_initVoltageMillis = 1150;
-    m_fanInvertPolarity = false;
+    m_fanInvertPolarity = true;
     m_fanPerc = 100;
+    m_flipScreen = true;
     m_vr_maxTemp = TPS546_THROTTLE_TEMP; //Set max voltage regulator temp
 
     m_maxPin = 25.0;

--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -35,9 +35,15 @@ NerdQaxePlus::NerdQaxePlus() : Board() {
     m_initVoltageMillis = 1250;
     m_fanInvertPolarity = false;
     m_fanPerc = 100;
+    m_flipScreen = false;
     m_numPhases = 2;
     m_imax = m_numPhases * 30;
     m_ifault = (float) (m_imax - 5);
+
+    // afc settings
+    m_afcMinTemp = 45.0f;
+    m_afcMinFanSpeed = 55.0f;
+    m_afcMaxTemp = 65.0f;
 
     m_maxPin = 70.0;
     m_minPin = 30.0;

--- a/main/boards/nerdqaxeplus2.cpp
+++ b/main/boards/nerdqaxeplus2.cpp
@@ -30,3 +30,12 @@ NerdQaxePlus2::NerdQaxePlus2() : NerdQaxePlus() {
 #endif
     m_asics = new BM1370();
 }
+
+float NerdQaxePlus2::getTemperature(int index) {
+    float temp = NerdQaxePlus::getTemperature(index);
+    if (!temp) {
+        return 0.0;
+    }
+    // we can't read the real chip temps but this should be about right
+    return temp + 10.0f; // offset of 10°C
+}

--- a/main/boards/nerdqaxeplus2.h
+++ b/main/boards/nerdqaxeplus2.h
@@ -12,4 +12,5 @@ class NerdQaxePlus2 : public NerdQaxePlus {
 
   public:
     NerdQaxePlus2();
+    float getTemperature(int index);
 };

--- a/main/displays/displayDriver.cpp
+++ b/main/displays/displayDriver.cpp
@@ -413,7 +413,8 @@ lv_obj_t *DisplayDriver::initTDisplayS3(void)
 
     esp_lcd_panel_swap_xy(panel_handle, true);
 
-    if (!Config::isFlipScreenEnabled()) {
+    Board *board = SYSTEM_MODULE.getBoard();
+    if (!board->isFlipScreenEnabled()) {
         esp_lcd_panel_mirror(panel_handle, true, false);
     } else {
         esp_lcd_panel_mirror(panel_handle, false, true);
@@ -526,15 +527,17 @@ void DisplayDriver::updateCurrentSettings()
     if (m_ui->ui_SettingsScreen == NULL)
         return;
 
+    Board *board = SYSTEM_MODULE.getBoard();
+
     lv_label_set_text(m_ui->ui_lbPoolSet, STRATUM_MANAGER.getCurrentPoolHost()); // Update label
 
     snprintf(strData, sizeof(strData), "%d", STRATUM_MANAGER.getCurrentPoolPort());
     lv_label_set_text(m_ui->ui_lbPortSet, strData); // Update label
 
-    snprintf(strData, sizeof(strData), "%d", Config::getAsicFrequency());
+    snprintf(strData, sizeof(strData), "%d", board->getAsicFrequency());
     lv_label_set_text(m_ui->ui_lbFreqSet, strData); // Update label
 
-    snprintf(strData, sizeof(strData), "%d", Config::getAsicVoltage());
+    snprintf(strData, sizeof(strData), "%d", board->getAsicVoltageMillis());
     lv_label_set_text(m_ui->ui_lbVcoreSet, strData); // Update label
 
     bool auto_fan_speed = Config::isAutoFanSpeedEnabled();
@@ -603,7 +606,7 @@ void DisplayDriver::updateGlobalState()
         return;
 
     // snprintf(strData, sizeof(strData), "%.0f", power_management->chip_temp);
-    snprintf(strData, sizeof(strData), "%.0f", POWER_MANAGEMENT_MODULE.getAvgChipTemp());
+    snprintf(strData, sizeof(strData), "%.0f", POWER_MANAGEMENT_MODULE.getChipTempMax());
     lv_label_set_text(m_ui->ui_lbTemp, strData);       // Update label
     lv_label_set_text(m_ui->ui_lblTempPrice, strData); // Update label
 

--- a/main/http_server/http_server.cpp
+++ b/main/http_server/http_server.cpp
@@ -719,7 +719,7 @@ static esp_err_t GET_system_info(httpd_req_t *req)
     doc["maxVoltage"]         = board->getMaxVin();
     doc["minVoltage"]         = board->getMinVin();
     doc["current"]            = POWER_MANAGEMENT_MODULE.getCurrent();
-    doc["temp"]               = POWER_MANAGEMENT_MODULE.getAvgChipTemp();
+    doc["temp"]               = POWER_MANAGEMENT_MODULE.getChipTempMax();
     doc["vrTemp"]             = POWER_MANAGEMENT_MODULE.getVRTemp();
     doc["hashRateTimestamp"]  = history->getCurrentTimestamp();
     doc["hashRate"]           = history->getCurrentHashrate10m();
@@ -755,10 +755,10 @@ static esp_err_t GET_system_info(httpd_req_t *req)
     doc["frequency"]          = board->getAsicFrequency();
     doc["jobInterval"]        = board->getAsicJobIntervalMs();
     doc["overheat_temp"]      = Config::getOverheatTemp();
-    doc["flipscreen"]         = Config::isFlipScreenEnabled() ? 1 : 0;
+    doc["flipscreen"]         = board->isFlipScreenEnabled() ? 1 : 0;
     doc["invertscreen"]       = Config::isInvertScreenEnabled() ? 1 : 0; // unused?
     doc["autoscreenoff"]      = Config::isAutoScreenOffEnabled() ? 1 : 0;
-    doc["invertfanpolarity"]  = Config::isInvertFanPolarityEnabled() ? 1 : 0;
+    doc["invertfanpolarity"]  = board->isInvertFanPolarityEnabled() ? 1 : 0;
     doc["autofanspeed"]       = Config::isAutoFanSpeedEnabled() ? 1 : 0;
 
     // system screen

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -86,9 +86,6 @@ namespace Config {
     inline void setSwarmConfig(const char* value) { nvs_config_set_string(NVS_CONFIG_SWARM, value); }
 
     // ---- uint16_t Getters ----
-    inline uint16_t getAsicFrequency() { return nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, 0); }
-    inline uint16_t getAsicVoltage() { return nvs_config_get_u16(NVS_CONFIG_ASIC_VOLTAGE, 0); }
-    inline uint16_t getAsicJobInterval() { return nvs_config_get_u16(NVS_CONFIG_ASIC_JOB_INTERVAL, 0); }
     inline uint16_t getStratumPortNumber() { return nvs_config_get_u16(NVS_CONFIG_STRATUM_PORT, CONFIG_STRATUM_PORT); }
     inline uint16_t getStratumFallbackPortNumber() { return nvs_config_get_u16(NVS_CONFIG_STRATUM_FALLBACK_PORT, CONFIG_STRATUM_FALLBACK_PORT); }
     inline uint16_t getFanSpeed() { return nvs_config_get_u16(NVS_CONFIG_FAN_SPEED, CONFIG_FAN_SPEED); }
@@ -112,9 +109,7 @@ namespace Config {
     inline void setBestDiff(uint64_t value) { nvs_config_set_u64(NVS_CONFIG_BEST_DIFF, value); }
 
     // ---- Boolean Getters (Stored as uint16_t but used as bool) ----
-    inline bool isFlipScreenEnabled() { return nvs_config_get_u16(NVS_CONFIG_FLIP_SCREEN, CONFIG_FLIP_SCREEN_VALUE) != 0; }
     inline bool isInvertScreenEnabled() { return nvs_config_get_u16(NVS_CONFIG_INVERT_SCREEN, 0) != 0; } // todo unused?
-    inline bool isInvertFanPolarityEnabled() { return nvs_config_get_u16(NVS_CONFIG_INVERT_FAN_POLARITY, CONFIG_INVERT_POLARITY_VALUE) != 0; }
     inline bool isAutoFanSpeedEnabled() { return nvs_config_get_u16(NVS_CONFIG_AUTO_FAN_SPEED, CONFIG_AUTO_FAN_SPEED_VALUE) != 0; }
     inline bool isSelfTestEnabled() { return nvs_config_get_u16(NVS_CONFIG_SELF_TEST, 0) != 0; }
     inline bool isAutoScreenOffEnabled() { return nvs_config_get_u16(NVS_CONFIG_AUTO_SCREEN_OFF, CONFIG_AUTO_SCREEN_OFF_VALUE) != 0; }
@@ -129,4 +124,11 @@ namespace Config {
     inline void setAutoScreenOff(bool value) { nvs_config_set_u16(NVS_CONFIG_AUTO_SCREEN_OFF, value ? 1 : 0); }
     inline void setInfluxEnabled(bool value) { nvs_config_set_u16(NVS_CONFIG_INFLUX_ENABLE, value ? 1 : 0); }
 
+
+    // with board specific default values
+    inline uint16_t getAsicFrequency(uint16_t d) { return nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, d); }
+    inline uint16_t getAsicVoltage(uint16_t d) { return nvs_config_get_u16(NVS_CONFIG_ASIC_VOLTAGE, d); }
+    inline uint16_t getAsicJobInterval(uint16_t d) { return nvs_config_get_u16(NVS_CONFIG_ASIC_JOB_INTERVAL, d); }
+    inline bool isFlipScreenEnabled(bool d) { return nvs_config_get_u16(NVS_CONFIG_FLIP_SCREEN, d ? 1 : 0) != 0; }
+    inline bool isInvertFanPolarityEnabled(bool d) { return nvs_config_get_u16(NVS_CONFIG_INVERT_FAN_POLARITY, d ? 1 : 0) != 0; }
 }

--- a/main/tasks/create_jobs_task.cpp
+++ b/main/tasks/create_jobs_task.cpp
@@ -201,13 +201,13 @@ void *create_jobs_task(void *pvParameters)
 
         uint64_t current_time = esp_timer_get_time();
         if (last_submit_time) {
-            ESP_LOGI(TAG, "job interval %dms", (int) ((current_time - last_submit_time) / 1e3));
+            ESP_LOGD(TAG, "job interval %dms", (int) ((current_time - last_submit_time) / 1e3));
         }
         last_submit_time = current_time;
 
         int asic_job_id = asics->sendWork(extranonce_2, next_job);
 
-        ESP_LOGI(TAG, "Sent Job: %02X", asic_job_id);
+        ESP_LOGD(TAG, "Sent Job: %02X", asic_job_id);
 
         // save job
         asicJobs.storeJob(next_job, asic_job_id);

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -16,36 +16,11 @@
 #include "boards/board.h"
 
 #define POLL_RATE 2000
-#define THROTTLE_TEMP 65.0
 
 static const char *TAG = "power_management";
 
 PowerManagementTask::PowerManagementTask() {
     m_mutex = PTHREAD_MUTEX_INITIALIZER;
-}
-
-// Set the fan speed between 20% min and 100% max based on chip temperature as input.
-// The fan speed increases from 20% to 100% proportionally to the temperature increase from 50 and THROTTLE_TEMP
-double PowerManagementTask::automaticFanSpeed(Board* board, float chip_temp)
-{
-    double result = 0.0;
-    double min_temp = 45.0;
-    double min_fan_speed = 35.0;
-
-    if (chip_temp < min_temp) {
-        result = min_fan_speed;
-    } else if (chip_temp >= THROTTLE_TEMP) {
-        result = 100;
-    } else {
-        double temp_range = THROTTLE_TEMP - min_temp;
-        double fan_range = 100 - min_fan_speed;
-        result = ((chip_temp - min_temp) / temp_range) * fan_range + min_fan_speed;
-    }
-
-    float perc = (float) result / 100;
-    m_fanPerc = perc;
-    board->setFanSpeed(perc);
-    return result;
 }
 
 void PowerManagementTask::taskWrapper(void *pvParameters) {
@@ -115,11 +90,6 @@ void PowerManagementTask::task()
             board->requestBuckTelemtry();
             last_temp_request = esp_timer_get_time();
         }
-        //Get the readed MaxChipTemp of all chainged chips after
-        //calling requestChipTemp()
-        //IMPORTANT: this value only makes sense with BM1368 ASIC, with other Asics will remain at 0
-        float m_MaxChipTemp = 0.0;
-        if (asics) m_MaxChipTemp = asics->getMaxChipTemp();
 
         float vin = board->getVin();
         float iin = board->getIin();
@@ -151,22 +121,26 @@ void PowerManagementTask::task()
         m_power = pin;
         board->getFanSpeed(&m_fanRPM);
 
-        // calculate the average of ASICs measuring temp sensors
-        float tempSum = 0.0;
-        int tempCount = 0;
+        // collect temperatures
+        // get the max of all asic measuring temp sensors
+        float tmp1075Max = 0.0f;
         for (int i=0; i < board->getNumTempSensors(); i++) {
             float tmp = board->getTemperature(i);
             if (tmp) {
-                tempSum += tmp;
-                tempCount++;
+                ESP_LOGI(TAG, "Temperature %d: %.2f C", i, tmp);
             }
+            tmp1075Max = std::max(tmp1075Max, tmp);
         }
-        m_chipTempAvg = tempCount ? (tempSum / (float) tempCount) : 0.0f;
+
+        //Get the readed MaxChipTemp of all chained chips after
+        //calling requestChipTemp()
+        //IMPORTANT: this value only makes sense with BM1368 ASIC, with other Asics will remain at 0
+        float intChipTempMax = asics ? asics->getMaxChipTemp() : 0.0f;
 
         // Uses the worst case between board temp sensor or Asic temp read command
-        m_chipTempAvg = std::max(m_chipTempAvg, m_MaxChipTemp);
+        m_chipTempMax = std::max(tmp1075Max, intChipTempMax);
 
-        influx_task_set_temperature(m_chipTempAvg, m_vrTemp);
+        influx_task_set_temperature(m_chipTempMax, m_vrTemp);
 
         float vr_maxTemp = asic_overheat_temp;
         if(board->getVrMaxTemp()) {
@@ -174,7 +148,7 @@ void PowerManagementTask::task()
         }
 
         if (asic_overheat_temp &&
-            (m_chipTempAvg > asic_overheat_temp || m_vrTemp > vr_maxTemp)) {
+            (m_chipTempMax > asic_overheat_temp || m_vrTemp > vr_maxTemp)) {
             // over temperature
             SYSTEM_MODULE.setOverheated(true);
             // disables the buck
@@ -183,11 +157,10 @@ void PowerManagementTask::task()
         }
 
         if (auto_fan_speed) {
-            m_fanPerc = (float) automaticFanSpeed(board, m_chipTempAvg);
+            m_fanPerc = board->automaticFanSpeed(m_chipTempMax);
         } else {
-            float fs = (float) Config::getFanSpeed();
-            m_fanPerc = fs;
-            board->setFanSpeed((float) fs / 100);
+            m_fanPerc = (float) Config::getFanSpeed();
+            board->setFanSpeed(m_fanPerc / 100.0f);
         }
         pthread_mutex_unlock(&m_mutex);
 

--- a/main/tasks/power_management_task.h
+++ b/main/tasks/power_management_task.h
@@ -8,7 +8,7 @@ class PowerManagementTask {
     pthread_mutex_t m_mutex;
     uint16_t m_fanPerc;
     uint16_t m_fanRPM;
-    float m_chipTempAvg;
+    float m_chipTempMax;
     float m_vrTemp;
     float m_voltage;
     float m_power;
@@ -38,9 +38,9 @@ class PowerManagementTask {
     {
         return m_current;
     };
-    float getAvgChipTemp()
+    float getChipTempMax()
     {
-        return m_chipTempAvg;
+        return m_chipTempMax;
     };
     float getVRTemp()
     {


### PR DESCRIPTION
- different automatic fan control settings per board
- offset of 10°C on top (on BM1370 boards) of the measured heatsink temp to estimate chip internal temperature what makes it more realistic
- moved inverted fan polarity and flipped screen from kconfig to board specific default settings 