### PR TITLE
Add poolDifficulty field to system info export + UI

### DIFF
--- a/main/http_server/axe-os/src/app/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/app/models/ISystemInfo.ts
@@ -46,7 +46,8 @@ export interface ISystemInfo {
     fallbackStratumUser: string,
     isUsingFallbackStratum: boolean,
     isStratumConnected: boolean,
-    stratumDifficulty: number;
+    stratumDifficulty: number,
+    poolDifficulty: number,
     frequency: number,
     defaultFrequency: number,
     version: string,

--- a/main/http_server/axe-os/src/app/pages/home/home.component.html
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.html
@@ -251,16 +251,6 @@
               </div>
               <div class="row flex-nowrap">
                 <div class="col-fixed-width">
-                  <span class="text-hint">Diff:</span>
-                </div>
-                <div class="col">
-                  {{ info.poolDifficulty }}
-                </div>
-              </div>
-
-
-              <div class="row flex-nowrap">
-                <div class="col-fixed-width">
                   <span class="text-hint">User:</span>
                 </div>
                 <div class="col">
@@ -275,6 +265,14 @@
                       {{ currentStratumUser.substring(currentStratumUserLength - 20) }}
                     </span>
                   </div>
+                </div>
+              </div>
+              <div class="row flex-nowrap">
+                <div class="col-fixed-width">
+                  <span class="text-hint">Diff:</span>
+                </div>
+                <div class="col">
+                  {{ info.poolDifficulty }}
                 </div>
               </div>
             </nb-card-body>

--- a/main/http_server/axe-os/src/app/pages/home/home.component.html
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.html
@@ -249,6 +249,15 @@
                   {{ info.isUsingFallbackStratum ? info.fallbackStratumPort : info.stratumPort }}
                 </div>
               </div>
+              <div class="row flex-nowrap">
+                <div class="col-fixed-width">
+                  <span class="text-hint">Diff:</span>
+                </div>
+                <div class="col">
+                  {{ info.poolDifficulty }}
+                </div>
+              </div>
+
 
               <div class="row flex-nowrap">
                 <div class="col-fixed-width">

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -64,6 +64,7 @@ const defaultInfo: ISystemInfo = {
   lastResetReason: "Unknown",
   jobInterval: 1200,
   stratumDifficulty: 1000,
+  poolDifficulty: 0,
 
   pidTargetTemp: 55,
   pidP: 2.0,

--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -98,6 +98,7 @@ esp_err_t GET_system_info(httpd_req_t *req)
     doc["isStratumConnected"] = STRATUM_MANAGER.isAnyConnected();
     doc["fanspeed"]           = POWER_MANAGEMENT_MODULE.getFanPerc();
     doc["fanrpm"]             = POWER_MANAGEMENT_MODULE.getFanRPM();
+    doc["poolDifficulty"]     = SYSTEM_MODULE.getPoolDifficulty();
 
     // If history was requested, add the history data as a nested object
     if (history_requested) {


### PR DESCRIPTION
This PR exposes the current pool difficulty received from the Stratum server to the WebUI:

- Adds `poolDifficulty` to the `/system/info` REST endpoint
- Extends the `ISystemInfo` model accordingly
- Displays the value in the system section of the home page

**Example use case**: quick verification of Stratum difficulty changes without checking logs or JSON traffic.

Screenshot:

<img width="290" alt="Bildschirmfoto 2025-05-28 um 13 53 28" src="https://github.com/user-attachments/assets/78fa159a-e77a-40cd-adb8-780f3c5cbe7d" />
