### PR TITLE
Add PSRAM-based NVS caching

### DIFF
--- a/main/http_server/handler_alert.cpp
+++ b/main/http_server/handler_alert.cpp
@@ -79,6 +79,8 @@ esp_err_t POST_update_alert(httpd_req_t *req)
 
     doc.clear();
 
+    Config::flush_nvs_changes();  // Commit batched alert settings to NVS
+    ESP_LOGI(TAG, "Alert configuration flushed to NVS");
     httpd_resp_send_chunk(req, NULL, 0);
 
     // reload discord alerter config

--- a/main/http_server/handler_influx.cpp
+++ b/main/http_server/handler_influx.cpp
@@ -105,7 +105,8 @@ esp_err_t PATCH_update_influx(httpd_req_t *req)
     }
 
     doc.clear();
-
+    Config::flush_nvs_changes();  // Commit batched Influx settings to NVS
+    ESP_LOGI(TAG, "Influx configuration flushed to NVS");
     httpd_resp_send_chunk(req, NULL, 0);
     return ESP_OK;
 }

--- a/main/http_server/handler_restart.cpp
+++ b/main/http_server/handler_restart.cpp
@@ -4,6 +4,7 @@
 #include "global_state.h"
 #include "http_cors.h"
 #include "http_utils.h"
+#include "nvs_config.h"
 
 static const char *TAG = "http_restart";
 
@@ -18,6 +19,8 @@ esp_err_t POST_restart(httpd_req_t *req)
     }
 
     ESP_LOGI(TAG, "Restarting System because of API Request");
+
+    Config::flush_nvs_changes();  // Ensure persistent settings are saved
 
     // Send HTTP response before restarting
     const char *resp_str = "System will restart shortly.";

--- a/main/http_server/handler_swarm.cpp
+++ b/main/http_server/handler_swarm.cpp
@@ -36,6 +36,8 @@ esp_err_t PATCH_update_swarm(httpd_req_t *req)
     buf[total_len] = '\0';
 
     Config::setSwarmConfig(buf);
+    Config::flush_nvs_changes();  // Ensure Swarm config is written to flash
+    ESP_LOGI(TAG, "Swarm config flushed to NVS");
     httpd_resp_send_chunk(req, NULL, 0);
     return ESP_OK;
 }

--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -330,6 +330,10 @@ esp_err_t PATCH_update_settings(httpd_req_t *req)
 
     doc.clear();
 
+    // Apply all changes to NVS in one go
+    Config::flush_nvs_changes();
+    ESP_LOGI(TAG, "Configuration changes flushed to NVS");
+
     // Signal the end of the response
     httpd_resp_send_chunk(req, NULL, 0);
 

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -4,6 +4,7 @@
 #include "esp_log.h"
 #include "esp_netif.h"
 #include "esp_task_wdt.h"
+#include "esp_timer.h"
 #include "mbedtls/platform.h"
 #include "nvs_flash.h"
 
@@ -111,6 +112,14 @@ void free_psram(void *ptr) {
     heap_caps_free(ptr);
 }
 
+// Periodic NVS flush if any settings are marked dirty
+static void nvs_flush_timer_callback(void* arg) {
+    if (Config::has_dirty()) {
+        ESP_LOGI(TAG, "Auto-flushing dirty config values");
+        Config::flush_nvs_changes();
+    }
+}
+
 #if 0
 const UBaseType_t max_tasks = 30;
 TaskStatus_t task_list[max_tasks];
@@ -177,6 +186,22 @@ extern "C" void app_main(void)
     board->loadSettings();
     board->initBoard();
 
+    // Start periodic NVS flush (every 5 minutes)
+    esp_timer_handle_t nvs_flush_timer;
+    esp_timer_create_args_t timer_args = {
+        .callback = &nvs_flush_timer_callback,
+        .arg = NULL,
+        .dispatch_method = ESP_TIMER_TASK,
+        .name = "nvs_flush_timer"
+    };
+
+    esp_err_t err = esp_timer_create(&timer_args, &nvs_flush_timer);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Failed to create NVS flush timer: %s", esp_err_to_name(err));
+    } else {
+        esp_timer_start_periodic(nvs_flush_timer, 300000000);
+        ESP_LOGI(TAG, "NVS flush timer started");
+    }
 
     SYSTEM_MODULE.setBoard(board);
 

