### PR TITLE
improve pll settings

### DIFF
--- a/components/bm1397/include/asic.h
+++ b/components/bm1397/include/asic.h
@@ -75,6 +75,7 @@ typedef struct __attribute__((__packed__))
 class Asic {
 protected:
     float m_current_frequency;
+    float m_actual_current_frequency;
 
     void send(uint8_t header, uint8_t *data, uint8_t data_len, bool debug);
     void send2(uint8_t header, uint8_t b0, uint8_t b1);


### PR DESCRIPTION
minimizes the error instead of failing if no exact pll is found