### PR TITLE
Add display of poolDifficulty value in Swarm UI

### DIFF
--- a/main/http_server/axe-os/src/app/pages/swarm/swarm.component.html
+++ b/main/http_server/axe-os/src/app/pages/swarm/swarm.component.html
@@ -85,6 +85,7 @@
                         <th>Shares</th>
                         <th>Power</th>
                         <th>Temp</th>
+                        <th>Pool Diff</th>
                         <th>Best Diff</th>
                         <th>Version</th>
                         <th>&nbsp;</th>
@@ -134,6 +135,8 @@
                                     {{ axe.vrTemp | number:'1.0-1' }}°<small>C</small>
                                 </div>
                             </td>
+                            <!-- Stratum Pool Diff -->
+                            <td>{{ axe.poolDifficulty | number:'1.0-0' }}</td>
                             <!-- Best Diff with Best Session Diff tooltip -->
                             <td>
                                 <div>{{ axe.bestDiff }}</div>

--- a/main/http_server/axe-os/src/app/pages/swarm/swarm.component.ts
+++ b/main/http_server/axe-os/src/app/pages/swarm/swarm.component.ts
@@ -243,6 +243,7 @@ export class SwarmComponent implements OnInit, OnDestroy {
               bestDiff: 0,
               version: 0,
               uptimeSeconds: 0,
+              poolDifficulty: 0,
             });
           })
         ),


### PR DESCRIPTION
🙌
This change adds a new column "Pool Diff" to the Swarm page in the UI, displaying the `poolDifficulty` value returned by each device’s _/api/system/info_ response.
The value is formatted as an integer (`number:'1.0-0'`).
No changes were required in the data retrieval logic, as the value is already included via the spread operator (`...result`).

... also added a fallback value (`0`) for `poolDifficulty` - just in case 😅