### PR TITLE
Refactor: use pdMS_TO_TICKS for delay conversions

### DIFF
--- a/components/bm1397/asic.cpp
+++ b/components/bm1397/asic.cpp
@@ -179,7 +179,7 @@ bool Asic::doFrequencyTransition(float target_frequency) {
             printf("ERROR: Failed to set frequency to %.2f MHz\n", current);
             return false;
         }
-        vTaskDelay(100 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(100));
     }
 
     // Ramp in the appropriate direction
@@ -190,7 +190,7 @@ bool Asic::doFrequencyTransition(float target_frequency) {
             printf("ERROR: Failed to set frequency to %.2f MHz\n", current);
             return false;
         }
-        vTaskDelay(100 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(100));
     }
 
     // Set the exact target frequency to finalize

--- a/components/connect/connect.c
+++ b/components/connect/connect.c
@@ -78,7 +78,7 @@ static void event_handler(void *arg, esp_event_base_t event_base, int32_t event_
     } else if (event_base == WIFI_EVENT && event_id == WIFI_EVENT_STA_DISCONNECTED) {
 
         // Wait a little
-        vTaskDelay(1000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(1000));
 
         if (s_retry_num < WIFI_MAXIMUM_RETRY) {
             esp_wifi_connect();

--- a/main/boards/board.cpp
+++ b/main/boards/board.cpp
@@ -99,7 +99,7 @@ bool Board::selfTest(){
 
     temp_display->logMessage("Self test not supported on this board...");
     ESP_LOGI("board", "Self test not supported on this board");
-    vTaskDelay(1000 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(1000));
 
     return false;
 }
@@ -135,17 +135,17 @@ FanPolarityGuess Board::guessFanPolarity() {
     ESP_LOGI("polarity", "set 50%%");
     setFanPolarity(false);
     setFanSpeed(0.5f);
-    vTaskDelay(settleTimeMs / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(settleTimeMs));
 
     // Test low speed
     setFanSpeed(lowPWM);
-    vTaskDelay(settleTimeMs / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(settleTimeMs));
     getFanSpeed(&rpmLow);
     ESP_LOGI("polarity", "set %.2f%% read: %d", lowPWM, rpmLow);
 
     // Test high speed
     setFanSpeed(highPWM);
-    vTaskDelay(settleTimeMs / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(settleTimeMs));
     getFanSpeed(&rpmHigh);
     ESP_LOGI("polarity", "set %.2f%% read: %d", highPWM, rpmHigh);
 

--- a/main/boards/nerdaxe.cpp
+++ b/main/boards/nerdaxe.cpp
@@ -135,19 +135,19 @@ bool NerdAxe::initAsics()
     gpio_set_level(BM1366_RST_PIN, 0);
 
     // wait 250ms
-    vTaskDelay(250 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(250));
 
      // set output voltage
     setVoltage((float) m_asicVoltageMillis / 1000.0f);
 
     // wait 500ms
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     // release reset pin
     gpio_set_level(BM1366_RST_PIN, 1);
 
     // delay for 250ms
-    vTaskDelay(250 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(250));
 
     SERIAL_clear_buffer();
     m_chipsDetected = m_asics->init(m_asicFrequency, m_asicCount, m_asicMaxDifficulty);
@@ -157,11 +157,11 @@ bool NerdAxe::initAsics()
     }
     int maxBaud = m_asics->setMaxBaud();
     // no idea why a delay is needed here starting with esp-idf 5.4 🙈
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
     SERIAL_set_baud(maxBaud);
     SERIAL_clear_buffer();
 
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     m_isInitialized = true;
     return true;

--- a/main/boards/nerdaxegamma.cpp
+++ b/main/boards/nerdaxegamma.cpp
@@ -97,26 +97,26 @@ bool NerdaxeGamma::initAsics() {
     setVoltage(0.0);
 
     // wait 500ms
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     // set reset low
     gpio_set_level(BM1370_RST_PIN, 0);
 
     // wait 250ms
-    vTaskDelay(250 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(250));
 
     // set the init voltage
     // use the higher voltage for initialization
     setVoltage((float) MAX(m_initVoltageMillis, m_asicVoltageMillis) / 1000.0f);
 
     // wait 500ms
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     // release reset pin
     gpio_set_level(BM1370_RST_PIN, 1);
 
     // delay for 250ms
-    vTaskDelay(250 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(250));
 
     SERIAL_clear_buffer();
     m_chipsDetected = m_asics->init(m_asicFrequency, m_asicCount, m_asicMaxDifficulty);
@@ -126,11 +126,11 @@ bool NerdaxeGamma::initAsics() {
     }
     int maxBaud = m_asics->setMaxBaud();
     // no idea why a delay is needed here starting with esp-idf 5.4 🙈
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
     SERIAL_set_baud(maxBaud);
     SERIAL_clear_buffer();
 
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     m_isInitialized = true;
     return true;

--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -105,11 +105,11 @@ bool NerdQaxePlus::initBoard()
 void NerdQaxePlus::shutdown() {
     setVoltage(0.0);
 
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     LDO_disable();
 
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 }
 
 bool NerdQaxePlus::initAsics()
@@ -124,13 +124,13 @@ bool NerdQaxePlus::initAsics()
     gpio_set_level(BM1368_RST_PIN, 0);
 
     // wait 250ms
-    vTaskDelay(250 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(250));
 
     // enable LDOs
     LDO_enable();
 
     // wait 100ms
-    vTaskDelay(100 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(100));
 
     // init buck and enable output
     m_tps->init(m_numPhases, m_imax, m_ifault);
@@ -140,13 +140,13 @@ bool NerdQaxePlus::initAsics()
     setVoltage((float) MAX(m_initVoltageMillis, m_asicVoltageMillis) / 1000.0f);
 
     // wait 500ms
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     // release reset pin
     gpio_set_level(BM1368_RST_PIN, 1);
 
     // delay for 250ms
-    vTaskDelay(250 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(250));
 
     SERIAL_clear_buffer();
     m_chipsDetected = m_asics->init(m_asicFrequency, m_asicCount, m_asicMaxDifficulty);
@@ -156,11 +156,11 @@ bool NerdQaxePlus::initAsics()
     }
     int maxBaud = m_asics->setMaxBaud();
     // no idea why a delay is needed here starting with esp-idf 5.4 🙈
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
     SERIAL_set_baud(maxBaud);
     SERIAL_clear_buffer();
 
-    vTaskDelay(500 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(500));
 
     // set final output voltage
     setVoltage((float) m_asicVoltageMillis / 1000.0f);

--- a/main/displays/displayDriver.cpp
+++ b/main/displays/displayDriver.cpp
@@ -225,7 +225,7 @@ void DisplayDriver::lvglTimerTask(void *param)
         if (m_animationsEnabled) {
             increaseLvglTick();
             lv_timer_handler();                 // Process pending LVGL tasks
-            vTaskDelay(5 / portTICK_PERIOD_MS); // Delay during animations
+            vTaskDelay(pdMS_TO_TICKS(5)); // Delay during animations
             if (elapsed_Ani_cycles++ > 80) {
                 // After 1s aprox stop animations
                 m_animationsEnabled = false;
@@ -239,7 +239,7 @@ void DisplayDriver::lvglTimerTask(void *param)
                     displayTurnOn();
                 changeScreen();
             }
-            vTaskDelay(200 / portTICK_PERIOD_MS); // Delay waiting animation trigger
+            vTaskDelay(pdMS_TO_TICKS(200)); // Delay waiting animation trigger
         }
         if (m_button2PressedFlag) {
             m_button2PressedFlag = false;

--- a/main/http_server/handler_ota.cpp
+++ b/main/http_server/handler_ota.cpp
@@ -115,7 +115,7 @@ esp_err_t POST_OTA_update(httpd_req_t *req)
 
     httpd_resp_sendstr(req, "Firmware update complete, rebooting now!\n");
     ESP_LOGI(TAG, "Restarting System because of Firmware update complete");
-    vTaskDelay(1000 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(1000));
     POWER_MANAGEMENT_MODULE.restart();
 
     return ESP_OK;

--- a/main/http_server/handler_restart.cpp
+++ b/main/http_server/handler_restart.cpp
@@ -20,7 +20,7 @@ esp_err_t POST_restart(httpd_req_t *req)
     httpd_resp_send(req, resp_str, HTTPD_RESP_USE_STRLEN);
 
     // Delay to ensure the response is sent
-    vTaskDelay(1000 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(1000));
 
     // Restart the system
     POWER_MANAGEMENT_MODULE.restart();

--- a/main/http_server/http_websocket.cpp
+++ b/main/http_server/http_websocket.cpp
@@ -99,13 +99,13 @@ void websocket_log_handler(void* param)
 			if (message != NULL) {
 				FREE(message);
 			}
-			vTaskDelay(10 / portTICK_PERIOD_MS);
+			vTaskDelay(pdMS_TO_TICKS(10));
 			continue;
 		}
 
 		if (fd == -1) {
 			FREE(message);
-			vTaskDelay(100 / portTICK_PERIOD_MS);
+			vTaskDelay(pdMS_TO_TICKS(100));
 			continue;
 		}
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -85,7 +85,7 @@ static void setup_wifi()
     ESP_LOGI(TAG, "Finished, waiting for user input.");
 
     while (1) {
-        vTaskDelay(1000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(1000));
     }
 }
 
@@ -196,7 +196,7 @@ extern "C" void app_main(void)
     bool should_self_test = Config::isSelfTestEnabled();
     if (should_self_test && !best_diff) {
         board->selfTest();
-        vTaskDelay(60 * 60 * 1000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(60 * 60 * 1000));
     }
 
     xTaskCreate(SYSTEM_MODULE.taskWrapper, "SYSTEM_task", 4096, &SYSTEM_MODULE, 3, NULL);
@@ -234,7 +234,7 @@ extern "C" void app_main(void)
 
     //char* taskList = (char*) malloc(8192);
     while (1) {
-        vTaskDelay(10000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(10000));
         size_t free_internal_heap = heap_caps_get_free_size(MALLOC_CAP_INTERNAL);
 
         if (free_internal_heap < 10000) {

--- a/main/self_test/self_test.cpp
+++ b/main/self_test/self_test.cpp
@@ -49,7 +49,7 @@ void self_test(void *pvParameters)
     // Initialize display
     display_init();
     display_log_message("Self test initiated...");
-    vTaskDelay(1000 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(1000));
 
     GlobalState *GLOBAL_STATE = (GlobalState *) pvParameters;
 
@@ -77,10 +77,10 @@ void self_test(void *pvParameters)
     ESP_LOGI(TAG, "%u chips detected, %u expected", chips_detected, GLOBAL_STATE->asic_count);
 
     int baud = (*GLOBAL_STATE->ASIC_functions.set_max_baud_fn)();
-    vTaskDelay(10 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(10));
     SERIAL_set_baud(baud);
 
-    vTaskDelay(1000 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(1000));
 
     mining_notify notify_message;
     notify_message.job_id = 0;
@@ -128,7 +128,7 @@ void self_test(void *pvParameters)
     ESP_LOGI(TAG, "Sending work");
 
     (*GLOBAL_STATE->ASIC_functions.send_work_fn)(GLOBAL_STATE, job);
-    // vTaskDelay((GLOBAL_STATE->asic_job_frequency_ms - 0.3) / portTICK_PERIOD_MS);
+    // vTaskDelay(pdMS_TO_TICKS((GLOBAL_STATE->asic_job_frequency_ms - 0.3)));
 
     // ESP_LOGI(TAG, "Receiving work");
 

--- a/main/system.cpp
+++ b/main/system.cpp
@@ -267,11 +267,11 @@ void System::task() {
         if (result == ESP_OK && (wifiMode == WIFI_MODE_APSTA || wifiMode == WIFI_MODE_AP) &&
             strcmp(m_wifiStatus, "Failed to connect") == 0) {
             showApInformation(nullptr);
-            vTaskDelay(5000 / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(5000));
         } else {
             updateConnection();
         }
-        vTaskDelay(100 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(100));
     }
 
     m_display->miningScreen();
@@ -308,7 +308,7 @@ void System::task() {
         m_display->updateCurrentSettings();
         m_display->refreshScreen();
 
-        vTaskDelay(5000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(5000));
     }
 }
 

--- a/main/tasks/apis_task.cpp
+++ b/main/tasks/apis_task.cpp
@@ -242,7 +242,7 @@ void APIsFetcher::task() {
             fetchData(APIurl_GLOBALHASH, APItype_HASHRATE);
             fetchData(APIurl_GETFEES, APItype_FEES);
 
-            vTaskDelay(60000 / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(60000));
         }while (m_enabled);
     }
 }

