### PR TITLE
Intermediate steps for frequency expanded in UI selection

### DIFF
--- a/main/boards/nerdoctaxegamma.cpp
+++ b/main/boards/nerdoctaxegamma.cpp
@@ -61,7 +61,7 @@ NerdOctaxeGamma::NerdOctaxeGamma() : NerdQaxePlus2() {
         m_tps = new TPS53667();
 
         // Extended frequency range for TPS53667 (6 phases, higher power capacity)
-        m_asicFrequencies = {525, 575, 600, 625, 650, 675, 700, 750, 800};
+        m_asicFrequencies = {525, 550, 575, 600, 625, 650, 675, 700, 725, 750, 775, 800};
         m_absMaxAsicFrequency = 850;  // Absolute max for manual input (danger zone)
 
         // Extended voltage range for TPS53667 (6 phases, higher current capacity)


### PR DESCRIPTION
I noticed that the OCTAXE Gamma 6P had “forgotten” a few intermediate steps in the selection UI. These have been added for improved UI/UX.

CC @BitMaker-hub 