### PR TITLE
Fix hash rate chart tooltip

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.ts
@@ -116,7 +116,12 @@ export class HomeComponent implements AfterViewChecked, OnInit, OnDestroy {
           labels: {
             color: textColor
           }
-        }
+        },
+        tooltip: {
+          callbacks: {
+            label: (x: any) => `${x.dataset.label}: ${HashSuffixPipe.transform(x.raw)}`
+          }
+        },
       },
       scales: {
         x: {


### PR DESCRIPTION
Currently, the hash rate in the tooltip is displayed as a raw value e.g. 468,000,000,000. For a more user-friendly experience, it would be better to convert the value and display it with a suffix e.g. `TH/s`.

**Before**
<img width="1168" alt="Screenshot 2025-06-09 at 17 26 56" src="https://github.com/user-attachments/assets/2e16cba9-ef4b-4e50-939f-be260ece647a" />

**After**
<img width="1164" alt="Screenshot 2025-06-09 at 17 26 28" src="https://github.com/user-attachments/assets/d4bb23f5-a675-49fe-93e1-c3780c8404b4" />