--- a/main/nvs_config.cpp
+++ b/main/nvs_config.cpp
@@ -1,17 +1,67 @@
 #include <string.h>
-
 #include "esp_log.h"
 #include "nvs.h"
 #include "nvs_config.h"
 
 #define NVS_CONFIG_NAMESPACE "main"
+#define MAX_CONFIG_ENTRIES 96
 
 namespace Config {
 
 static const char *TAG = "nvs_config";
 
+// --- Config cache structure ---
+typedef enum {
+    CONFIG_TYPE_STRING,
+    CONFIG_TYPE_U16,
+    CONFIG_TYPE_U64
+} config_type_t;
+
+typedef struct {
+    const char* key;
+    config_type_t type;
+    bool valid;
+    bool dirty;
+    union {
+        char* str_value;
+        uint16_t u16_value;
+        uint64_t u64_value;
+    } data;
+} ConfigCacheEntry;
+
+static ConfigCacheEntry config_cache[MAX_CONFIG_ENTRIES];
+
+// --- Utility to find or create cache entry ---
+static ConfigCacheEntry* get_cache_entry(const char* key, config_type_t type)
+{
+    for (int i = 0; i < MAX_CONFIG_ENTRIES; ++i) {
+        if (config_cache[i].key && strcmp(config_cache[i].key, key) == 0) {
+            return &config_cache[i];
+        }
+    }
+    for (int i = 0; i < MAX_CONFIG_ENTRIES; ++i) {
+        if (!config_cache[i].key) {
+            config_cache[i].key = key;
+            config_cache[i].type = type;
+            config_cache[i].valid = false;
+            config_cache[i].dirty = false;
+            return &config_cache[i];
+        }
+    }
+    ESP_LOGW(TAG, "Config cache full, could not store key: %s", key);
+    return NULL;
+}
+
 char *nvs_config_get_string(const char *key, const char *default_value)
 {
+    ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_STRING);
+    if (!entry) return strdup(default_value);
+
+    if (entry->valid) {
+        ESP_LOGD(TAG, "Cache hit: %s", key);
+        return strdup(entry->data.str_value);
+    }
+
     nvs_handle handle;
     esp_err_t err;
     err = nvs_open(NVS_CONFIG_NAMESPACE, NVS_READONLY, &handle);
@@ -21,46 +71,49 @@ char *nvs_config_get_string(const char *key, const char *default_value)
 
     size_t size = 0;
     err = nvs_get_str(handle, key, NULL, &size);
-
     if (err != ESP_OK) {
         nvs_close(handle);
         return strdup(default_value);
     }
 
-    char *out = (char *) malloc(size);
-    err = nvs_get_str(handle, key, out, &size);
-
-    if (err != ESP_OK) {
-        free(out);
-        nvs_close(handle);
-        return strdup(default_value);
-    }
-
+    char *val = (char *) malloc(size);
+    err = nvs_get_str(handle, key, val, &size);
     nvs_close(handle);
-    return out;
+
+    if (err != ESP_OK) {
+        free(val);
+        return strdup(default_value);
+    }
+
+    entry->data.str_value = strdup(val);
+    entry->valid = true;
+    free(val);
+    return strdup(entry->data.str_value);
 }
 
 void nvs_config_set_string(const char *key, const char *value)
 {
+    ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_STRING);
+    if (!entry) return;
 
-    nvs_handle handle;
-    esp_err_t err;
-    err = nvs_open(NVS_CONFIG_NAMESPACE, NVS_READWRITE, &handle);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "Could not open nvs");
-        return;
+    if (entry->valid && entry->data.str_value) {
+        free(entry->data.str_value);
     }
