### PR TITLE
Add hideFoundBlockOverlay() usage and adjust display logic

### DIFF
--- a/main/displays/displayDriver.cpp
+++ b/main/displays/displayDriver.cpp
@@ -235,20 +235,34 @@ void DisplayDriver::lvglTimerTask(void *param)
             if (m_button1PressedFlag) {
                 m_button1PressedFlag = false;
                 m_lastKeypressTime = esp_timer_get_time();
-                if (!m_displayIsOn)
-                    displayTurnOn();
-                changeScreen();
+
+                if (m_isActiveOverlay) {
+                    hideFoundBlockOverlay();
+                } else {
+                    if (!m_displayIsOn) {
+                        displayTurnOn();
+                    }
+                    changeScreen();
+                }
             }
             vTaskDelay(pdMS_TO_TICKS(200)); // Delay waiting animation trigger
         }
+
         if (m_button2PressedFlag) {
             m_button2PressedFlag = false;
             m_lastKeypressTime = esp_timer_get_time();
-            if (m_displayIsOn)
-                displayTurnOff();
-            else
+
+            if (m_displayIsOn) {
+                if (m_isActiveOverlay) {
+                    hideFoundBlockOverlay();
+                } else {
+                    displayTurnOff();
+                }
+            } else {
                 displayTurnOn();
+            }
         }
+
 
         // Check if we have a screen turned-on override
         if (m_isActiveOverlay) {


### PR DESCRIPTION
Hello,

This pull request integrates the previously defined but unused 
function `hideFoundBlockOverlay()` into the button handling logic 
for button1 and button2. It ensures that overlays are properly 
hidden when appropriate.

Previously, after a found block was triggered, the display and LED 
would remain active and could not be turned off using the buttons, 
effectively requiring a full system restart. This update fixes that 
behavior.

Additionally, minor adjustments to the display state transitions 
have been made to improve screen behavior consistency.

Thank you for reviewing this contribution.