### PR TITLE
optimize i2c locking during OTA update

### DIFF
--- a/main/boards/nerdaxe.cpp
+++ b/main/boards/nerdaxe.cpp
@@ -127,7 +127,7 @@ bool NerdAxe::initBoard()
 }
 
 void NerdAxe::shutdown() {
-    // NOP / TODO
+    setVoltage(0.0);
 }
 
 bool NerdAxe::initAsics()

--- a/main/boards/nerdaxegamma.cpp
+++ b/main/boards/nerdaxegamma.cpp
@@ -93,7 +93,7 @@ bool NerdaxeGamma::initBoard()
 }
 
 void NerdaxeGamma::shutdown() {
-    // NOP / TODO
+    setVoltage(0.0);
 }
 
 bool NerdaxeGamma::initAsics() {

--- a/main/http_server/handler_ota.cpp
+++ b/main/http_server/handler_ota.cpp
@@ -30,41 +30,52 @@ esp_err_t POST_WWW_update(httpd_req_t *req)
         return ESP_FAIL;
     }
 
+    // Erase the entire www partition before writing
     {
         // lock the power management module
         LockGuard g(POWER_MANAGEMENT_MODULE);
-
-        // Erase the entire www partition before writing
+        ESP_LOGI(TAG, "erasing www partition ...");
         ESP_ERROR_CHECK(esp_partition_erase_range(www_partition, 0, www_partition->size));
+        ESP_LOGI(TAG, "erasing done");
+    }
 
-        // don't put it on the stack
-        char *buf = (char*) malloc(2048);
+    // don't put it on the stack
+    char *buf = (char*) malloc(2048);
+    uint32_t offset = 0;
 
