### PR TITLE
fix autoscreen off and enable display on soft-power off

### DIFF
--- a/main/boards/board.h
+++ b/main/boards/board.h
@@ -95,6 +95,7 @@ public:
     Asic *m_asics = nullptr;
 
     bool m_isInitialized = false;
+    bool m_isBuckInitialized = false;
 
   public:
     Board();
@@ -182,6 +183,11 @@ public:
     {
         return m_isInitialized;
     };
+
+    bool isBuckInitialized()
+    {
+        return m_isBuckInitialized;
+    }
 
     virtual Asic *getAsics()
     {

--- a/main/boards/nerdaxe.cpp
+++ b/main/boards/nerdaxe.cpp
@@ -152,6 +152,8 @@ bool NerdAxe::initAsics()
     // wait 500ms
     vTaskDelay(pdMS_TO_TICKS(500));
 
+    m_isBuckInitialized = true;
+
     // release reset pin
     gpio_set_level(BM1366_RST_PIN, 1);
 

--- a/main/boards/nerdaxegamma.cpp
+++ b/main/boards/nerdaxegamma.cpp
@@ -122,6 +122,8 @@ bool NerdaxeGamma::initAsics() {
     // wait 500ms
     vTaskDelay(pdMS_TO_TICKS(500));
 
+    m_isBuckInitialized = true;
+
     // release reset pin
     gpio_set_level(BM1370_RST_PIN, 1);
 

--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -150,6 +150,8 @@ bool NerdQaxePlus::initAsics()
     // wait 500ms
     vTaskDelay(pdMS_TO_TICKS(500));
 
+    m_isBuckInitialized = true;
+
     // release reset pin
     gpio_set_level(BM1368_RST_PIN, 1);
 

--- a/main/displays/displayDriver.cpp
+++ b/main/displays/displayDriver.cpp
@@ -172,6 +172,7 @@ void DisplayDriver::startShutdownCountdown() {
     if (m_shutdownCountdownActive) return;
 
     m_shutdownCountdownActive = true;
+    m_isActiveOverlay = true;
     m_shutdownStartTime = esp_timer_get_time();
 
     lv_obj_t* scr = lv_scr_act();
@@ -213,6 +214,7 @@ void DisplayDriver::hideShutdownCountdown() {
         m_shutdownLabel = nullptr;
     }
     m_shutdownCountdownActive = false;
+    m_isActiveOverlay = false;
 }
 
 
@@ -493,6 +495,11 @@ void DisplayDriver::processButtons(Button &btn1, Button &btn2, int64_t tnow,
     uint32_t evt1 = btn1.getEvent();
     uint32_t evt2 = btn2.getEvent();
     bool bothPressed = (evt1 & BTN_EVENT_PRESSED) && (evt2 & BTN_EVENT_PRESSED);
+    bool anyPressed = (evt1 & BTN_EVENT_PRESSED) || (evt2 & BTN_EVENT_PRESSED);
+
+    if (anyPressed) {
+        m_lastKeypressTime = tnow;
+    }
 
     // Ignore all button events within 200ms of both released
     if (esp_timer_get_time() < m_buttonIgnoreUntil_us) {

--- a/main/tasks/power_management_task.h
+++ b/main/tasks/power_management_task.h
@@ -35,11 +35,14 @@ class PowerManagementTask {
     float m_current;
     bool m_shutdown = false;
     PID *m_pid;
+    Board* m_board = nullptr;
 
     void checkCoreVoltageChanged();
     void checkAsicFrequencyChanged();
     void checkPidSettingsChanged();
     void checkVrFrequencyChanged();
+    void readAndPublishPowerTelemetry();
+    void applyAsicSettings();
     void task();
 
     bool startTimer();


### PR DESCRIPTION
Buck status registers were evaluated before it was initialized, leading to an error condition that forced the display to be on, but error was not visible and never cleared, disabeling autoscreen off completely.

Fix is to introduce a new flag that is set when the buck was initialized.

The `board->isInitialized()` couldn't be used because it's only set to true when at least one asic was detected.

Also refactored the power manager a bit.

Also there was an issue where the display wasn't turned on when pressing both buttons for soft-shutdown. Was fixed by setting the `m_activeOverlay`.