-
-    err = nvs_set_str(handle, key, value);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "Could not write nvs key: %s, value: %s", key, value);
-    }
-
-    nvs_close(handle);
+    entry->data.str_value = strdup(value);
+    entry->valid = true;
+    entry->dirty = true;
 }
 
 uint16_t nvs_config_get_u16(const char *key, const uint16_t default_value)
 {
+    ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_U16);
+    if (!entry) return default_value;
+
+    if (entry->valid) {
+        ESP_LOGD(TAG, "Cache hit: %s (u16)", key);
+        return entry->data.u16_value;
+    }
+
     nvs_handle handle;
     esp_err_t err;
     err = nvs_open(NVS_CONFIG_NAMESPACE, NVS_READONLY, &handle);
@@ -68,37 +121,38 @@ uint16_t nvs_config_get_u16(const char *key, const uint16_t default_value)
         return default_value;
     }
 
-    uint16_t out;
-    err = nvs_get_u16(handle, key, &out);
+    uint16_t val;
+    err = nvs_get_u16(handle, key, &val);
     nvs_close(handle);
 
     if (err != ESP_OK) {
         return default_value;
     }
-    return out;
+
+    entry->data.u16_value = val;
+    entry->valid = true;
+    return val;
 }
 
 void nvs_config_set_u16(const char *key, const uint16_t value)
 {
-
-    nvs_handle handle;
-    esp_err_t err;
-    err = nvs_open(NVS_CONFIG_NAMESPACE, NVS_READWRITE, &handle);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "Could not open nvs");
-        return;
-    }
-
-    err = nvs_set_u16(handle, key, value);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "Could not write nvs key: %s, value: %u", key, value);
-    }
-
-    nvs_close(handle);
+    ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_U16);
+    if (!entry) return;
+    entry->data.u16_value = value;
+    entry->valid = true;
+    entry->dirty = true;
 }
 
 uint64_t nvs_config_get_u64(const char *key, const uint64_t default_value)
 {
+    ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_U64);
+    if (!entry) return default_value;
+
+    if (entry->valid) {
+        ESP_LOGD(TAG, "Cache hit: %s (u64)", key);
+        return entry->data.u64_value;
+    }
+
     nvs_handle handle;
     esp_err_t err;
     err = nvs_open(NVS_CONFIG_NAMESPACE, NVS_READONLY, &handle);
@@ -106,34 +160,59 @@ uint64_t nvs_config_get_u64(const char *key, const uint64_t default_value)
         return default_value;
     }
 
-    uint64_t out;
-    err = nvs_get_u64(handle, key, &out);
+    uint64_t val;
+    err = nvs_get_u64(handle, key, &val);
+    nvs_close(handle);
 
     if (err != ESP_OK) {
-        nvs_close(handle);
         return default_value;
     }
 
-    nvs_close(handle);
-    return out;
+    entry->data.u64_value = val;
+    entry->valid = true;
+    return val;
 }
 
 void nvs_config_set_u64(const char *key, const uint64_t value)
 {
+    ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_U64);
+    if (!entry) return;
+    entry->data.u64_value = value;
+    entry->valid = true;
+    entry->dirty = true;
+}
 
+void flush_nvs_changes()
+{
     nvs_handle handle;
     esp_err_t err;
     err = nvs_open(NVS_CONFIG_NAMESPACE, NVS_READWRITE, &handle);
     if (err != ESP_OK) {
-        ESP_LOGW(TAG, "Could not open nvs");
+        ESP_LOGW(TAG, "Could not open NVS for flushing");
         return;
     }
 
-    err = nvs_set_u64(handle, key, value);
-    if (err != ESP_OK) {
-        ESP_LOGW(TAG, "Could not write nvs key: %s, value: %llu", key, value);
+    for (int i = 0; i < MAX_CONFIG_ENTRIES; ++i) {
+        if (!config_cache[i].key || !config_cache[i].dirty) continue;
+
+        switch (config_cache[i].type) {
+            case CONFIG_TYPE_STRING:
+                nvs_set_str(handle, config_cache[i].key, config_cache[i].data.str_value);
+                break;
+            case CONFIG_TYPE_U16:
+                nvs_set_u16(handle, config_cache[i].key, config_cache[i].data.u16_value);
+                break;
+            case CONFIG_TYPE_U64:
+                nvs_set_u64(handle, config_cache[i].key, config_cache[i].data.u64_value);
+                break;
+        }
+
+        config_cache[i].dirty = false;
     }
+
+    nvs_commit(handle);
     nvs_close(handle);
+    ESP_LOGI(TAG, "Configuration changes flushed to NVS");
 }
 
 void migrate_config() {
@@ -154,5 +233,13 @@ void migrate_config() {
     }
 }
 
+bool has_dirty() {
+    for (int i = 0; i < MAX_CONFIG_ENTRIES; ++i) {
+        if (config_cache[i].key && config_cache[i].dirty) {
+            return true;
+        }
+    }
+    return false;
 }
 
+} // namespace Config