-        while (remaining > 0) {
-            int recv_len = httpd_req_recv(req, buf, min(remaining, 2048));
+    while (remaining > 0) {
+        int recv_len = httpd_req_recv(req, buf, min(remaining, 2048));
 
-            if (recv_len == HTTPD_SOCK_ERR_TIMEOUT) {
-                continue;
-            } else if (recv_len <= 0) {
-                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Protocol Error");
-                free(buf);
-                return ESP_FAIL;
+        if (recv_len == HTTPD_SOCK_ERR_TIMEOUT) {
+            continue;
+        } else if (recv_len <= 0) {
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Protocol Error");
+            free(buf);
+            return ESP_FAIL;
+        }
+
+        {
+            // lock the power management module
+            LockGuard g(POWER_MANAGEMENT_MODULE);
+
+            // print each 64kb
+            if (!(offset & 0xffff)) {
+                ESP_LOGI(TAG, "flashing to %08lx", offset);
             }
-
-            if (esp_partition_write(www_partition, www_partition->size - remaining, (const void *) buf, recv_len) != ESP_OK) {
+            if (esp_partition_write(www_partition, offset, (const void *) buf, recv_len) != ESP_OK) {
                 httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Write Error");
                 free(buf);
                 return ESP_FAIL;
             }
-
-            remaining -= recv_len;
-
-            // give the scheduler a chance for other tasks
-            vTaskDelay(1);
         }
+        remaining -= recv_len;
+        offset += recv_len;
 
-        free(buf);
+        // switch task to not stall the PID
+        taskYIELD();
     }
+
+    free(buf);
 
     httpd_resp_sendstr(req, "WWW update complete\n");
     return ESP_OK;
@@ -82,51 +93,61 @@ esp_err_t POST_OTA_update(httpd_req_t *req)
     esp_ota_handle_t ota_handle;
     int remaining = req->content_len;
 
-    {
-        // lock the power management module
-        LockGuard g(POWER_MANAGEMENT_MODULE);
+    // lock the power management module
+    LockGuard g(POWER_MANAGEMENT_MODULE);
 
-        const esp_partition_t *ota_partition = esp_ota_get_next_update_partition(NULL);
-        ESP_ERROR_CHECK(esp_ota_begin(ota_partition, OTA_SIZE_UNKNOWN, &ota_handle));
+    // Shut down buck converter before starting OTA.
+    // During OTA, I2C conflicts prevent the PID from working correctly.
+    // Disabling hardware avoids any risk of overheating.
+    // The device will reboot after the update anyway.
+    POWER_MANAGEMENT_MODULE.shutdown();
 
-        // don't put it on the stack
-        char *buf = (char*) malloc(2048);
+    const esp_partition_t *ota_partition = esp_ota_get_next_update_partition(NULL);
+    ESP_ERROR_CHECK(esp_ota_begin(ota_partition, OTA_SIZE_UNKNOWN, &ota_handle));
 
-        while (remaining > 0) {
-            int recv_len = httpd_req_recv(req, buf, min(remaining, 2048));
+    // don't put it on the stack
+    char *buf = (char*) malloc(2048);
+    uint32_t offset = 0;
 
-            // Timeout Error: Just retry
-            if (recv_len == HTTPD_SOCK_ERR_TIMEOUT) {
-                continue;
+    while (remaining > 0) {
+        int recv_len = httpd_req_recv(req, buf, min(remaining, 2048));
 
-                // Serious Error: Abort OTA
-            } else if (recv_len <= 0) {
-                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Protocol Error");
-                free(buf);
-                return ESP_FAIL;
-            }
+        // Timeout Error: Just retry
+        if (recv_len == HTTPD_SOCK_ERR_TIMEOUT) {
+            continue;
 
-            // Successful Upload: Flash firmware chunk
-            if (esp_ota_write(ota_handle, (const void *) buf, recv_len) != ESP_OK) {
-                esp_ota_abort(ota_handle);
-                httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Flash Error");
-                free(buf);
-                return ESP_FAIL;
-            }
-
-            remaining -= recv_len;
-
-            // give the scheduler a chance for other tasks
-            vTaskDelay(1);
-        }
-
-        free(buf);
-
-        // Validate and switch to new OTA image and reboot
-        if (esp_ota_end(ota_handle) != ESP_OK || esp_ota_set_boot_partition(ota_partition) != ESP_OK) {
-            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Validation / Activation Error");
+            // Serious Error: Abort OTA
+        } else if (recv_len <= 0) {
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Protocol Error");
+            free(buf);
             return ESP_FAIL;
         }
+
+        // Successful Upload: Flash firmware chunk
+        // print each 64kb
+        if (!(offset & 0xffff)) {
+            ESP_LOGI(TAG, "flashing to %08lx", offset);
+        }
+        if (esp_ota_write(ota_handle, (const void *) buf, recv_len) != ESP_OK) {
+            esp_ota_abort(ota_handle);
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Flash Error");
+            free(buf);
+            return ESP_FAIL;
+        }
+
+        remaining -= recv_len;
+        offset += recv_len;
+
+        // give the scheduler a chance for other tasks
+        taskYIELD();
+    }
+
+    free(buf);
+
+    // Validate and switch to new OTA image and reboot
+    if (esp_ota_end(ota_handle) != ESP_OK || esp_ota_set_boot_partition(ota_partition) != ESP_OK) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Validation / Activation Error");
+        return ESP_FAIL;
     }
 
     httpd_resp_sendstr(req, "Firmware update complete, rebooting now!\n");
@@ -134,5 +155,6 @@ esp_err_t POST_OTA_update(httpd_req_t *req)
     vTaskDelay(pdMS_TO_TICKS(1000));
     POWER_MANAGEMENT_MODULE.restart();
 
+    // unreachable
     return ESP_OK;
 }

--- a/main/http_server/handler_restart.cpp
+++ b/main/http_server/handler_restart.cpp
@@ -22,9 +22,12 @@ esp_err_t POST_restart(httpd_req_t *req)
     // Delay to ensure the response is sent
     vTaskDelay(pdMS_TO_TICKS(1000));
 
+    // lock the power management module
+    LockGuard g(POWER_MANAGEMENT_MODULE);
+
     // Restart the system
     POWER_MANAGEMENT_MODULE.restart();
 
-    // This return statement will never be reached, but it's good practice to include it
+    // unreachable
     return ESP_OK;
 }

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -28,19 +28,22 @@ void PowerManagementTask::taskWrapper(void *pvParameters) {
     powerManagementTask->task();
 }
 
+// hardware lock must be acquired before calling this function
 void PowerManagementTask::restart() {
-    ESP_LOGW(TAG, "Shutdown requested ...");
-    // stops the main task
-    lock();
+    ESP_LOGW(TAG, "Restarting firmware ...");
 
-    ESP_LOGW(TAG, "HW lock acquired!");
     // shutdown asics and LDOs before reset
-    Board* board = SYSTEM_MODULE.getBoard();
-    board->shutdown();
+    shutdown();
 
     ESP_LOGW(TAG, "restart");
     esp_restart();
-    unlock();
+}
+
+void PowerManagementTask::shutdown() {
+    Board* board = SYSTEM_MODULE.getBoard();
+    if (board) {
+        board->shutdown();
+    }
 }
 
 void PowerManagementTask::requestChipTemps() {

--- a/main/tasks/power_management_task.h
+++ b/main/tasks/power_management_task.h
@@ -75,4 +75,6 @@ class PowerManagementTask {
     void unlock() {
         pthread_mutex_unlock(&m_mutex);
     }
+
+    void shutdown();
 };


### PR DESCRIPTION
The last change introduced to aggressive locking what could lead to overheating during OTA updates when the fan rpms are not yet stable after a reboot.

This PR changes it in this way:
- allow task switches during www update (PID works normally) but prevent concurrent i2c comms and flash update via mutex
- shutdown buck converter during fw update (PID is not needed) because device is rebooted afterwards anyways