### PR TITLE
abs max values were missing

### DIFF
--- a/main/boards/nerdaxe.cpp
+++ b/main/boards/nerdaxe.cpp
@@ -42,6 +42,8 @@ NerdAxe::NerdAxe() : Board() {
     m_asicVoltages = {1100, 1150, 1200, 1250, 1300};
     m_defaultAsicFrequency = m_asicFrequency = 485;
     m_defaultAsicVoltageMillis = m_asicVoltageMillis = 1200;
+    m_absMaxAsicFrequency = 650;
+    m_absMaxAsicVoltageMillis = 1400;
     m_fanInvertPolarity = true;
     m_fanPerc = 100;
     m_flipScreen = true;

--- a/main/boards/nerdaxegamma.cpp
+++ b/main/boards/nerdaxegamma.cpp
@@ -31,6 +31,8 @@ NerdaxeGamma::NerdaxeGamma() : NerdAxe() {
     m_asicVoltages = {1120, 1130, 1140, 1150, 1160, 1170, 1180, 1190, 1200};
     m_defaultAsicFrequency = m_asicFrequency = 515;
     m_defaultAsicVoltageMillis = m_asicVoltageMillis = 1150;
+    m_absMaxAsicFrequency = 750;
+    m_absMaxAsicVoltageMillis = 1300;
     m_initVoltageMillis = 1150;
     m_fanInvertPolarity = true;
     m_fanPerc = 100;


### PR DESCRIPTION
abs max values were missing what clamped the asic frequency and voltage to 0 on nerdaxe and nerdaxe gamma