### PR TITLE
Fix header logo for mobile view

### DIFF
--- a/main/http_server/axe-os/src/app/@theme/components/header/header.component.scss
+++ b/main/http_server/axe-os/src/app/@theme/components/header/header.component.scss
@@ -6,11 +6,11 @@
   display: flex;
   justify-content: space-between;
   width: 100%;
+  column-gap: 1.25rem;
 
   .logo-container {
     display: flex;
     align-items: center;
-    width: calc(#{nb-theme(sidebar-width)} - #{nb-theme(header-padding)});
   }
 
   nb-action {
@@ -43,13 +43,18 @@
     }
 
     .logo {
-      margin-top: 5px;
-      padding: 0 1.25rem;
+      padding: 0 0 0 1.25rem;
       font-size: 1.75rem;
       @include nb-ltr(border-left, 1px solid nb-theme(divider-color));
       @include nb-rtl(border-right, 1px solid nb-theme(divider-color));
       white-space: nowrap;
       text-decoration: none;
+
+      img {
+        display: block;
+        max-height: 40px;
+        max-width: 100%;
+      }
     }
   }
 /*

--- a/main/http_server/axe-os/src/app/@theme/styles/themes.scss
+++ b/main/http_server/axe-os/src/app/@theme/styles/themes.scss
@@ -6,6 +6,7 @@
 $nb-themes: nb-register-theme((
   //layout-padding-top: 2.25rem,
   layout-padding: 1rem,
+  header-height: 5rem,
 
   menu-item-icon-margin: 0 0.5rem 0 0,
 
@@ -32,6 +33,7 @@ $nb-themes: nb-register-theme((
 $nb-themes: nb-register-theme((
   //layout-padding-top: 2.25rem,
   layout-padding: 1rem,
+  header-height: 5rem,
 
   menu-item-icon-margin: 0 0.5rem 0 0,
 
@@ -57,6 +59,7 @@ $nb-themes: nb-register-theme((
 $nb-themes: nb-register-theme((
   //layout-padding-top: 2.25rem,
   layout-padding: 1rem,
+  header-height: 5rem,
 
   menu-item-icon-margin: 0 0.5rem 0 0,
 
@@ -80,6 +83,7 @@ $nb-themes: nb-register-theme((
 $nb-themes: nb-register-theme((
   //layout-padding-top: 2.25rem,
   layout-padding: 1rem,
+  header-height: 5rem,
 
   menu-item-icon-margin: 0 0.5rem 0 0,
 


### PR DESCRIPTION
On mobile devices, the logo slides under the theme select box. With the fix I solve the problem so that the logo has dynamic width.

👎
<img src="https://github.com/user-attachments/assets/725cfe51-fcd6-485c-bb6d-30ab9f45be78" width="200">

👍
<img src="https://github.com/user-attachments/assets/ec00e2cc-e214-413b-99fb-0ca71174195e" width="200">