--- a/main/nvs_config.cpp
+++ b/main/nvs_config.cpp
@@ -42,8 +42,20 @@ static SemaphoreHandle_t config_mutex = nullptr;
 static char* heap_caps_strdup(const char* src, uint32_t caps) {
     if (!src) return nullptr;
     size_t len = strlen(src) + 1;
+
+    // check for length
+    constexpr size_t MAX_STR_LENGTH = 1024;
+    if (len > MAX_STR_LENGTH) {
+        ESP_LOGE(TAG, "String exceeds maximum allowed length of %zu bytes.", MAX_STR_LENGTH);
+        return nullptr;
+    }
+
     char* dst = (char*) heap_caps_malloc(len, caps);
-    if (dst) memcpy(dst, src, len);
+    if (!dst) {
+        ESP_LOGE(TAG, "Memory allocation for string duplication failed. Requested size: %zu bytes.", len);
+        return nullptr;
+    }
+    memcpy(dst, src, len);
     return dst;
 }
 
@@ -73,6 +85,12 @@ static ConfigCacheEntry* get_cache_entry(const char* key, config_type_t type) {
     // If not found, find a free slot for a new entry
     for (int i = 0; i < MAX_CONFIG_ENTRIES; ++i) {
         if (!config_cache[i].key) {
+            // Duplicate the key to avoid unexpected issues
+            char* duplicated_key = heap_caps_strdup(key, MALLOC_CAP_SPIRAM);
+            if (!duplicated_key) {
+                ESP_LOGE(TAG, "Failed to duplicate key '%s' due to memory allocation issues.", key);
+                return NULL;
+            }
             config_cache[i].key = key;
             config_cache[i].type = type;
             config_cache[i].valid = false;
@@ -84,24 +102,32 @@ static ConfigCacheEntry* get_cache_entry(const char* key, config_type_t type) {
     return NULL;
 }
 
-// --- API Functions ---
+// --- String Functions ---
 char *nvs_config_get_string(const char *key, const char *default_value) {
     CONFIG_LOCK();
     ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_STRING);
     if (!entry) {
+        ESP_LOGE(TAG, "Failed to get or create cache entry for key: %s", key);
         CONFIG_UNLOCK();
         const char* fallback = default_value ? default_value : ""; // Return default or empty string, but never NULL
-        return heap_caps_strdup(fallback, MALLOC_CAP_SPIRAM);
+        char* result = heap_caps_strdup(fallback, MALLOC_CAP_SPIRAM);
+        if (!result) {
+            ESP_LOGE(TAG, "Failed to allocate memory for fallback string.");
+        }
+        return result;
     }
 
     if (entry->valid) {
         ESP_LOGD(TAG, "Cache hit for string key: %s", key);
         char* result = heap_caps_strdup(entry->data.str_value, MALLOC_CAP_SPIRAM);
+        if (!result) {
+            ESP_LOGE(TAG, "Failed to allocate memory for cached string.");
+        }
         CONFIG_UNLOCK();
         return result;
     }
 
-    ESP_LOGD(TAG, "Cache miss for string key: %s. Reading from NVS.", key);
+    ESP_LOGI(TAG, "Cache miss for string key: %s. Reading from NVS.", key);
 
     nvs_handle handle;
     char* loaded_value = NULL;
@@ -114,9 +140,17 @@ char *nvs_config_get_string(const char *key, const char *default_value) {
             loaded_value = (char*) heap_caps_malloc(size, MALLOC_CAP_SPIRAM);
             if (loaded_value) {
                 nvs_get_str(handle, key, loaded_value, &size);
+            } else {
+                ESP_LOGE(TAG, "Failed to allocate memory for NVS string key: %s", key);
             }
+        } else if (err == ESP_ERR_NVS_NOT_FOUND) {
+            ESP_LOGW(TAG, "Key not found in NVS: %s. Using default value.", key);
+        } else {
+            ESP_LOGE(TAG, "Error reading key: %s from NVS. Error: %d", key, err);
         }
         nvs_close(handle);
+    } else {
+        ESP_LOGW(TAG, "Failed to open NVS for key: %s. Using default value.", key);
     }
 
     // If loading from NVS failed, use the default value.
@@ -124,16 +158,30 @@ char *nvs_config_get_string(const char *key, const char *default_value) {
     if (!loaded_value) {
         const char* source_str = default_value ? default_value : "";
         loaded_value = (char*) heap_caps_strdup(source_str, MALLOC_CAP_SPIRAM);
-    }
-    // Final fallback if strdup fails
-    if (!loaded_value) {
-        loaded_value = (char*) heap_caps_strdup("", MALLOC_CAP_SPIRAM);
+        // Final fallback if strdup fails
+        if (!loaded_value) {
+            ESP_LOGE(TAG, "Failed to allocate memory for fallback value.");
+            CONFIG_UNLOCK();
+            return NULL;
+        }
     }
 
-    entry->data.str_value = loaded_value;
-    entry->valid = true;
+    if (err == ESP_OK || err == ESP_ERR_NVS_NOT_FOUND) {
+        if (entry->data.str_value) {
+            heap_caps_free(entry->data.str_value);
+        }
+        entry->data.str_value = loaded_value;
+        entry->valid = true;
+    } else {
+        ESP_LOGW(TAG, "NVS read error for key %s. Cache entry remains invalid.", key);
+        entry->valid = false;
+    }
 
     char* result = heap_caps_strdup(loaded_value, MALLOC_CAP_SPIRAM);
+    if (!result) {
+        ESP_LOGE(TAG, "Failed to allocate memory for result string.");
+    }
+
     CONFIG_UNLOCK();
     return result;
 }
@@ -142,6 +190,13 @@ void nvs_config_set_string(const char *key, const char *value) {
     CONFIG_LOCK();
     ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_STRING);
     if (!entry) {
+        ESP_LOGE(TAG, "Failed to get or create cache entry for key: %s", key);
+        CONFIG_UNLOCK();
+        return;
+    }
+
+    if (entry->type != CONFIG_TYPE_STRING) {
+        ESP_LOGE(TAG, "Type mismatch for key: %s. Expected type CONFIG_TYPE_STRING, but found type %d.", key, entry->type);
         CONFIG_UNLOCK();
         return;
     }
@@ -152,15 +207,24 @@ void nvs_config_set_string(const char *key, const char *value) {
 
     const char* source_str = value ? value : "";
     entry->data.str_value = (char*) heap_caps_strdup(source_str, MALLOC_CAP_SPIRAM);
+    if (!entry->data.str_value) {
+        ESP_LOGE(TAG, "Failed to allocate memory for string value for key: %s", key);
+        entry->valid = false;
+        entry->dirty = false;
+        CONFIG_UNLOCK();
+        return;
+    }
     entry->valid = true;
     entry->dirty = true;
     CONFIG_UNLOCK();
 }
 
+// --- U16 Functions ---
 uint16_t nvs_config_get_u16(const char *key, const uint16_t default_value) {
     CONFIG_LOCK();
     ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_U16);
     if (!entry) {
+        ESP_LOGE(TAG, "Failed to get or create cache entry for key: %s", key);
         CONFIG_UNLOCK();
         return default_value;
     }
@@ -172,17 +236,30 @@ uint16_t nvs_config_get_u16(const char *key, const uint16_t default_value) {
         return val;
     }
 
-    ESP_LOGD(TAG, "Cache miss for u16 key: %s. Reading from NVS.", key);
+    ESP_LOGI(TAG, "Cache miss for u16 key: %s. Reading from NVS.", key);
     nvs_handle handle;
     uint16_t val = default_value;
     esp_err_t err = nvs_open(NVS_CONFIG_NAMESPACE, NVS_READONLY, &handle);
     if (err == ESP_OK) {
-        nvs_get_u16(handle, key, &val);
+        err = nvs_get_u16(handle, key, &val);
+        if (err == ESP_ERR_NVS_NOT_FOUND) {
+            ESP_LOGW(TAG, "Key not found in NVS: %s. Using default value.", key);
+        } else if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Error reading key: %s from NVS. Error: %d", key, err);
+        }
         nvs_close(handle);
+    } else {
+        ESP_LOGE(TAG, "Failed to open NVS for key: %s. Using default value.", key);
     }
 
-    entry->data.u16_value = val;
-    entry->valid = true;
+    if (err == ESP_OK || err == ESP_ERR_NVS_NOT_FOUND) {
+        entry->data.u16_value = val;
+        entry->valid = true;
+    } else {
+        ESP_LOGW(TAG, "NVS read error for key %s. Cache entry remains invalid.", key);
+        entry->valid = false;
+    }
+
     CONFIG_UNLOCK();
     return val;
 }
