### PR TITLE
Add configurable TCP keepalive for stratum connection

### DIFF
--- a/config.cvs.example
+++ b/config.cvs.example
@@ -138,3 +138,10 @@ stratumdiff,data,u64,1000
 
 # Discord Webhook URL
 #alrt_disc_url,data,string,https://discord.com/api/webhooks/your_token_here
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ↓↓↓ STRATUM KEEPALIVE ↓↓↓
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Enable TCP Keepalive for Stratum socket
+#stratum_keep,data,u16,0

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -202,3 +202,18 @@ menu "Discord Alert Configuration"
             Be sure to keep this secret!
 
 endmenu
+
+menu "Stratum Keepalive Configuration"
+
+    config STRATUM_KEEPALIVE_ENABLE
+        bool "Enable TCP Keepalive for Stratum connection"
+        default y
+        help
+            Enables TCP keepalive on the Stratum socket to detect broken connections.
+
+    config STRATUM_KEEPALIVE_ENABLE_VALUE
+        int
+        default 1 if STRATUM_KEEPALIVE_ENABLE
+        default 0
+
+endmenu

--- a/main/http_server/axe-os/src/app/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/app/models/ISystemInfo.ts
@@ -62,6 +62,7 @@ export interface ISystemInfo {
     lastResetReason: string,
     jobInterval: number,
     lastpingrtt: number,
+    stratum_keep: number,
 
     boardtemp1?: number,
     boardtemp2?: number,

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.html
@@ -261,6 +261,9 @@
                 <div class="form-row">
                     <nb-checkbox formControlName="autoscreenoff">Automatic Screen Shutdown</nb-checkbox>
                 </div>
+                <div class="form-row">
+                  <nb-checkbox formControlName="stratum_keep">Enable Stratum TCP Keepalive</nb-checkbox>
+                </div>
             </nb-card-body>
         </nb-card>
         <div class="d-flex align-items-center justify-content-between mt-2">

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
@@ -53,6 +53,7 @@ export class EditComponent implements OnInit {
     'invertfanpolarity',
     'autofanpolarity',
     'stratumDifficulty',
+    'stratum_keep',
   ]);
 
   @Input() uri = '';
