### PR TITLE
Develop

### DIFF
--- a/main/boards/drivers/TPS53647.h
+++ b/main/boards/drivers/TPS53647.h
@@ -3,6 +3,9 @@
 #include "driver/i2c.h"
 #include "esp_err.h"
 
+#define TPS53647_THROTTLE_TEMP 105.0
+#define TPS53647_MAX_TEMP 125.0
+
 class TPS53647 {
 protected:
     uint8_t m_i2cAddr;

--- a/main/boards/nerdqaxeplus2.cpp
+++ b/main/boards/nerdqaxeplus2.cpp
@@ -35,6 +35,8 @@ NerdQaxePlus2::NerdQaxePlus2() : NerdQaxePlus() {
     m_asicMinDifficulty = 512;
     m_asicMinDifficultyDualPool = 256;
 
+    m_vr_maxTemp = TPS53647_THROTTLE_TEMP; //Set max voltage regulator temp
+
 #ifdef NERDQAXEPLUS2
     m_theme = new ThemeNerdqaxeplus2();
 #endif
@@ -51,6 +53,17 @@ float NerdQaxePlus2::getTemperature(int index) {
     // we can't read the real chip temps but this should be about right
     return temp + 10.0f; // offset of 10°C
 }
+
+float NerdQaxePlus2::getVRTemp() {
+    float vrTemp = m_tps->get_temperature();
+
+    // depricated, external vr temp
+    // float tmp = TMP1075_read_temperature(1);
+    // ESP_LOGI(TAG, "tmp1075 vs tps: %.2f vs %.2f (diff: %.2f)", tmp, vrTemp, vrTemp - tmp);
+
+    return vrTemp;
+}
+
 
 void NerdQaxePlus2::requestChipTemps() {
     // NOP

--- a/main/boards/nerdqaxeplus2.h
+++ b/main/boards/nerdqaxeplus2.h
@@ -14,4 +14,5 @@ class NerdQaxePlus2 : public NerdQaxePlus {
     NerdQaxePlus2();
     float getTemperature(int index);
     virtual void requestChipTemps();
+    virtual float getVRTemp();
 };

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -360,7 +360,13 @@ void PowerManagementTask::task()
 
         // we let the PID always calculate for "bumpless transfer"
         // when switching modes
-        pid_input = std::max(m_chipTempMax, m_vrTemp);
+        #ifdef NERDQAXEPLUS2
+            pid_input = m_chipTempMax;
+        #else
+            pid_input = std::max(m_chipTempMax, m_vrTemp);
+        #endif
+
+        
         m_pid->Compute();
 
         switch (temp_control_mode) {


### PR DESCRIPTION
USE CSD95472Q5MC internal temperature reading for VR temp, set the maximum CSD95472Q5MC temp to 105 (data sheet states 125)

Affects nerdqaxe++ only