### PR TITLE
make sure all http server connections will be closed

### DIFF
--- a/main/http_server/handler_alert.cpp
+++ b/main/http_server/handler_alert.cpp
@@ -13,8 +13,8 @@ static const char* TAG = "http_alert";
 
 esp_err_t GET_alert_info(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
@@ -48,8 +48,8 @@ esp_err_t GET_alert_info(httpd_req_t *req)
 
 esp_err_t POST_update_alert(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
@@ -95,8 +95,8 @@ esp_err_t POST_update_alert(httpd_req_t *req)
 
 esp_err_t POST_test_alert(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (set_cors_headers(req) != ESP_OK) {
         httpd_resp_send_500(req);

--- a/main/http_server/handler_influx.cpp
+++ b/main/http_server/handler_influx.cpp
@@ -13,8 +13,8 @@ static const char* TAG="http_influx";
 /* Simple handler for getting system handler */
 esp_err_t GET_influx_info(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
@@ -62,8 +62,8 @@ esp_err_t GET_influx_info(httpd_req_t *req)
 
 esp_err_t PATCH_update_influx(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");

--- a/main/http_server/handler_ota.cpp
+++ b/main/http_server/handler_ota.cpp
@@ -14,8 +14,8 @@ extern bool enter_recovery;
 
 esp_err_t POST_WWW_update(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
@@ -97,8 +97,8 @@ esp_err_t POST_WWW_update(httpd_req_t *req)
  */
 esp_err_t POST_OTA_update(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
@@ -112,7 +112,7 @@ esp_err_t POST_OTA_update(httpd_req_t *req)
     int remaining = req->content_len;
 
     // lock the power management module
-    LockGuard g(POWER_MANAGEMENT_MODULE);
+    LockGuard lg(POWER_MANAGEMENT_MODULE);
 
     // Shut down buck converter before starting OTA.
     // During OTA, I2C conflicts prevent the PID from working correctly.

--- a/main/http_server/handler_ota_factory.cpp
+++ b/main/http_server/handler_ota_factory.cpp
@@ -610,8 +610,8 @@ bool FactoryOTAUpdate::trigger(const char *url)
  */
 esp_err_t POST_OTA_update_from_url(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     ESP_LOGI(TAG, "=== POST_OTA_update_from_url called ===");
 
@@ -685,8 +685,8 @@ esp_err_t POST_OTA_update_from_url(httpd_req_t *req)
 
 esp_err_t GET_OTA_status(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     httpd_resp_set_hdr(req, "Cache-Control", "no-store, no-cache, must-revalidate");
 

--- a/main/http_server/handler_otp.cpp
+++ b/main/http_server/handler_otp.cpp
@@ -20,8 +20,8 @@ static bool enrollmengActive = false;
 
 esp_err_t POST_create_otp(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
@@ -62,8 +62,8 @@ esp_err_t POST_create_otp(httpd_req_t *req)
 
 esp_err_t PATCH_update_otp(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
@@ -122,8 +122,8 @@ esp_err_t PATCH_update_otp(httpd_req_t *req)
 
 esp_err_t GET_otp_status(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
@@ -139,9 +139,6 @@ esp_err_t GET_otp_status(httpd_req_t *req)
     JsonDocument doc(&allocator);
 
     doc["enabled"] = otp.isEnabled();
-
-    // close connection afterwards
-    httpd_resp_set_hdr(req, "Connection", "close");
 
     esp_err_t ret = sendJsonResponse(req, doc);
     doc.clear();
@@ -165,8 +162,8 @@ static uint32_t clamp_ttl_ms(uint64_t v, uint32_t min_ms, uint32_t max_ms) {
 
 esp_err_t POST_create_otp_session(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");

--- a/main/http_server/handler_restart.cpp
+++ b/main/http_server/handler_restart.cpp
@@ -11,8 +11,8 @@ extern bool enter_recovery;
 
 esp_err_t POST_restart(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");

--- a/main/http_server/handler_swarm.cpp
+++ b/main/http_server/handler_swarm.cpp
@@ -9,8 +9,8 @@ static const char* TAG = "http_swarm";
 
 esp_err_t PATCH_update_swarm(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     // Set CORS headers
     if (set_cors_headers(req) != ESP_OK) {
@@ -46,8 +46,8 @@ esp_err_t PATCH_update_swarm(httpd_req_t *req)
 
 esp_err_t GET_swarm(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");

--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -20,8 +20,8 @@ static const char *TAG = "http_system";
 /* Simple handler for getting system handler */
 esp_err_t GET_system_info(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
@@ -177,9 +177,6 @@ esp_err_t GET_system_info(httpd_req_t *req)
 
     //ESP_LOGI(TAG, "allocs: %d, deallocs: %d, reallocs: %d", allocs, deallocs, reallocs);
 
-    // close connection to prevent clogging
-    httpd_resp_set_hdr(req, "Connection", "close");
-
     // Serialize the JSON document to a String and send it
     esp_err_t ret = sendJsonResponse(req, doc);
     doc.clear();
@@ -199,8 +196,8 @@ esp_err_t GET_system_info(httpd_req_t *req)
 
 esp_err_t PATCH_update_settings(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
@@ -351,8 +348,8 @@ esp_err_t PATCH_update_settings(httpd_req_t *req)
 
 esp_err_t GET_system_asic(httpd_req_t *req)
 {
-    // always set connection: close
-    httpd_resp_set_hdr(req, "Connection", "close");
+    // close connection when out of scope
+    ConGuard g(http_server, req);
 
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
@@ -397,9 +394,6 @@ esp_err_t GET_system_asic(httpd_req_t *req)
         const auto& volts = board->getVoltageOptions();
         for (uint32_t v : volts) { arr.add(v); }
     }
-
-    // Verbindung schließen, damit nichts „hängt“
-    httpd_resp_set_hdr(req, "Connection", "close");
 
     esp_err_t ret = sendJsonResponse(req, doc);
     doc.clear();

--- a/main/http_server/http_utils.h
+++ b/main/http_server/http_utils.h
@@ -34,3 +34,21 @@ esp_err_t sendJsonResponse(httpd_req_t *req, JsonDocument &doc);
 esp_err_t getPostData(httpd_req_t *req);
 esp_err_t getJsonData(httpd_req_t *req, JsonDocument &doc);
 esp_err_t validateOTP(httpd_req_t *req, bool force = false);
+
+extern httpd_handle_t http_server;
+
+class ConGuard {
+protected:
+    httpd_handle_t m_http_server;
+    httpd_req_t *m_req;
+public:
+    ConGuard(httpd_handle_t http_server, httpd_req_t *req): m_http_server(http_server), m_req(req) {
+        httpd_resp_set_hdr(m_req, "Connection", "close");
+    };
+    ~ConGuard() {
+        int sock = httpd_req_to_sockfd(m_req);
+        if (sock >= 0 && m_http_server) {
+            httpd_sess_trigger_close(m_http_server, sock);
+        }
+    }
+};


### PR DESCRIPTION
Adds a "ConGuard" that ensures `Connection:close` is set and `httpd_sess_trigger_close` is called in every return path from http server handlers

before (no FIN from the server):
```
17:13:30.459531 IP 192.168.0.194.80 > 192.168.0.197.49102: Flags [P.], seq 2017:3457, ack 767, win 4994, length 1440: HTTP
17:13:30.459539 IP 192.168.0.197.49102 > 192.168.0.194.80: Flags [.], ack 3457, win 65535, length 0
17:13:30.461876 IP 192.168.0.194.80 > 192.168.0.197.49102: Flags [P.], seq 3457:3781, ack 767, win 4994, length 324: HTTP
17:13:30.461884 IP 192.168.0.197.49102 > 192.168.0.194.80: Flags [.], ack 3781, win 65535, length 0
```

now:
```
22:09:17.692048 IP 192.168.0.194.80 > 192.168.0.197.50768: Flags [P.], seq 70:122, ack 64, win 5697, length 52: HTTP
22:09:17.692063 IP 192.168.0.197.50768 > 192.168.0.194.80: Flags [.], ack 122, win 64119, length 0
22:09:17.692742 IP 192.168.0.194.80 > 192.168.0.197.50768: Flags [F.], seq 122, ack 64, win 5697, length 0
22:09:17.692775 IP 192.168.0.197.50768 > 192.168.0.194.80: Flags [F.], seq 64, ack 123, win 64118, length 0
22:09:17.694412 IP 192.168.0.194.80 > 192.168.0.197.50768: Flags [.], ack 65, win 5696, length 0
```

tested with
```
printf 'GET /api/system/info HTTP/1.1\r\nHost: 192.168.0.194\r\nConnection: close\r\n\r\n'   | nc -v 192.168.0.194 80
```
and 
```
sudo tcpdump -i enp11s0 -n "host 192.168.0.194 and port 80"
```