@@ -91,6 +92,7 @@ export class EditComponent implements OnInit {
         info.overheat_temp = Math.min(info.overheat_temp, 90);
 
         this.form = this.fb.group({
+          stratum_keep: [info.stratum_keep == 1],
           flipscreen: [info.flipscreen == 1],
           invertscreen: [info.invertscreen == 1],
           autoscreenoff: [info.autoscreenoff == 1],
@@ -209,6 +211,8 @@ export class EditComponent implements OnInit {
     if (form.stratumPassword === '*****') {
       delete form.stratumPassword;
     }
+
+    form.stratum_keep = form.stratum_keep ? 1 : 0;
 
     this.systemService.updateSystem(this.uri, form)
       .pipe(this.loadingService.lockUIUntilComplete())

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -70,6 +70,7 @@ const defaultInfo: ISystemInfo = {
   stratumDifficulty: 1000,
   lastpingrtt: 0.00,
   poolDifficulty: 0,
+  stratum_keep: 0,
 
   pidTargetTemp: 55,
   pidP: 2.0,

--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -138,6 +138,7 @@ esp_err_t GET_system_info(httpd_req_t *req)
     doc["invertfanpolarity"]  = board->isInvertFanPolarityEnabled() ? 1 : 0;
     doc["autofanpolarity"]  = board->isAutoFanPolarityEnabled() ? 1 : 0;
     doc["autofanspeed"]       = Config::getTempControlMode();
+    doc["stratum_keep"]       = Config::isStratumKeepaliveEnabled() ? 1 : 0;
 
     // system screen
     doc["ASICModel"]          = board->getAsicModel();
@@ -292,6 +293,11 @@ esp_err_t PATCH_update_settings(httpd_req_t *req)
     }
     if (doc["autoscreenoff"].is<bool>()) {
         Config::setAutoScreenOff(doc["autoscreenoff"].as<bool>());
+    }
+    if (doc["stratum_keep"].is<bool>() || doc["stratum_keep"].is<int>()) {
+        bool value = doc["stratum_keep"].as<int>() != 0;
+        Config::setStratumKeepaliveEnabled(value);
+        ESP_LOGI("system", "stratum_keep updated via WebUI: %s", value ? "ENABLED" : "DISABLED");
     }
     if (doc["pidTargetTemp"].is<uint16_t>()) {
         Config::setPidTargetTemp(doc["pidTargetTemp"].as<uint16_t>());

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -18,6 +18,7 @@
 #define NVS_CONFIG_STRATUM_FALLBACK_USER "fbstratumuser"
 #define NVS_CONFIG_STRATUM_FALLBACK_PASS "fbstratumpass"
 #define NVS_CONFIG_STRATUM_DIFFICULTY "stratumdiff"
+#define NVS_CONFIG_STRATUM_KEEPALIVE "stratum_keep"
 
 #define NVS_CONFIG_ASIC_FREQ "asicfrequency"
 #define NVS_CONFIG_ASIC_VOLTAGE "asicvoltage"
@@ -57,6 +58,12 @@
 #define CONFIG_AUTO_FAN_SPEED_VALUE 1
 #elif defined(CONFIG_FAN_MODE_PID)
 #define CONFIG_AUTO_FAN_SPEED_VALUE 2
+#endif
+
+#ifdef CONFIG_STRATUM_KEEPALIVE_DEFAULT
+#define CONFIG_KEEPALIVE_VALUE 1
+#else
+#define CONFIG_KEEPALIVE_VALUE 0
 #endif
 
 #include <stdint.h>
@@ -144,6 +151,8 @@ namespace Config {
     inline bool isAutoScreenOffEnabled() { return nvs_config_get_u16(NVS_CONFIG_AUTO_SCREEN_OFF, CONFIG_AUTO_SCREEN_OFF_VALUE) != 0; }
     inline bool isInfluxEnabled() { return nvs_config_get_u16(NVS_CONFIG_INFLUX_ENABLE, CONFIG_INFLUX_ENABLE_VALUE) != 0; }
     inline bool isDiscordAlertEnabled() { return nvs_config_get_u16(NVS_CONFIG_ALERT_DISCORD_ENABLE, CONFIG_ALERT_DISCORD_ENABLE_VALUE) != 0; }
+    inline bool isStratumKeepaliveEnabled() { return nvs_config_get_u16(NVS_CONFIG_STRATUM_KEEPALIVE, CONFIG_STRATUM_KEEPALIVE_ENABLE_VALUE) != 0; }
+
 
     // ---- Boolean Setters ----
     inline void setFlipScreen(bool value) { nvs_config_set_u16(NVS_CONFIG_FLIP_SCREEN, value ? 1 : 0); }
@@ -154,7 +163,7 @@ namespace Config {
     inline void setAutoScreenOff(bool value) { nvs_config_set_u16(NVS_CONFIG_AUTO_SCREEN_OFF, value ? 1 : 0); }
     inline void setInfluxEnabled(bool value) { nvs_config_set_u16(NVS_CONFIG_INFLUX_ENABLE, value ? 1 : 0); }
     inline void setDiscordAlertEnabled(bool value) { nvs_config_set_u16(NVS_CONFIG_ALERT_DISCORD_ENABLE, value ? 1 : 0); }
-
+    inline void setStratumKeepaliveEnabled(bool value) { nvs_config_set_u16(NVS_CONFIG_STRATUM_KEEPALIVE, value ? 1 : 0); }
 
     // with board specific default values
     inline uint16_t getAsicFrequency(uint16_t d) { return nvs_config_get_u16(NVS_CONFIG_ASIC_FREQ, d); }


### PR DESCRIPTION
This pull request introduces a new setting to enable or disable TCP keepalive for the stratum socket connection.

Changes included:
	•	Configurable via WebUI (checkbox in the settings page)
	•	Persisted in NVS under the key `stratum_keep` (shortened due to key length limits in NVS)
	•	Default value is derived from Kconfig (`CONFIG_STRATUM_KEEPALIVE_ENABLE`)
	•	Used during socket setup in `stratum_task.cpp` (setupSocketTimeouts)

The setting can be toggled at runtime and survives reboots. If no value is stored yet, the system falls back to the compile-time default. Needs reboot to take effect immediately. 

Screenshot:
<img width="332" height="218" alt="Bildschirmfoto 2025-07-16 um 10 41 50" src="https://github.com/user-attachments/assets/0698ad5d-c1f6-4a5d-b1bc-aaad59a9c54d" />

Logs disabled:
```
₿ I (26551) stratum task: Set socket timeout to 30 for recv and write
₿ I (26561) stratum task: TCP Keepalive is disabled via config.
```
Logs enabled:
```
₿ I (26491) stratum task: Set socket timeout to 30 for recv and write
₿ I (26501) stratum task: TCP Keepalive enabled: idle=10s, interval=5s, count=3

```