### PR TITLE
animation finished callback on screen changes

### DIFF
--- a/main/displays/displayDriver.h
+++ b/main/displays/displayDriver.h
@@ -115,6 +115,7 @@ class DisplayDriver {
     int64_t m_shutdownStartTime;
     lv_obj_t* m_shutdownLabel;
     int64_t m_buttonIgnoreUntil_us;
+    bool m_screenAnimationRunning = false;
 
     UI *m_ui;
 
@@ -174,6 +175,7 @@ class DisplayDriver {
     void processButtons(Button &btn1, Button &btn2, int64_t tnow, bool &btn1Press, bool &btn2Press, bool &btnBothLongPress);
     uint32_t handleLvglTick(int32_t &elapsed_Ani_cycles);
 
+    void safe_screen_change(lv_obj_t * new_scr, lv_scr_load_anim_t anim_type, uint32_t speed, uint32_t delay);
   public:
     // Constructor
     DisplayDriver();
@@ -192,6 +194,10 @@ class DisplayDriver {
     void logMessage(const char *message);                           // Log a message to the display
     void waitForSplashs();
     void loadSettings();                                            // (re)load settings
+
+    void setScreenAnimationRunning(bool state) {
+      m_screenAnimationRunning = state;
+    }
 
     UiState getState() {
       return m_state;

--- a/main/displays/ui.cpp
+++ b/main/displays/ui.cpp
@@ -18,6 +18,11 @@ static const char *TAG="ui";
 
 ///////////////////// FUNCTIONS ////////////////////
 
+void on_screen_loaded(lv_event_t * e)
+{
+    DisplayDriver* driver = static_cast<DisplayDriver*>(lv_event_get_user_data(e));
+    driver->setScreenAnimationRunning(false);
+}
 
 ///////////////////// SCREENS ////////////////////
 
@@ -95,6 +100,7 @@ void UI::portalScreenInit(void)
     lv_obj_set_style_text_opa(ui_lbSSID, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_align(ui_lbSSID, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_font(ui_lbSSID, &ui_font_OpenSansBold13, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_add_event_cb(ui_PortalScreen, on_screen_loaded, LV_EVENT_SCREEN_LOADED, m_display);
 
     // lv_obj_add_event_cb(ui_Splash2, ui_event_Splash2, LV_EVENT_ALL, NULL);
 
@@ -258,6 +264,7 @@ void UI::miningScreenInit(void)
     lv_obj_set_style_text_opa(ui_lbASIC, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_align(ui_lbASIC, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_font(ui_lbASIC, &ui_font_OpenSansBold14, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_add_event_cb(ui_MiningScreen, on_screen_loaded, LV_EVENT_SCREEN_LOADED, m_display);
 
     // lv_obj_add_event_cb(ui_MiningScreen, ui_event_MiningScreen, LV_EVENT_ALL, NULL);
 }
@@ -393,6 +400,7 @@ void UI::settingsScreenInit(void)
     lv_obj_set_style_text_opa(ui_lbPortSet, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_align(ui_lbPortSet, LV_TEXT_ALIGN_LEFT, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_font(ui_lbPortSet, &ui_font_OpenSansBold13, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_add_event_cb(ui_SettingsScreen, on_screen_loaded, LV_EVENT_SCREEN_LOADED, m_display);
 }
 
 void UI::logScreenInit(void)
@@ -475,6 +483,7 @@ void UI::bTCScreenInit(void)
     lv_obj_set_style_text_opa(ui_lblTempPrice, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_align(ui_lblTempPrice, LV_TEXT_ALIGN_RIGHT, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_font(ui_lblTempPrice, &ui_font_OpenSansBold24, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_add_event_cb(ui_BTCScreen, on_screen_loaded, LV_EVENT_SCREEN_LOADED, m_display);
 }
 
 void UI::globalStatsScreenInit(void)
@@ -585,6 +594,7 @@ void UI::globalStatsScreenInit(void)
     lv_obj_set_style_text_opa(ui_lblhighFee, 255, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_align(ui_lblhighFee, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN | LV_STATE_DEFAULT);
     lv_obj_set_style_text_font(ui_lblhighFee, &ui_font_OpenSansBold13, LV_PART_MAIN | LV_STATE_DEFAULT);
+    lv_obj_add_event_cb(ui_GlobalStats, on_screen_loaded, LV_EVENT_SCREEN_LOADED, m_display);
 
 }
 void UI::createQRScreen(uint8_t *buf, int size) {
@@ -639,6 +649,7 @@ void UI::createQRScreen(uint8_t *buf, int size) {
 
         // Align label relative to the parent (screen)
         lv_obj_align(label, LV_ALIGN_LEFT_MID, 10, 0); // start in left half, 10 px margin
+        lv_obj_add_event_cb(ui_qrScreen, on_screen_loaded, LV_EVENT_SCREEN_LOADED, m_display);
     }
 
     // white background
@@ -676,6 +687,7 @@ void UI::powerOffScreenInit(void)
     lv_obj_t *img = lv_img_create(ui_PowerOffScreen);
     lv_img_set_src(img, &ui_img_safe_png);
     lv_obj_align(img, LV_ALIGN_CENTER, 0, 0);  // Center of screen
+    lv_obj_add_event_cb(ui_PowerOffScreen, on_screen_loaded, LV_EVENT_SCREEN_LOADED, m_display);
 }
 
 
@@ -776,10 +788,11 @@ void UI::hideImageOverlay()
     }
 }
 
-void UI::init(Board* board)
+void UI::init(Board* board, DisplayDriver *display)
 {
     m_board = board;
     m_theme = board->getTheme();
+    m_display = display;
 
     lv_disp_t *dispp = lv_disp_get_default();
     lv_theme_t *m_theme =

--- a/main/displays/ui.h
+++ b/main/displays/ui.h
@@ -84,6 +84,7 @@ protected:
 
     Board* m_board;
     Theme* m_theme;
+    DisplayDriver *m_display;
 
     lv_color_t* m_qr_canvas_buf = nullptr;
     int         m_qr_canvas_w   = 0;   // == height
@@ -103,7 +104,7 @@ protected:
 public:
     UI();
 
-    void init(Board* board);
+    void init(Board* board, DisplayDriver* display);
 
     void miningScreenInit(void);
     void settingsScreenInit(void);


### PR DESCRIPTION
When pressing the screen change button multiple times the fw crashed.

This PR adds a flag that an animation is in progress and the flag is reset with the animation ended callback.

Button presses are ignored while the flag is set.