### PR TITLE
Fix bestDiff formatting: prevent "-Infinity" and broken number pipe / PR #164

### DIFF
--- a/main/http_server/axe-os/src/app/pages/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/pages/swarm/swarm.component.html
@@ -65,7 +65,8 @@
         <nb-card class="text-center mb-0" style="flex: 1;">
             <nb-card-body>
                 <span class="text-start">Best Diff</span>
-                <span class="text-primary fw-bold">{{ (totals.bestDiff | number) == "0" ? 0 : totals.bestDiff }}</span>
+                <!-- <span class="text-primary fw-bold">{{ (totals.bestDiff | number) == "0" ? 0 : totals.bestDiff }}</span> -->
+                <span class="text-primary fw-bold">{{ totals.bestDiff === '0.00' ? 0 : totals.bestDiff }}</span>
             </nb-card-body>
         </nb-card>
     </div>

--- a/main/http_server/axe-os/src/app/pages/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/pages/swarm/swarm.component.ts
@@ -267,8 +267,11 @@ export class SwarmComponent implements OnInit, OnDestroy {
   }
 
   private convertBestDiffToNumber(bestDiff: string): number {
-    if (!bestDiff) return 0;
+    if (!bestDiff || typeof bestDiff !== 'string') return 0;
+
     const value = parseFloat(bestDiff);
+    if (isNaN(value)) return 0;
+
     const unit = bestDiff.slice(-1).toUpperCase();
     switch (unit) {
       case 'T': return value * 1000000000000;
@@ -280,6 +283,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
   }
 
   private formatBestDiff(value: number): string {
+    if (!isFinite(value) || isNaN(value)) return '0.00';
     if (value >= 1000000000000) return `${(value / 1000000000000).toFixed(2)}T`;
     if (value >= 1000000000) return `${(value / 1000000000).toFixed(2)}G`;
     if (value >= 1000000) return `${(value / 1000000).toFixed(2)}M`;
@@ -290,7 +294,12 @@ export class SwarmComponent implements OnInit, OnDestroy {
   private calculateTotals() {
     this.totals.hashRate = this.swarm.reduce((sum, axe) => sum + (axe.hashRate || 0), 0);
     this.totals.power = this.swarm.reduce((sum, axe) => sum + (axe.power || 0), 0);
-    const maxDiff = Math.max(...this.swarm.map(axe => this.convertBestDiffToNumber(axe.bestDiff)));
+
+    const numericDiffs = this.swarm
+      .map(axe => this.convertBestDiffToNumber(axe.bestDiff))
+      .filter(v => !isNaN(v) && isFinite(v));
+
+    const maxDiff = numericDiffs.length > 0 ? Math.max(...numericDiffs) : 0;
     this.totals.bestDiff = this.formatBestDiff(maxDiff);
   }
 


### PR DESCRIPTION
This patch improves the handling of `bestDiff` values in the swarm overview:

- Filters out invalid `bestDiff` entries before calling Math.max(...)
- Prevents `-Infinity` from being rendered when no valid values exist
- Adds fallback logic in `formatBestDiff()` for NaN and Infinity cases
- Removes the problematic number pipe usage that broke values like "1.23G"

I left the old `number` pipe line in the HTML commented out (`<!-- ... -->`) for reference — feel free to remove it after review if it's no longer needed (line 68).

See also my comment in the previous PR #164 for background:
https://github.com/shufps/ESP-Miner-NerdQAxePlus/pull/164#issuecomment-2936012566