### PR TITLE
Develop

### DIFF
--- a/main/boards/drivers/TPS53647.h
+++ b/main/boards/drivers/TPS53647.h
@@ -3,6 +3,9 @@
 #include "driver/i2c.h"
 #include "esp_err.h"
 
+#define TPS53647_THROTTLE_TEMP 105.0
+#define TPS53647_MAX_TEMP 125.0
+
 class TPS53647 {
 protected:
     uint8_t m_i2cAddr;

--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -61,6 +61,8 @@ NerdQaxePlus::NerdQaxePlus() : Board() {
     m_asicMinDifficulty = 256;
     m_asicMinDifficultyDualPool = 128;
 
+    m_vr_maxTemp = TPS53647_THROTTLE_TEMP; //Set max voltage regulator temp
+
 #ifdef NERDQAXEPLUS
     m_theme = new ThemeNerdqaxeplus();
 #endif
@@ -262,11 +264,11 @@ float NerdQaxePlus::getTemperature(int index) {
 float NerdQaxePlus::getVRTemp() {
     float vrTemp = m_tps->get_temperature();
 
-    // test
-    float tmp = TMP1075_read_temperature(1);
-    ESP_LOGI(TAG, "tmp1075 vs tps: %.2f vs %.2f (diff: %.2f)", tmp, vrTemp, vrTemp - tmp);
+    // depricated, external vr temp
+    // float tmp = TMP1075_read_temperature(1);
+    // ESP_LOGI(TAG, "tmp1075 vs tps: %.2f vs %.2f (diff: %.2f)", tmp, vrTemp, vrTemp - tmp);
 
-    return tmp;
+    return vrTemp;
 }
 
 float NerdQaxePlus::getVin() {


### PR DESCRIPTION
Use the internal CSD95472Q5MC temperature sensor for the most accurate VR temperature sensing and raise the maximum limit to 105C. The stated operating limit in the data sheet is 125C. 

This effectly depricates the TMP1075 in the VR area. 