--- a/main/tasks/influx_task.cpp
+++ b/main/tasks/influx_task.cpp
@@ -91,7 +91,7 @@ static void forever()
 {
     ESP_LOGI(TAG, "halting influx_task");
     while (1) {
-        vTaskDelay(15000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(15000));
     }
 }
 
@@ -150,7 +150,7 @@ void influx_task(void *pvParameters)
         if (loaded_values_ok) {
             break;
         }
-        vTaskDelay(15000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(15000));
     }
 
     ESP_LOGI(TAG, "last values: total_uptime: %d, total_best_difficulty: %.3f, total_blocks_found: %d",
@@ -170,6 +170,6 @@ void influx_task(void *pvParameters)
         influx_task_fetch_from_system_module(module);
         influxdb->write();
         pthread_mutex_unlock(&influxdb->m_lock);
-        vTaskDelay(15000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(15000));
     }
 }

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -154,7 +154,7 @@ void PowerManagementTask::task()
     m_pid->SetControllerDirection(REVERSE);
     m_pid->Initialize();
 
-    vTaskDelay(3000 / portTICK_PERIOD_MS);
+    vTaskDelay(pdMS_TO_TICKS(3000));
 
     while (1) {
         lock();
@@ -276,6 +276,6 @@ void PowerManagementTask::task()
         }
         unlock();
 
