### PR TITLE
hide discord webhook

### DIFF
--- a/main/http_server/axe-os/src/app/models/IAlertSettings.ts
+++ b/main/http_server/axe-os/src/app/models/IAlertSettings.ts
@@ -1,4 +1,4 @@
 export interface IAlertSettings {
-  alertEnable: number;
-  discordURL: string;
+  alertDiscordEnable: number;
+  alertDiscordWebhook: string;
 }

--- a/main/http_server/axe-os/src/app/pages/alert/alert.component.html
+++ b/main/http_server/axe-os/src/app/pages/alert/alert.component.html
@@ -11,13 +11,13 @@
           An alert will be triggered if the device reboots after failing to submit a share for 1 hour.
         </div>
         <div class="form-row">
-          <nb-checkbox formControlName="alertEnable">Enable</nb-checkbox>
+          <nb-checkbox formControlName="alertDiscordEnable">Enable</nb-checkbox>
         </div>
 
         <div class="form-row">
-          <label for="discordURL" class="form-label">Webhook URL:</label>
+          <label for="alertDiscordWebhook" class="form-label">Webhook URL:</label>
           <div class="form-control-wrapper">
-            <input nbInput id="discordURL" type="text" formControlName="discordURL"
+            <input nbInput id="alertDiscordWebhook" type="password" formControlName="alertDiscordWebhook"
               placeholder="https://discord.com/api/webhooks/..." /><br />
             <small>Webhook from your Discord channel integration</small>
           </div>

--- a/main/http_server/axe-os/src/app/pages/alert/alert.component.ts
+++ b/main/http_server/axe-os/src/app/pages/alert/alert.component.ts
@@ -30,11 +30,11 @@ export class AlertComponent implements OnInit {
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe(data => {
         this.form = this.fb.group({
-          discordURL: [data.discordURL, [
+          alertDiscordWebhook: ['WEBHOOK', [
             Validators.required,
             Validators.pattern(/^https:\/\/discord\.com\/api\/webhooks\/.+$/)
           ]],
-          alertEnable: [data.alertEnable === 1]
+          alertDiscordEnable: [data.alertDiscordEnable === 1],
         });
       });
   }
@@ -42,12 +42,11 @@ export class AlertComponent implements OnInit {
   public save() {
     const form = this.form.getRawValue();
 
-    const payload: IAlertSettings = {
-      discordURL: form.discordURL,
-      alertEnable: form.alertEnable
-    };
+    if (form.alertDiscordWebhook === 'WEBHOOK') {
+      delete form.alertDiscordWebhook;
+    }
 
-    this.systemService.updateAlertInfo(this.uri, payload)
+    this.systemService.updateAlertInfo(this.uri, form)
       .pipe(this.loadingService.lockUIUntilComplete())
       .subscribe({
         next: () => {
@@ -55,19 +54,6 @@ export class AlertComponent implements OnInit {
         },
         error: (err: HttpErrorResponse) => {
           this.toastrService.danger('Could not save alert settings.', err.message);
-        }
-      });
-  }
-
-  public restart() {
-    this.systemService.restart()
-      .pipe(catchError(error => {
-        this.toastrService.danger('Restart failed.', 'Error');
-        return of(null);
-      }))
-      .subscribe(res => {
-        if (res !== null) {
-          this.toastrService.success('Device restarted.', 'Success');
         }
       });
   }

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -203,8 +203,8 @@ export class SystemService {
       return this.httpClient.get(`${uri}/api/alert/info`) as Observable<IAlertSettings>;
     } else {
       return of({
-        alertEnable: 0,
-        discordURL: 'https://discord.com/api/webhooks/xxx/yyy'
+        alertDiscordEnable: 0,
+        alertDiscordWebhook: 'https://discord.com/api/webhooks/xxx/yyy'
       }).pipe(delay(1000));
     }
   }

--- a/main/http_server/handler_alert.cpp
+++ b/main/http_server/handler_alert.cpp
@@ -24,18 +24,19 @@ esp_err_t GET_alert_info(httpd_req_t *req)
         return ESP_FAIL;
     }
 
-    char *discordURL = Config::getDiscordWebhook();
+    char *alertDiscordWebhook = Config::getDiscordWebhook();
 
     PSRAMAllocator allocator;
     JsonDocument doc(&allocator);
 
-    doc["discordURL"]  = discordURL;
-    doc["alertEnable"] = Config::isDiscordAlertEnabled() ? 1 : 0;
+    // don't send the alertDiscordWebhook on the API
+    //doc["alertDiscordWebhook"]  = alertDiscordWebhook;
+    doc["alertDiscordEnable"] = Config::isDiscordAlertEnabled() ? 1 : 0;
 
     esp_err_t ret = sendJsonResponse(req, doc);
 
     doc.clear();
-    free(discordURL);
+    free(alertDiscordWebhook);
 
     return ret;
 }
@@ -82,11 +83,11 @@ esp_err_t POST_update_alert(httpd_req_t *req)
         return ESP_FAIL;
     }
 
-    if (doc["discordURL"].is<const char*>()) {
-        Config::setDiscordWebhook(doc["discordURL"].as<const char*>());
+    if (doc["alertDiscordWebhook"].is<const char*>()) {
+        Config::setDiscordWebhook(doc["alertDiscordWebhook"].as<const char*>());
     }
-    if (doc["alertEnable"].is<bool>()) {
-        Config::setDiscordAlertEnabled(doc["alertEnable"].as<bool>());
+    if (doc["alertDiscordEnable"].is<bool>()) {
+        Config::setDiscordAlertEnabled(doc["alertDiscordEnable"].as<bool>());
     }
 
     doc.clear();


### PR DESCRIPTION
don't return the discord webhook via the API and treat it like a password or a token. Also some renaming