### PR TITLE
Improve logging in connectStratum()

### DIFF
--- a/main/tasks/stratum_task.cpp
+++ b/main/tasks/stratum_task.cpp
@@ -132,12 +132,13 @@ int StratumTask::connectStratum(const char *host_ip, uint16_t port)
 
     int err = ::connect(sock, (struct sockaddr *) &dest_addr, sizeof(dest_addr));
     if (err != 0) {
+        ESP_LOGE(m_tag, "Connect failed to %s:%d (errno %d: %s)", host_ip, port, errno, strerror(errno));
         shutdown(sock, SHUT_RDWR);
         close(sock);
         return 0;
     }
 
-    ESP_LOGI(m_tag, "Connected");
+    ESP_LOGI(m_tag, "Connected to %s:%d", host_ip, port);
 
     if (!setupSocketTimeouts(sock)) {
         ESP_LOGE(m_tag, "Error setting socket timeouts");


### PR DESCRIPTION
Adds more detailed log output to `connectStratum()` to aid debugging and diagnosis of connection issues.
- Failed connection attempts now log both the `errno` value and its string description via `strerror(errno)`
- Successful connections now include the target IP and port in the log message

This makes it easier to distinguish between network errors, unreachable ports, and DNS-related issues—especially useful when running with fallback logic or in unstable network environments.