### PR TITLE
Enable TCP Keepalive support for Stratum sockets

### DIFF
--- a/main/tasks/stratum_task.cpp
+++ b/main/tasks/stratum_task.cpp
@@ -165,6 +165,32 @@ bool StratumTask::setupSocketTimeouts(int sock)
         ESP_LOGE(m_tag, "Failed to set socket send timeout");
         return false;
     }
+
+    // Enable TCP Keepalive
+    int enable = 1;
+    if (setsockopt(sock, SOL_SOCKET, SO_KEEPALIVE, &enable, sizeof(enable)) < 0) {
+        ESP_LOGE(m_tag, "Failed to enable SO_KEEPALIVE");
+        return false;
+    }
+
+    // Configure Keepalive parameters
+    int keepidle = 10;   // Start sending keepalive probes after 10 seconds of inactivity
+    int keepintvl = 5;   // Interval of 5 seconds between individual keepalive probes
+    int keepcnt = 3;     // Disconnect after 3 unanswered probes
+
+    if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPIDLE, &keepidle, sizeof(keepidle)) < 0) {
+        ESP_LOGW(m_tag, "TCP_KEEPIDLE not supported or failed to set");
+        // This might not be critical, so we could just log a warning and continue
+    }
+    if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPINTVL, &keepintvl, sizeof(keepintvl)) < 0) {
+        ESP_LOGE(m_tag, "Failed to set TCP_KEEPINTVL");
+    }
+    if (setsockopt(sock, IPPROTO_TCP, TCP_KEEPCNT, &keepcnt, sizeof(keepcnt)) < 0) {
+        ESP_LOGE(m_tag, "Failed to set TCP_KEEPCNT");
+    }
+
+    ESP_LOGI(m_tag, "TCP Keepalive enabled: idle=%ds, interval=%ds, count=%d", keepidle, keepintvl, keepcnt);
+
     return true;
 }
 


### PR DESCRIPTION
This change enables TCP Keepalive on all outgoing Stratum connections to improve robustness and detect silently dropped peers.

The following socket options are now configured in `setupSocketTimeouts()`:
- `SO_KEEPALIVE` is enabled to activate the mechanism.
- `TCP_KEEPIDLE`, `TCP_KEEPINTVL`, and `TCP_KEEPCNT` are set to detect idle or broken connections after 10 seconds of inactivity, using 3 probes spaced 5 seconds apart.

This complements the existing `SO_RCVTIMEO` setting, which protects individual `recv()` calls from hanging indefinitely.
While `SO_RCVTIMEO` affects blocking calls on the socket layer (e.g. `recv()`), TCP Keepalive operates at the TCP protocol level to detect dead peers even in the absence of active reads.

**Sample log entry:**
`₿ I (28839) stratum task: TCP Keepalive enabled: idle=10s, interval=5s, count=3`

Based on esp-idf 5.5 - No additional configuration changes are required as TCP Keepalive support is already enabled