### PR TITLE
fix(system): include stratumDifficulty in observable mapping

### DIFF
--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -63,6 +63,7 @@ const defaultInfo: ISystemInfo = {
   autoscreenoff: 0,
   lastResetReason: "Unknown",
   jobInterval: 1200,
+  stratumDifficulty: 1000,
 
   pidTargetTemp: 55,
   pidP: 2.0,


### PR DESCRIPTION
Follow-up patch created for #172 

This adds the missing `stratumDifficulty` mapping to the observable in `system.service.ts`, which is required for reboot detection in the UI.