### PR TITLE
Add WiFi RSSI display to WebUI and system info response

### DIFF
--- a/main/http_server/axe-os/src/app/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/app/models/ISystemInfo.ts
@@ -29,6 +29,7 @@ export interface ISystemInfo {
     hostname: string,
     hostip: string,
     macAddr: string,
+    wifiRSSI: number,
     ssid: string,
     wifiPass: string,
     wifiStatus: string,

--- a/main/http_server/axe-os/src/app/pages/system/system.component.html
+++ b/main/http_server/axe-os/src/app/pages/system/system.component.html
@@ -17,8 +17,21 @@
                     <td>{{ info.lastResetReason }}</td>
                 </tr>
                 <tr>
-                    <td><b>WiFi Status:</b></td>
-                    <td>{{ info.wifiStatus }}</td>
+                  <td><b>WiFi Status:</b></td>
+                  <td>
+                    <span class="wifi-status-combined">
+                      {{ info.wifiStatus }}
+                      <span class="rssi-inline">
+                        ({{ info.wifiRSSI }} dBm)
+                        <div class="wifi-bars" [attr.title]="getRssiTooltip(info.wifiRSSI)">
+                          <div class="bar" [class.active]="info.wifiRSSI > -85"></div>
+                          <div class="bar" [class.active]="info.wifiRSSI > -75"></div>
+                          <div class="bar" [class.active]="info.wifiRSSI > -65"></div>
+                          <div class="bar" [class.active]="info.wifiRSSI > -55"></div>
+                        </div>
+                      </span>
+                    </span>
+                  </td>
                 </tr>
                 <tr>
                     <td><b>MAC Address:</b></td>

--- a/main/http_server/axe-os/src/app/pages/system/system.component.scss
+++ b/main/http_server/axe-os/src/app/pages/system/system.component.scss
@@ -39,3 +39,45 @@
 :host ::ng-deep .ansi-cyan { color: #00ffff !important; }
 :host ::ng-deep .ansi-white { color: #ffffff !important; }
 
+.rssi-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wifi-bars {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 1rem;
+}
+
+.wifi-bars .bar {
+  width: 5px;
+  background-color: #ccc;
+  opacity: 0.4;
+  transition: 0.3s ease;
+}
+
+.wifi-bars .bar:nth-child(1) { height: 25%; }
+.wifi-bars .bar:nth-child(2) { height: 50%; }
+.wifi-bars .bar:nth-child(3) { height: 75%; }
+.wifi-bars .bar:nth-child(4) { height: 100%; }
+
+.wifi-bars .bar.active {
+  background-color: #4caf50;
+  opacity: 1;
+}
+
+.wifi-status-combined {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+@media (min-width: 600px) {
+  .wifi-status-combined {
+    flex-wrap: nowrap;
+  }
+}

--- a/main/http_server/axe-os/src/app/pages/system/system.component.ts
+++ b/main/http_server/axe-os/src/app/pages/system/system.component.ts
@@ -94,4 +94,11 @@ export class SystemComponent implements OnDestroy, AfterViewChecked {
     });
   }
 
+  public getRssiTooltip(rssi: number): string {
+    if (rssi <= -85) return 'Signal strength: Very weak (≤ -85 dBm)';
+    if (rssi <= -75) return 'Signal strength: Weak (≤ -75 dBm)';
+    if (rssi <= -65) return 'Signal strength: Moderate (≤ -65 dBm)';
+    if (rssi <= -55) return 'Signal strength: Strong (≤ -55 dBm)';
+    return 'Signal strength: Excellent (> -55 dBm)';
+  }
 }

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -33,6 +33,7 @@ const defaultInfo: ISystemInfo = {
   hostname: "Bitaxe",
   hostip: "192.168.0.123",
   macAddr: "DE:AD:C0:DE:0B:7C",
+  wifiRSSI: -90,
   ssid: "default",
   wifiPass: "password",
   wifiStatus: "Connected!",

--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -71,6 +71,7 @@ esp_err_t GET_system_info(httpd_req_t *req)
     doc["deviceModel"]        = board->getDeviceModel();
     doc["hostip"]             = SYSTEM_MODULE.getIPAddress();
     doc["macAddr"]            = SYSTEM_MODULE.getMacAddress();
+    doc["wifiRSSI"]           = SYSTEM_MODULE.get_wifi_rssi();
 
     // dashboard
     doc["power"]              = POWER_MANAGEMENT_MODULE.getPower();

--- a/main/system.cpp
+++ b/main/system.cpp
@@ -123,6 +123,21 @@ const char* System::getMacAddress() {
     return connect_get_mac_addr();
 }
 
+// Function to fetch and return the RSSI (dBm) value
+int System::get_wifi_rssi()
+{
+    wifi_ap_record_t ap_info;
+
+    // Query the connected Access Point's information
+    if (esp_wifi_sta_get_ap_info(&ap_info) == ESP_OK) {
+        ESP_LOGI("WIFI_RSSI", "Current RSSI: %d dBm", ap_info.rssi);
+        return ap_info.rssi;  // Return the actual RSSI value
+    } else {
+        ESP_LOGE("WIFI_RSSI", "Failed to fetch RSSI");
+        return -90;  // Return -90 to indicate an error
+    }
+}
+
 double System::calculateNetworkDifficulty(uint32_t nBits) {
     uint32_t mantissa = nBits & 0x007fffff;  // Extract the mantissa from nBits
     uint8_t exponent = (nBits >> 24) & 0xff;  // Extract the exponent from nBits
@@ -335,3 +350,4 @@ void System::notifyFoundNonce(double poolDiff, int asicNr) {
     m_currentHashrate10m = m_history->getCurrentHashrate10m();
     updateHashrate();
 }
+

--- a/main/system.h
+++ b/main/system.h
@@ -112,7 +112,9 @@ class System {
     // Made public (was protected) to allow usage in external modules like ASIC_result_task for formatting/logging.
     static void suffixString(uint64_t val, char *buf, size_t bufSize, int sigDigits); // Format a value with a suffix (e.g., K, M)
 
+    // WiFi related
     const char* getMacAddress();
+    int get_wifi_rssi();
 
     // Getter methods for retrieving statistics
     uint64_t getSharesRejected() const


### PR DESCRIPTION
This PR adds WiFi RSSI reporting and display:

- `wifiRSSI` exposed in `/api/system/info` (in dBm)
- System log output via `esp_wifi_sta_get_ap_info()`
- WebUI now shows RSSI next to WiFi status (dBm + signal bars)
- Tooltip shows signal quality (Very weak to Excellent)
- Responsive inline layout with mobile support

More context and screenshot in [#199 ](https://github.com/shufps/ESP-Miner-NerdQAxePlus/issues/199#issuecomment-2986858140)