@@ -191,19 +268,29 @@ void nvs_config_set_u16(const char *key, const uint16_t value) {
     CONFIG_LOCK();
     ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_U16);
     if (!entry) {
+        ESP_LOGE(TAG, "Failed to get or create cache entry for key: %s", key);
         CONFIG_UNLOCK();
         return;
     }
+
+    if (entry->type != CONFIG_TYPE_U16) {
+        ESP_LOGE(TAG, "Type mismatch for key: %s. Expected type CONFIG_TYPE_U16, but found type %d.", key, entry->type);
+        CONFIG_UNLOCK();
+        return;
+    }
+
     entry->data.u16_value = value;
     entry->valid = true;
     entry->dirty = true;
     CONFIG_UNLOCK();
 }
 
+// --- U64 Functions ---
 uint64_t nvs_config_get_u64(const char *key, const uint64_t default_value) {
     CONFIG_LOCK();
     ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_U64);
     if (!entry) {
+        ESP_LOGE(TAG, "Failed to get or create cache entry for key: %s", key);
         CONFIG_UNLOCK();
         return default_value;
     }
@@ -215,17 +302,30 @@ uint64_t nvs_config_get_u64(const char *key, const uint64_t default_value) {
         return val;
     }
 
-    ESP_LOGD(TAG, "Cache miss for u64 key: %s. Reading from NVS.", key);
+    ESP_LOGI(TAG, "Cache miss for u64 key: %s. Reading from NVS.", key);
     nvs_handle handle;
     uint64_t val = default_value;
     esp_err_t err = nvs_open(NVS_CONFIG_NAMESPACE, NVS_READONLY, &handle);
     if (err == ESP_OK) {
-        nvs_get_u64(handle, key, &val);
+        err = nvs_get_u64(handle, key, &val);
+        if (err == ESP_ERR_NVS_NOT_FOUND) {
+            ESP_LOGW(TAG, "Key not found in NVS: %s. Using default value.", key);
+        } else if (err != ESP_OK) {
+            ESP_LOGE(TAG, "Error reading key: %s from NVS. Error: %d", key, err);
+        }
         nvs_close(handle);
+    } else {
+        ESP_LOGE(TAG, "Failed to open NVS for key: %s. Using default value.", key);
     }
 
