### PR TITLE
don't overwrite error messages with something else

### DIFF
--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -346,9 +346,12 @@ Board::Error NerdQaxePlus::getFault(uint32_t *status) {
     // is buck off? Then something is wrong ...
     // return general error.
     // status_byte: Bit 6 = OFF
-    if (status_byte != 0xff && (status_byte & 0x40)) {
-        return Board::Error::PSU_FAULT;
-    }
+    // update: this has wrong behaviour because on eg over temp shutdown
+    // it would trigger PSU error with #40000000 what actually only says the vreg is off
+    // but without any TPS error flag set.
+    //if (status_byte != 0xff && (status_byte & 0x40)) {
+    //    return Board::Error::PSU_FAULT;
+    //}
 
     return Board::Error::NONE;
 }

--- a/main/displays/displayDriver.cpp
+++ b/main/displays/displayDriver.cpp
@@ -799,7 +799,8 @@ void DisplayDriver::updateHashrate(System *module, StratumManager* manager, floa
     char strData[20];
     char strDataActive[20];
 
-    float efficiency = power / (SYSTEM_MODULE.getCurrentHashrate() / 1000.0);
+    float hr = SYSTEM_MODULE.getCurrentHashrate() / 1000.0f;
+    float efficiency = (hr > 0) ? power / hr : 10000.0f;
     float hashrate = SYSTEM_MODULE.getCurrentHashrate();
     formatHashrate(strData, sizeof(strData), hashrate);
 
@@ -820,7 +821,7 @@ void DisplayDriver::updateHashrate(System *module, StratumManager* manager, floa
     lv_label_set_text(m_ui->ui_lblHashPrice, strData);  // Update hashrate
 
     snprintf(strData, sizeof(strData), "%.1f", efficiency);
-    lv_label_set_text(m_ui->ui_lbEficiency, strData); // Update eficiency label
+    lv_label_set_text(m_ui->ui_lbEficiency, (efficiency < 10000.0f) ? strData : "n/a"); // Update eficiency label
 
     snprintf(strData, sizeof(strData), "%.3fW", power);
     lv_label_set_text(m_ui->ui_lbPower, strData); // Actualiza el label

--- a/main/system.cpp
+++ b/main/system.cpp
@@ -141,8 +141,8 @@ esp_reset_reason_t System::showLastResetReason() {
 }
 
 void System::showError(const char *error_message, uint32_t error_code) {
-    // is this error already shown? yes, do nothing
-    if (m_showsOverlay && m_currentErrorCode == error_code) {
+    // we are already displaying an error
+    if (m_showsOverlay && m_currentErrorCode != 0) {
         return;
     }
     m_display->showError(error_message, error_code);


### PR DESCRIPTION
Fixes the `#400000 PSU Fault` problem.

This happens when:
- VREG Temp crossed the shutdown temp (default 70°C)
- it switched off the vreg and triggered the error "Miner overheated"
- in the next loop of the power manager task it saw that the OFF bit in the TPS status is set, assuming there is an error
- it generated a second error with the flags `#40000000` only saying the vreg is off but without any error
- the original error message was overwritten with the new useless error message

This PR prevents overwriting the original error on the screen