### PR TITLE
improve ASIC result logging: include pool and session difficulty

### DIFF
--- a/main/system.cpp
+++ b/main/system.cpp
@@ -204,7 +204,9 @@ void System::suffixString(uint64_t val, char* buf, size_t bufSize, int sigDigits
             snprintf(buf, bufSize, "%d%s", (unsigned int)dval, suffix);
     } else {
         int nDigits = sigDigits - 1 - (dval > 0.0 ? floor(log10(dval)) : 0);
-        snprintf(buf, bufSize, "%*.*f%s", sigDigits + 1, nDigits, dval, suffix);
+        //snprintf(buf, bufSize, "%*.*f%s", sigDigits + 1, nDigits, dval, suffix);
+        if (nDigits < 0) nDigits = 0;
+        snprintf(buf, bufSize, "%.*f%s", nDigits, dval, suffix);
     }
 }
 

--- a/main/system.h
+++ b/main/system.h
@@ -87,7 +87,6 @@ class System {
     void updateSystemPerformance();                    // Update performance metrics
     void showApInformation(const char *error);         // Show Access Point (AP) information with optional error message
     double calculateNetworkDifficulty(uint32_t nBits); // Calculate network difficulty based on pool difficulty
-    void suffixString(uint64_t val, char *buf, size_t bufSize, int sigDigits); // Format a value with a suffix (e.g., K, M)
 
   public:
     System();
@@ -109,6 +108,9 @@ class System {
     void checkForBestDiff(double foundDiff, uint32_t nbits); // Check if the found difficulty is the best so far
     void notifyMiningStarted();                              // Notify system that mining has started
     void notifyNewNtime(uint32_t ntime);                     // Notify system of new `ntime` received from the pool
+
+    // Made public (was protected) to allow usage in external modules like ASIC_result_task for formatting/logging.
+    static void suffixString(uint64_t val, char *buf, size_t bufSize, int sigDigits); // Format a value with a suffix (e.g., K, M)
 
     const char* getMacAddress();
 

--- a/main/tasks/asic_result_task.cpp
+++ b/main/tasks/asic_result_task.cpp
@@ -57,9 +57,14 @@ void ASIC_result_task(void *pvParameters)
         // check the nonce difficulty
         double nonce_diff = test_nonce_value(job, asic_result.nonce, asic_result.rolled_version);
 
-        // log the ASIC response
-        ESP_LOGI(TAG, "Job ID: %02X AsicNr: %d Ver: %08" PRIX32 " Nonce %08" PRIX32 " diff %.1f of %ld.", asic_job_id,
-                 asic_result.asic_nr, asic_result.rolled_version, asic_result.nonce, nonce_diff, job->asic_diff);
+        // get best known session diff
+        char bestDiffString[16];
+        System::suffixString(SYSTEM_MODULE.getBestSessionNonceDiff(), bestDiffString, sizeof(bestDiffString), 3);
+
+        // log the ASIC response, including pool and best session difficulty using human-readable SI formatting
+        ESP_LOGI(TAG, "Job ID: %02X AsicNr: %d Ver: %08" PRIX32 " Nonce %08" PRIX32 " diff %.1f/%lu/%s",
+            asic_job_id, asic_result.asic_nr, asic_result.rolled_version, asic_result.nonce,
+            nonce_diff, job->pool_diff, bestDiffString);
 
         if (nonce_diff > job->pool_diff) {
             STRATUM_MANAGER.submitShare(job->jobid, job->extranonce2, job->ntime, asic_result.nonce,


### PR DESCRIPTION
### **Summary**

This change enhances the ASIC result logging by including:

- The current nonce diff (`nonce_diff`)
- The current pool difficulty (`job->pool_diff`)
- The best session nonce difficulty (via `System::getBestSessionNonceDiff()`), formatted with SI suffixes (e.g. "13.6k", "1.2M" etc.)

### **Motivation**

The previous log format only included the `asic_diff`, which was capped at 1024 for BM1368 chips and 2048 for BM1370 – values that don’t convey much real-world difficulty information on their own.
This updated output gives a better real-time view into how valid shares compare to the pool and the best known session result.

**Sample output before**
```
₿ I (12345) asic_result: Job ID: 40 AsicNr: 1 Ver: 28484000 Nonce A2860404 diff 2175.4 of 1024
```

**Example output with new logging**
```
₿ I (433477) asic_result: Job ID: 68 AsicNr: 1 Ver: 326C2000 Nonce B4F6043A diff 1096128.0/1970/221k
₿ I (433647) asic_result: Job ID: 00 AsicNr: 3 Ver: 20B1E000 Nonce 96670D4C diff 1145.3/1970/1.10M
```

### **Notes**

- `System::suffixString` was moved from `protected` to `public` to enable reuse in the logging context.
- Output formatting was adjusted in `system.cpp` to avoid leading spaces in SI-formatted numbers - original code left commented out to preserve context during formatting adjustments