-        vTaskDelay(POLL_RATE / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(POLL_RATE));
     }
 }

--- a/main/tasks/stratum_task.cpp
+++ b/main/tasks/stratum_task.cpp
@@ -182,13 +182,13 @@ void StratumTask::task()
         // we do it here because we could reload the config after
         // it was updated on the UI and settings
         if (!strlen(m_config->host)) {
-            vTaskDelay(10000 / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(10000));
             continue;
         }
 
         // should stay stopped?
         if (m_stopFlag) {
-            vTaskDelay(10000 / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(10000));
             continue;
         }
 
@@ -197,7 +197,7 @@ void StratumTask::task()
         if (!isWifiConnected()) {
             ESP_LOGI(m_tag, "WiFi disconnected, attempting to reconnect...");
             esp_wifi_connect();
-            vTaskDelay(10000 / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(10000));
             continue;
         }
 
@@ -205,7 +205,7 @@ void StratumTask::task()
         char ip[INET_ADDRSTRLEN] = {0};
         if (!resolveHostname(m_config->host, ip, sizeof(ip))) {
             ESP_LOGE(m_tag, "%s couldn't be resolved!", m_config->host);
-            vTaskDelay(10000 / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(10000));
             continue;
         }
 
@@ -213,7 +213,7 @@ void StratumTask::task()
 
         if (!(m_sock = connectStratum(ip, m_config->port))) {
             ESP_LOGE(m_tag, "Socket unable to connect to %s:%d (errno %d)", m_config->host, m_config->port, errno);
-            vTaskDelay(10000 / portTICK_PERIOD_MS);
+            vTaskDelay(pdMS_TO_TICKS(10000));
             continue;
         }
 