-    entry->data.u64_value = val;
-    entry->valid = true;
+    if (err == ESP_OK || err == ESP_ERR_NVS_NOT_FOUND) {
+        entry->data.u64_value = val;
+        entry->valid = true;
+    } else {
+        ESP_LOGW(TAG, "NVS read error for key %s. Cache entry remains invalid.", key);
+        entry->valid = false;
+    }
+
     CONFIG_UNLOCK();
     return val;
 }
@@ -234,20 +334,29 @@ void nvs_config_set_u64(const char *key, const uint64_t value) {
     CONFIG_LOCK();
     ConfigCacheEntry* entry = get_cache_entry(key, CONFIG_TYPE_U64);
     if (!entry) {
+        ESP_LOGE(TAG, "Failed to get or create cache entry for key: %s", key);
         CONFIG_UNLOCK();
         return;
     }
+
+    if (entry->type != CONFIG_TYPE_U64) {
+        ESP_LOGE(TAG, "Type mismatch for key: %s. Expected type CONFIG_TYPE_U64, but found type %d.", key, entry->type);
+        CONFIG_UNLOCK();
+        return;
+    }
+
     entry->data.u64_value = value;
     entry->valid = true;
     entry->dirty = true;
     CONFIG_UNLOCK();
 }
 
+// --- flush changes to NVS ---
 void flush_nvs_changes() {
     ConfigCacheEntry dirty_copy[MAX_CONFIG_ENTRIES] = {0};
     int dirty_count = 0;
 
-    ESP_LOGD(TAG, "Scanning for dirty entries to flush.");
+    ESP_LOGI(TAG, "Scanning for dirty entries to flush.");
     CONFIG_LOCK();
     for (int i = 0; i < MAX_CONFIG_ENTRIES && dirty_count < MAX_CONFIG_ENTRIES; ++i) {
         if (config_cache[i].key && config_cache[i].dirty) {
@@ -256,8 +365,10 @@ void flush_nvs_changes() {
 
             if (dirty_copy[dirty_count].type == CONFIG_TYPE_STRING && config_cache[i].data.str_value) {
                 dirty_copy[dirty_count].data.str_value = strdup(config_cache[i].data.str_value);
-            } else if (dirty_copy[dirty_count].type == CONFIG_TYPE_STRING) {
-                dirty_copy[dirty_count].data.str_value = NULL;
+                if (!dirty_copy[dirty_count].data.str_value) {
+                    ESP_LOGE(TAG, "Failed to duplicate string for key: %s. Skipping entry.", config_cache[i].key);
+                    continue; // skips entry if mem allocation fails
+                }
             }
             dirty_count++;
         }
@@ -265,7 +376,7 @@ void flush_nvs_changes() {
     CONFIG_UNLOCK();
 
     if (dirty_count == 0) {
-        ESP_LOGD(TAG, "No dirty entries to flush.");
+        ESP_LOGI(TAG, "No dirty entries to flush.");
         return;
     }
 
@@ -275,7 +386,9 @@ void flush_nvs_changes() {
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "Could not open NVS for flushing");
         for(int i = 0; i < dirty_count; ++i) {
-            if(dirty_copy[i].type == CONFIG_TYPE_STRING && dirty_copy[i].data.str_value) free(dirty_copy[i].data.str_value);
+            if(dirty_copy[i].type == CONFIG_TYPE_STRING && dirty_copy[i].data.str_value) {
+                free(dirty_copy[i].data.str_value);
+            }
         }
         return;
     }
@@ -315,6 +428,7 @@ void flush_nvs_changes() {
     ESP_LOGI(TAG, "Configuration changes flushed to NVS.");
 }
 
+// --- caching check utility ---
 bool has_dirty() {
     CONFIG_LOCK();
     for (int i = 0; i < MAX_CONFIG_ENTRIES; ++i) {
@@ -330,13 +444,26 @@ bool has_dirty() {
 // --- Debugging utility ---
 void dump_cache_status() {
     ESP_LOGI(TAG, "--- Dumping Config Cache Status ---");
+    bool is_cache_empty = true;
+
     CONFIG_LOCK();
     for (int i = 0; i < MAX_CONFIG_ENTRIES; ++i) {
         if (config_cache[i].key) {
-            ESP_LOGI(TAG, "[%2d] key=%-18s, valid=%d, dirty=%d", i, config_cache[i].key, config_cache[i].valid, config_cache[i].dirty);
+            is_cache_empty = false;
+            ESP_LOGI(TAG, "[%2d] key=%-18s, valid=%d, dirty=%d, type=%d",
+                     i,
+                     config_cache[i].key,
+                     config_cache[i].valid,
+                     config_cache[i].dirty,
+                     config_cache[i].type);
         }
     }
     CONFIG_UNLOCK();
+
+    if (is_cache_empty) {
+        ESP_LOGI(TAG, "Config Cache is empty.");
+    }
+
     ESP_LOGI(TAG, "--- End of Cache Dump ---");
 }
 

--- a/main/nvs_config.cpp
+++ b/main/nvs_config.cpp
@@ -91,7 +91,7 @@ static ConfigCacheEntry* get_cache_entry(const char* key, config_type_t type) {
                 ESP_LOGE(TAG, "Failed to duplicate key '%s' due to memory allocation issues.", key);
                 return NULL;
             }
-            config_cache[i].key = key;
+            config_cache[i].key = duplicated_key;
             config_cache[i].type = type;
             config_cache[i].valid = false;
             config_cache[i].dirty = false;

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -224,6 +224,7 @@ namespace Config {
     inline bool isOTPEnabled() { return nvs_config_get_u16(NVS_CONFIG_OTP_ENABLED, 0) != 0; }
 
     void migrate_config();
+    void init_cache();         // Allocate PSRAM-backed cache and mutex
     void flush_nvs_changes();  // Flush cached config values to NVS
     bool has_dirty();          // Check if any cached values are dirty
 }

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -227,4 +227,5 @@ namespace Config {
     void init_cache();         // Allocate PSRAM-backed cache and mutex
     void flush_nvs_changes();  // Flush cached config values to NVS
     bool has_dirty();          // Check if any cached values are dirty
+    void dump_cache_status();  // in case we want to monitor the nvs-cache - not used currently
 }

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -224,4 +224,6 @@ namespace Config {
     inline bool isOTPEnabled() { return nvs_config_get_u16(NVS_CONFIG_OTP_ENABLED, 0) != 0; }
 
     void migrate_config();
+    void flush_nvs_changes();  // Flush cached config values to NVS
+    bool has_dirty();          // Check if any cached values are dirty
 }

--- a/main/system.cpp
+++ b/main/system.cpp
@@ -186,6 +186,8 @@ void System::checkForBestDiff(double diff, uint32_t nbits) {
     m_bestNonceDiff = (uint64_t)diff;
 
     Config::setBestDiff(m_bestNonceDiff);
+    Config::flush_nvs_changes();
+    ESP_LOGI(TAG, "New best diff flushed to NVS");
 
     // Make the best_nonce_diff into a string
     suffixString((uint64_t)diff, m_bestDiffString, DIFF_STRING_SIZE, 0);

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -30,6 +30,9 @@ void PowerManagementTask::taskWrapper(void *pvParameters) {
 }
 
 void PowerManagementTask::restart() {
+    Config::flush_nvs_changes();  // Ensure all config changes are persisted
+    ESP_LOGI(TAG, "Configuration changes flushed to NVS");
+
     ESP_LOGW(TAG, "Shutdown requested ...");
     // stops the main task
     lock();


### PR DESCRIPTION
This PR introduces a RAM-based caching layer for configuration values stored in NVS, along with a batched flush mechanism to reduce latency and flash wear.

**Summary of changes:**
- All `Config::get*()` calls now return cached values if available, avoiding repeated flash reads.
- All `Config::set*()` calls only modify the RAM cache and mark entries as dirty.
- A central `flush_nvs_changes()` function writes only dirty entries to NVS in a single transaction.
- API endpoints now call `flush_nvs_changes()` after updates.
- A background timer (every 5 minutes) flushes dirty values if needed.
- System restart and OTA update paths also flush explicitly before rebooting.
- Debug logging has been added to track cache hits (`ESP_LOGD`).

**Benefits:**
- Significantly reduces flash read and write operations, especially during high-frequency polling (e.g. UI requests).
- Minimizes blocking flash access in GET requests like `/api/system/info`.
- Reduces flash wear and improves overall responsiveness.

No configuration values or behavior are affected unless they are written via the API or auto-flush is triggered.