### PR TITLE
feat(settings): add stratumDifficulty setting to mining configuration (Danger Zone)

### DIFF
--- a/main/http_server/axe-os/src/app/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/app/models/ISystemInfo.ts
@@ -46,6 +46,7 @@ export interface ISystemInfo {
     fallbackStratumUser: string,
     isUsingFallbackStratum: boolean,
     isStratumConnected: boolean,
+    stratumDifficulty: number;
     frequency: number,
     defaultFrequency: number,
     version: string,

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.html
@@ -162,6 +162,13 @@
                             <small>Mining job switching time in milliseconds.</small>
                         </div>
                     </div>
+                    <div class="form-row">
+                        <label for="stratumDifficulty" class="form-label">Stratum Difficulty:</label>
+                        <div class="form-control-wrapper">
+                            <input nbInput id="stratumDifficulty" formControlName="stratumDifficulty" type="number" /><br />
+                            <small>Target mining difficulty (integer)</small>
+                        </div>
+                    </div>
                 </ng-container>
             </nb-card-body>
         </nb-card>

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
@@ -125,6 +125,7 @@ export class EditComponent implements OnInit {
           coreVoltage: [info.coreVoltage, [Validators.min(1005), Validators.max(1400), Validators.required]],
           frequency: [info.frequency, [Validators.required]],
           jobInterval: [info.jobInterval, [Validators.required]],
+          stratumDifficulty: [info.stratumDifficulty, [Validators.required, Validators.min(1)]],
           autofanspeed: [info.autofanspeed ?? 0, [Validators.required]],
           pidTargetTemp: [info.pidTargetTemp ?? 55, [
             Validators.min(30),

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
@@ -52,6 +52,7 @@ export class EditComponent implements OnInit {
     'fallbackStratumUser',
     'invertfanpolarity',
     'autofanpolarity',
+    'stratumDifficulty',
   ]);
 
   @Input() uri = '';

--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -63,6 +63,8 @@ esp_err_t GET_system_info(httpd_req_t *req)
     char *fallbackStratumURL = Config::getStratumFallbackURL();
     char *fallbackStratumUser= Config::getStratumFallbackUser();
 
+    doc["stratumDifficulty"] = Config::getStratumDifficulty();
+
     // static
     doc["asicCount"]          = board->getAsicCount();
     doc["smallCoreCount"]     = (board->getAsics()) ? board->getAsics()->getSmallCoreCount() : 0;
@@ -258,6 +260,9 @@ esp_err_t PATCH_update_settings(httpd_req_t *req)
         if (jobInterval > 0) {
             Config::setAsicJobInterval(jobInterval);
         }
+    }
+    if (doc["stratumDifficulty"].is<uint32_t>()) {
+        Config::setStratumDifficulty(doc["stratumDifficulty"].as<uint32_t>());
     }
     if (doc["flipscreen"].is<bool>()) {
         Config::setFlipScreen(doc["flipscreen"].as<bool>());

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -131,6 +131,7 @@ namespace Config {
 
     // ---- uint64_t Setters ----
     inline void setBestDiff(uint64_t value) { nvs_config_set_u64(NVS_CONFIG_BEST_DIFF, value); }
+    inline void setStratumDifficulty(uint32_t value) { nvs_config_set_u64(NVS_CONFIG_STRATUM_DIFFICULTY, value); }
 
     // ---- Boolean Getters (Stored as uint16_t but used as bool) ----
     inline bool isInvertScreenEnabled() { return nvs_config_get_u16(NVS_CONFIG_INVERT_SCREEN, 0) != 0; } // todo unused?


### PR DESCRIPTION
**Summary**
This pull request adds full support for configuring the `stratumDifficulty` parameter via the web interface. The new input field is located in the “Mining Settings” section and becomes visible when "Danger Zone" is enabled .


- Added a new stratumDifficulty input field to the edit form
- Field is pre-filled using the current NVS value (`Config::getStratumDifficulty`)
- Included stratumDifficulty in the GET /system response
- Updated the TypeScript interface ISystemInfo
- Extended the list of fields that trigger a reboot (rebootRequiredFields)
- added setter definition in `nvs_config.h`

**Motivation**
Some advanced users may want to override the default difficulty negotiation and enforce a fixed target, for testing or compatibility reasons. This change provides a convenient and persistent way to configure that value. 

**User Interface**
The setting is only visible when "Danger Zone" is enabled and appears in the same section as other low-level ASIC settings such as frequency and voltage.

<img width="1045" alt="Bildschirmfoto 2025-05-25 um 16 22 32" src="https://github.com/user-attachments/assets/a015ff4c-1505-4628-9b97-3336fe34c785" />

