### PR TITLE
Virtual destructor

### DIFF
--- a/main/boards/board.cpp
+++ b/main/boards/board.cpp
@@ -19,6 +19,20 @@ Board::Board() {
     m_numFans = 1;
 }
 
+Board::~Board() {
+    // Deallocate chip temperature array
+    if (m_chipTemps) {
+        delete[] m_chipTemps;
+        m_chipTemps = nullptr;
+    }
+
+    // Deallocate theme object (allocated in derived class constructors)
+    if (m_theme) {
+        delete m_theme;
+        m_theme = nullptr;
+    }
+}
+
 void Board::loadSettings()
 {
     m_fanPerc = Config::getFanSpeed();
@@ -56,6 +70,11 @@ void Board::loadSettings()
 }
 
 bool Board::initBoard() {
+    if (m_chipTemps) {
+        delete[] m_chipTemps;
+        m_chipTemps = nullptr;
+    }
+
     m_chipTemps = new float[m_asicCount]();
     return true;
 }
@@ -79,6 +98,10 @@ void Board::requestChipTemps() {
 }
 
 float Board::getMaxChipTemp() {
+    if (!m_chipTemps) {
+        return 0.0f;
+    }
+    
     float maxTemp = 0.0f;
     for (int i=0;i<m_asicCount;i++) {
         maxTemp = std::max(maxTemp, m_chipTemps[i]);

--- a/main/boards/board.h
+++ b/main/boards/board.h
@@ -38,7 +38,7 @@ public:
     int m_asicCount;
     int m_chipsDetected = 0;
     int m_numTempSensors = 0;
-    float *m_chipTemps;
+    float *m_chipTemps = nullptr;
     const char *m_swarmColorName = "blue";
     uint32_t m_vrFrequency;
     uint32_t m_defaultVrFrequency;
@@ -99,6 +99,22 @@ public:
 
   public:
     Board();
+    /**
+     * @brief Destructor for Board class.
+     *
+     * Releases dynamically allocated resources:
+     * - Deallocates the m_chipTemps array (float[] allocated in initBoard())
+     * - Deletes the m_theme object (Theme* allocated in derived class constructors)
+     *
+     * This is essential for preventing memory leaks, especially important for:
+     * - Re-initialization scenarios where initBoard() is called multiple times
+     * - Polymorphic deletion through Board* pointers
+     * - Proper cleanup when Board instances are destroyed
+     *
+     * The destructor is virtual to ensure correct cleanup of derived classes
+     * when deleted through a base class pointer.
+     */
+    virtual ~Board();
 
     virtual bool initBoard();
     virtual bool initAsics() = 0;


### PR DESCRIPTION
While checking the NerdQX profiles, my IDE kicked in and detected a possible memory leak. It suggested implementing a destructor. Primarily complained about was m_theme, optionally recommended but also m_chipTemps.
 
* Memory leaks: If Boardinstances are created/managed multiple times (e.g., in tests, factory/self-test workflows, future refactorings, or when Board is reinitialized), these allocations remain stuck in the heap.
* Unclear ownership/maintainability: Without a clear “owner” (who is responsible for delete?), there is a high risk that someone will later add cleanup in a subclass, resulting in inconsistencies or double-free risks.

This adjustment has been successfully tested on a NerdQX and OCT P4. @shufps feel free to check if it really makes sense from a technical point of view, as you are much more familiar with the code. Maybe it's a quick win.