### PR TITLE
Dashboard: Heat section optimisation for Nerdaxe Ultra

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/home.component.html
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.html
@@ -168,8 +168,10 @@
             <span class="text-hint">Heat</span>
           </nb-card-header>
           <nb-card-body class="no-scroll">
+            @let heatSectionColModifier = info.vrTemp > 0 ? 6 : 4;
+
             <div class="row text-center">
-              <div class="col-6">
+              <div class="col-{{ heatSectionColModifier }}">
                 <app-gauge [value]="info.temp" [min]="20" [max]="75" [format]="'1.1-1'" [unit]="'°C'"
                   [label]="'ASIC Temp'"></app-gauge>
               </div>
@@ -177,11 +179,11 @@
                 <app-gauge [value]="info.vrTemp" [min]="20" [max]="145" [format]="'1.1-1'" [unit]="'°C'"
                   [label]="'VR Temp'"></app-gauge>
               </div>
-              <div class="col-6">
+              <div class="col-{{ heatSectionColModifier }}">
                 <app-gauge [value]="info.fanspeed" [min]="0" [format]="'1.0-0'" [max]="100" [unit]="'%'"
                   [label]="'Fan Speed'"></app-gauge>
               </div>
-              <div class="col-6">
+              <div class="col-{{ heatSectionColModifier }}">
                 <app-gauge [value]="info.fanrpm" [format]="'1.0-0'" [min]="0" [max]="20000" [unit]="'RPM'"
                   [label]="'Fan RPM'"></app-gauge>
               </div>


### PR DESCRIPTION
Dynamic adjustment for the heat section column width if there is no box for VR temp (like Nerdaxe).

**Current state**
<img width="500" alt="Current" src="https://github.com/user-attachments/assets/0db98bc9-3773-4314-a41d-8f36a6d95f99" />

**Optimised columns**
<img width="500" alt="Optimized" src="https://github.com/user-attachments/assets/4069f111-6c67-407b-b7bd-62c34f9717e5" />