@@ -237,7 +237,7 @@ void StratumTask::task()
         m_manager->disconnectedCallback(m_index);
         m_isConnected = false;
 
-        vTaskDelay(10000 / portTICK_PERIOD_MS); // Delay before attempting to reconnect
+        vTaskDelay(pdMS_TO_TICKS(10000)); // Delay before attempting to reconnect
     }
     vTaskDelete(NULL);
 }
@@ -459,7 +459,7 @@ void StratumManager::task()
 
     // Watchdog Task Loop (optional, if needed)
     while (1) {
-        vTaskDelay(30000 / portTICK_PERIOD_MS);
+        vTaskDelay(pdMS_TO_TICKS(30000));
 
         // Reset watchdog if there was a submit response within the last hour
         if (((esp_timer_get_time() - m_lastSubmitResponseTimestamp) / 1000000) < 3600) {


### PR DESCRIPTION
**Summary**

Replaced manual tick calculations like `vTaskDelay(ms / portTICK_PERIOD_MS)` with `pdMS_TO_TICKS(ms)` throughout the codebase.

**Why**

- Improves **readability** and **clarity** of delay calls
- Reduces risk of **integer division bugs**
- Aligns with **FreeRTOS best practices** and official style
- Future-proof against changes in tick configuration

No functional change – this is a clean, mechanical refactor.