### PR TITLE
Slow I2C speeed to compensate for weak pull-ups

### DIFF
--- a/main/boards/drivers/i2c_master.cpp
+++ b/main/boards/drivers/i2c_master.cpp
@@ -2,7 +2,7 @@
 
 #define I2C_MASTER_SCL_IO 43        /*!< GPIO number used for I2C master clock */
 #define I2C_MASTER_SDA_IO 44        /*!< GPIO number used for I2C master data  */
-#define I2C_MASTER_FREQ_HZ 400000   /*!< I2C master clock frequency */
+#define I2C_MASTER_FREQ_HZ 100000   /*!< I2C master clock frequency */
 #define I2C_MASTER_TX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
 #define I2C_MASTER_RX_BUF_DISABLE 0 /*!< I2C master doesn't need buffer */
 


### PR DESCRIPTION
The liligo T display have very weak I2C pullups so the voltage has a slow rise time at 400khz, this is considered 'fast' mode. 

Depending on the exact manufacturing tolerances of the display the pullup may be so weak that there are erronious readings from the bus which casues incorrect PSU or overheat errrors. 

Slowing I2C to 100khz 'standard' mode should help with these edge cases, 100khz is also the standard in esp-miner 

<img width="1149" height="1067" alt="image" src="https://github.com/user-attachments/assets/88424d09-6a2e-40f9-825f-b764ac6d7c01" />
<img width="1406" height="801" alt="image" src="https://github.com/user-attachments/assets/fe026eb2-b0af-4ba1-9048-86fd2ab65137" />

