### PR TITLE
refactor (logs): stabilize virtual scroll, improve autoscroll & memory handling

### DIFF
--- a/main/http_server/axe-os/src/app/pages/system/system.component.html
+++ b/main/http_server/axe-os/src/app/pages/system/system.component.html
@@ -1,5 +1,6 @@
 <ng-container *ngIf="info$ | async as info">
-  <nb-card>
+
+  <nb-card *ngIf="!showLogs">
     <nb-card-header>{{ 'SYSTEM.OVERVIEW' | translate }}</nb-card-header>
     <nb-card-body>
       <table class="overview-table">
@@ -11,9 +12,12 @@
           <td><b>{{ 'SYSTEM.UPTIME' | translate }}:</b></td>
           <td>
             <span [title]="getBootTime(info.uptimeSeconds) | date:'medium'">
-              {{ info.uptimeSeconds | dateAgo }}</span>&nbsp;&nbsp;&nbsp;
-            <button nbButton size="small" (click)="restart()" status="danger">{{ 'SYSTEM.RESTART' | translate
-              }}</button>
+              {{ info.uptimeSeconds | dateAgo }}
+            </span>&nbsp;&nbsp;&nbsp;
+
+            <button nbButton size="small" (click)="restart()" status="danger">
+              {{ 'SYSTEM.RESTART' | translate }}
+            </button>
             &nbsp;
             <button nbButton size="small" (click)="shutdown()" status="warning">
               {{ 'SYSTEM.SHUTDOWN' | translate }}
@@ -59,12 +63,19 @@
           <td class="collab-card no-border">
             <nb-card class="collab-card">
               <nb-card-header class="collab-header">
-                <span class="text-hint" (click)="openLink('https://github.com/IxTechCrypto/NerdQX')" role="button"
-                  tabindex="0" title="NerdQX repository on Github"><u>NerdQX</u>
+                <span class="text-hint"
+                      (click)="openLink('https://github.com/IxTechCrypto/NerdQX')"
+                      role="button"
+                      tabindex="0"
+                      title="NerdQX repository on Github">
+                  <u>NerdQX</u>
                 </span>
                 <span class="text-hint" [innerHTML]="'SYSTEM.ABOUT_NERDQX' | translate"></span>
-                <span class="text-hint" (click)="openLink('https://plebbase.com/nerdqx-original')" role="button"
-                  tabindex="0" title="NerdQX ORIGINAL initiative">
+                <span class="text-hint"
+                      (click)="openLink('https://plebbase.com/nerdqx-original')"
+                      role="button"
+                      tabindex="0"
+                      title="NerdQX ORIGINAL initiative">
                   <span [innerHTML]="'SYSTEM.ABOUT_NERDQX_ORIGINAL' | translate"></span>
                 </span>.
               </nb-card-header>
@@ -78,36 +89,60 @@
                   <div class="colhead text-hint">shufps</div>
 
                   <!-- Logos row (clickable tiles) -->
-                  <div class="logo-cell clickable" (click)="openLink('https://ixtech.xyz')" role="button" tabindex="0"
-                    title="Ix Tech – Website" aria-label="Ix Tech – Website">
+                  <div class="logo-cell clickable"
+                       (click)="openLink('https://ixtech.xyz')"
+                       role="button"
+                       tabindex="0"
+                       title="Ix Tech – Website"
+                       aria-label="Ix Tech – Website">
                     <img class="logo" src="/assets/IxTech{{ logoPrefix }}.png" alt="Ix Tech logo" />
                   </div>
 
-                  <div class="logo-cell clickable" (click)="openLink('https://plebbase.com')" role="button" tabindex="0"
-                    title="PlebBase – Website" aria-label="PlebBase – Website">
+                  <div class="logo-cell clickable"
+                       (click)="openLink('https://plebbase.com')"
+                       role="button"
+                       tabindex="0"
+                       title="PlebBase – Website"
+                       aria-label="PlebBase – Website">
                     <img class="logo" src="/assets/PlebBase{{ logoPrefix }}.png" alt="PlebBase logo" />
                   </div>
 
-                  <div class="logo-cell clickable" (click)="openLink('https://github.com/phil31')" role="button"
-                    tabindex="0" title="phil31 – GitHub" aria-label="phil31 – GitHub">
+                  <div class="logo-cell clickable"
+                       (click)="openLink('https://github.com/phil31')"
+                       role="button"
+                       tabindex="0"
+                       title="phil31 – GitHub"
+                       aria-label="phil31 – GitHub">
                     <nb-icon icon="github-outline" class="gh-l" aria-label="GitHub"></nb-icon>
                   </div>
 
-                  <div class="logo-cell clickable" (click)="openLink('https://github.com/shufps')" role="button"
-                    tabindex="0" title="shufps – GitHub" aria-label="shufps – GitHub">
+                  <div class="logo-cell clickable"
+                       (click)="openLink('https://github.com/shufps')"
+                       role="button"
+                       tabindex="0"
+                       title="shufps – GitHub"
+                       aria-label="shufps – GitHub">
                     <nb-icon icon="github-outline" class="gh-l" aria-label="GitHub"></nb-icon>
                   </div>
 
                   <!-- X/Twitter row -->
-                  <div class="logo-cell x-cell" (click)="openLink('https://x.com/IxTechCrypto')" role="button"
-                    tabindex="0" title="Ix Tech – X (Twitter)" aria-label="Ix Tech – X (Twitter)">
+                  <div class="logo-cell x-cell"
+                       (click)="openLink('https://x.com/IxTechCrypto')"
+                       role="button"
+                       tabindex="0"
+                       title="Ix Tech – X (Twitter)"
+                       aria-label="Ix Tech – X (Twitter)">
                     <div class="x-tile">
                       <img class="x-logo" src="/assets/x-logo.png" alt="X (Twitter) logo" />
                     </div>
                   </div>
 
-                  <div class="logo-cell x-cell" (click)="openLink('https://x.com/trendkraft')" role="button"
-                    tabindex="0" title="PlebBase – X (Twitter)" aria-label="PlebBase – X (Twitter)">
+                  <div class="logo-cell x-cell"
+                       (click)="openLink('https://x.com/trendkraft')"
+                       role="button"
+                       tabindex="0"
+                       title="PlebBase – X (Twitter)"
+                       aria-label="PlebBase – X (Twitter)">
                     <div class="x-tile">
                       <img class="x-logo" src="/assets/x-logo.png" alt="X (Twitter) logo" />
                     </div>
@@ -115,14 +150,17 @@
 
                   <div class="logo-cell x-cell"><!-- no X link --></div>
 
-                  <div class="logo-cell x-cell" (click)="openLink('https://x.com/Pmaxsd')" role="button" tabindex="0"
-                    title="shufps – X (Twitter)" aria-label="shufps – X (Twitter)">
+                  <div class="logo-cell x-cell"
+                       (click)="openLink('https://x.com/Pmaxsd')"
+                       role="button"
+                       tabindex="0"
+                       title="shufps – X (Twitter)"
+                       aria-label="shufps – X (Twitter)">
                     <div class="x-tile">
                       <img class="x-logo" src="/assets/x-logo.png" alt="X (Twitter) logo" />
                     </div>
                   </div>
                 </div>
-
               </nb-card-body>
             </nb-card>
           </td>
@@ -131,33 +169,70 @@
     </nb-card-body>
   </nb-card>
 
+  <!-- LOGS CARD: always visible (button always there), content only if showLogs -->
   <nb-card class="mt-4">
     <nb-card-header style="display: flex; align-items: center; flex-wrap: nowrap;">
       {{ 'SYSTEM.REALTIME_LOGS' | translate }}
+
       <button nbButton size="small" status="primary" (click)="toggleLogs()" style="margin-left: 15px;">
-        {{ showLogs ? ('SYSTEM.HIDE' | translate) : ('SYSTEM.SHOW' | translate) }} {{ 'SYSTEM.LOGS' | translate
-        }}
+        {{ showLogs ? ('SYSTEM.HIDE' | translate) : ('SYSTEM.SHOW' | translate) }}
+        {{ 'SYSTEM.LOGS' | translate }}
       </button>
-      <button nbButton size="small" status="warning" (click)="stopScroll = !stopScroll" *ngIf="showLogs"
-        style="margin-left: 15px;">
-        {{ stopScroll ? ('SYSTEM.START' | translate) : ('SYSTEM.STOP' | translate) }} {{ 'SYSTEM.SCROLLING' |
-        translate }}
+
+      <button nbButton
+              size="small"
+              status="warning"
+              (click)="toggleScrolling()"
+              *ngIf="showLogs"
+              style="margin-left: 15px;">
+        {{ stopScroll ? ('SYSTEM.START' | translate) : ('SYSTEM.STOP' | translate) }}
+        {{ 'SYSTEM.SCROLLING' | translate }}
       </button>
+
       <div *ngIf="showLogs" style="display: flex; align-items: center; margin-left: 15px; margin-top: 0;">
-        <!-- Clear Filter Button -->
-        <button nbButton size="small" status="info" (click)="logFilterText = ''" style="margin-right: 10px;">
+        <button nbButton
+                size="small"
+                status="info"
+                (click)="logFilterText = ''; applyFilter(); onFilterMaybeScroll()"
+                style="margin-right: 10px;">
           {{ 'SYSTEM.CLEAR_FILTER' | translate }}
         </button>
-        <label for="logFilterText" style="margin-right: 5px;">{{ 'SYSTEM.FILTER' | translate }}</label>
-        <input id="logFilterText" type="text" [(ngModel)]="logFilterText"
-          [placeholder]="'SYSTEM.FILTER_LOGS_PLACEHOLDER' | translate"
-          style="margin-left: 5px; flex-grow: 1; width: calc(100% - 210px);" />
+
+        <label for="logFilterText" style="margin-right: 5px;">
+          {{ 'SYSTEM.FILTER' | translate }}
+        </label>
+
+        <input id="logFilterText"
+               type="text"
+               [(ngModel)]="logFilterText"
+               (ngModelChange)="applyFilter(); onFilterMaybeScroll()"
+               [placeholder]="'SYSTEM.FILTER_LOGS_PLACEHOLDER' | translate"
+               style="margin-left: 5px; flex-grow: 1; width: calc(100% - 210px);" />
       </div>
     </nb-card-header>
+
+    <nb-alert
+      status="info"
+      *ngIf="logsLockedByOtherTab && !showLogs"
+      class="mt-2">
+      {{ 'SYSTEM.LOGS_ALREADY_OPEN_OTHER_TAB' | translate }}
+    </nb-alert>
+
     <nb-card-body *ngIf="showLogs">
-      <div id="logs" #scrollContainer>
-        <div class="log-entry" *ngFor="let log of logs" [innerHTML]="'₿ ' + (log | ANSI)"></div>
-      </div>
+      <cdk-virtual-scroll-viewport
+        class="logs-viewport"
+        [itemSize]="logItemSize"
+        [minBufferPx]="minBufferPx"
+        [maxBufferPx]="maxBufferPx"
+        #viewport>
+
+        <div
+          class="log-entry"
+          *cdkVirtualFor="let log of filteredLogs; trackBy: trackByLogId"
+          [innerHTML]="'₿ ' + (log.text | ANSI)">
+        </div>
+
+      </cdk-virtual-scroll-viewport>
     </nb-card-body>
   </nb-card>
 

--- a/main/http_server/axe-os/src/app/pages/system/system.component.html
+++ b/main/http_server/axe-os/src/app/pages/system/system.component.html
@@ -189,6 +189,17 @@
         {{ 'SYSTEM.SCROLLING' | translate }}
       </button>
 
+      <button nbButton
+              size="small"
+              status="success"
+              *ngIf="showLogs"
+              [disabled]="logs.length === 0"
+              (click)="downloadLogs()"
+              style="margin-left: 15px;">
+        <nb-icon icon="download-outline" class="download-icon" aria-hidden="true"></nb-icon>
+        {{ 'SYSTEM.DOWNLOAD_LOGS' | translate }}
+      </button>
+
       <div *ngIf="showLogs" style="display: flex; align-items: center; margin-left: 15px; margin-top: 0;">
         <button nbButton
                 size="small"
@@ -229,7 +240,7 @@
         <div
           class="log-entry"
           *cdkVirtualFor="let log of filteredLogs; trackBy: trackByLogId"
-          [innerHTML]="'₿ ' + (log.text | ANSI)">
+          [innerHTML]="(formatLogForUi(log.text) | ANSI)">
         </div>
 
       </cdk-virtual-scroll-viewport>

--- a/main/http_server/axe-os/src/app/pages/system/system.component.scss
+++ b/main/http_server/axe-os/src/app/pages/system/system.component.scss
@@ -34,13 +34,20 @@
   font-family: ui-monospace, monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New";
   white-space: pre;       /* do not wrap -> stable height */
   line-height: 18px;      /* must match logItemSize */
-  padding: 0;
+  padding: 0 0 0 10px;
   margin: 0;
   background-color: #0D1117;
 
   /* optional: allow horizontal scroll for long lines */
   overflow-x: auto;
   overflow-y: hidden;
+}
+
+.download-icon {
+  margin-right: 8px;
+  vertical-align: middle;
+  font-size: 1.15rem;
+  line-height: 1;
 }
 
 :host ::ng-deep .ansi-red { color: #ff0000 !important; }

--- a/main/http_server/axe-os/src/app/pages/system/system.component.scss
+++ b/main/http_server/axe-os/src/app/pages/system/system.component.scss
@@ -11,24 +11,36 @@
     width: 200px;
 }
 
-#logs {
-    height: 100svh;
-    font-family: monospace;
-    border: 1px solid var(--border-basic-color-3);
-    overflow-y: scroll;
-    overflow-x: hidden;
-    background-color: var(--background-basic-color-3);
-    >div {
-        max-width: 100%;
-        line-break: anywhere;
-        font-family: 'Courier New', Courier, monospace;
-    }
+.logs-viewport {
+  height: 70vh;
+  width: 100%;
+  display: block;
+  overflow: auto;
+  contain: strict;
+  will-change: scroll-position;
+  background-color: #0D1117;
+
+  font-family: ui-monospace, monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New";
+  white-space: pre; /* stable wrapping for terminal-like logs */
 }
 
+/* Virtual scroll internal wrapper stability */
+.logs-viewport .cdk-virtual-scroll-content-wrapper {
+  contain: content;
+}
+
+/* Each log line must have stable, exact height = logItemSize */
 .log-entry {
-    font-family: monospace;
-    white-space: pre-wrap;
-    word-wrap: break-word;
+  font-family: ui-monospace, monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New";
+  white-space: pre;       /* do not wrap -> stable height */
+  line-height: 18px;      /* must match logItemSize */
+  padding: 0;
+  margin: 0;
+  background-color: #0D1117;
+
+  /* optional: allow horizontal scroll for long lines */
+  overflow-x: auto;
+  overflow-y: hidden;
 }
 
 :host ::ng-deep .ansi-red { color: #ff0000 !important; }

--- a/main/http_server/axe-os/src/app/pages/system/system.component.ts
+++ b/main/http_server/axe-os/src/app/pages/system/system.component.ts
@@ -1,30 +1,129 @@
-import { AfterViewChecked, Component, ElementRef, OnDestroy, ViewChild } from '@angular/core';
-import { interval, map, tap, catchError, of, Observable, shareReplay, startWith, Subscription, switchMap } from 'rxjs';
+import {
+  AfterViewInit,
+  ChangeDetectionStrategy,
+  ChangeDetectorRef,
+  Component,
+  NgZone,
+  OnDestroy,
+  ViewChild,
+} from '@angular/core';
+import {
+  bufferTime,
+  catchError,
+  filter as rxFilter,
+  interval,
+  map,
+  Observable,
+  of,
+  shareReplay,
+  startWith,
+  Subscription,
+  switchMap,
+  tap,
+} from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
+import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
+
+import { NbThemeService, NbToastrService } from '@nebular/theme';
+import { TranslateService } from '@ngx-translate/core';
+
+import { ISystemInfo } from '../../models/ISystemInfo';
+import { LoadingService } from '../../services/loading.service';
+import { OtpAuthService, EnsureOtpResult } from '../../services/otp-auth.service';
 import { SystemService } from '../../services/system.service';
 import { WebsocketService } from '../../services/web-socket.service';
-import { ISystemInfo } from '../../models/ISystemInfo';
-import { NbToastrService, NbThemeService } from '@nebular/theme';
-import { TranslateService } from '@ngx-translate/core';
-import { HttpErrorResponse, HttpEventType } from '@angular/common/http';
-import { OtpAuthService, EnsureOtpResult, EnsureOtpOptions } from '../../services/otp-auth.service';
-import { LoadingService } from '../../services/loading.service';
+
+type LogLine = { id: number; text: string };
+
+type LogsLockRecord = { ownerId: string; ts: number };
+type LogsBroadcastMessage =
+  | { type: 'LOCK_ACQUIRED'; ownerId: string }
+  | { type: 'LOCK_RELEASED'; ownerId: string };
 
 @Component({
   selector: 'app-logs',
   templateUrl: './system.component.html',
-  styleUrl: './system.component.scss'
+  styleUrls: ['./system.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SystemComponent implements OnDestroy, AfterViewChecked {
-  @ViewChild('scrollContainer') private scrollContainer!: ElementRef;
+export class SystemComponent implements OnDestroy, AfterViewInit {
+  /** Virtual scroll viewport used for high-performance log rendering. */
+  @ViewChild('viewport') viewport?: CdkVirtualScrollViewport;
+
+  /** Periodic system info stream. */
   public info$: Observable<ISystemInfo>;
 
-  public logs: string[] = [];
-  public logFilterText: string = '';
-  public showLogs = false;
-  public stopScroll = false;
-  public logoPrefix: string = '';
+  /** Full log buffer (capped by `maxLogs`). */
+  public logs: LogLine[] = [];
 
+  /** Filtered view of logs used by the virtual scroll viewport. */
+  public filteredLogs: LogLine[] = [];
+
+  /** Current log filter query. */
+  public logFilterText = '';
+
+  /** Whether the log viewer is visible and websocket is active. */
+  public showLogs = false;
+
+  /** Whether automatic scrolling is paused by user. */
+  public stopScroll = false;
+
+  /** Used to select light/dark logo variants. */
+  public logoPrefix = '';
+
+  /** Virtual scroll tuning (must match SCSS line-height). */
+  public logItemSize = 18;
+  public minBufferPx = 18 * 20;
+  public maxBufferPx = 18 * 80;
+
+  /** Adaptive max log count (updated from device heap). */
+  private maxLogs = 3000;
+
+  /** Monotonic ID for stable `trackBy` in virtual scroll. */
+  private nextLogId = 1;
+
+  /** Subscription to websocket stream. */
   private websocketSubscription?: Subscription;
+
+  /** True while a simple "scrollToIndex" RAF is pending (legacy helper). */
+  private pendingScroll = false;
+
+  /** "Sticky bottom" threshold in pixels. */
+  private readonly SCROLL_STICKY_THRESHOLD_PX = 120;
+
+  /** Active RAF id for smooth-follow animation loop. */
+  private scrollRafId: number | null = null;
+
+  /** Smooth-follow target scroll offset (px). */
+  private scrollTargetOffset = 0;
+
+  /** Ensures we queue at most one "follow update" RAF at a time. */
+  private followRafScheduled = false;
+
+  /** Storage key used for cross-tab master lock. */
+  private readonly LOGS_LOCK_KEY = 'logs_ws_master';
+
+  /** Unique tab identifier used as lock owner. */
+  private readonly TAB_ID =
+    typeof crypto !== 'undefined' && 'randomUUID' in crypto ? crypto.randomUUID() : `${Date.now()}-${Math.random()}`;
+
+  /** BroadcastChannel for cross-tab lock coordination (if supported). */
+  private bc?: BroadcastChannel;
+
+  /** True if another tab currently holds the lock. */
+  public logsLockedByOtherTab = false;
+
+  /** Owner id of the tab holding the lock (debug/info). */
+  public logsLockOwnerId: string | null = null;
+
+  /** Heartbeat timer id to keep lock fresh while logs are running. */
+  private lockHeartbeatTimer?: number;
+
+  /** Event handler references (so we can remove them). */
+  private onPageHide = () => {
+    this.cleanupWebsocket();
+    this.releaseLogsLock();
+  };
 
   constructor(
     private websocketService: WebsocketService,
@@ -34,6 +133,8 @@ export class SystemComponent implements OnDestroy, AfterViewChecked {
     private loadingService: LoadingService,
     private translateService: TranslateService,
     private otpAuth: OtpAuthService,
+    private ngZone: NgZone,
+    private cdr: ChangeDetectorRef
   ) {
     this.logoPrefix = themeService.currentTheme === 'default' ? '' : '_dark';
 
@@ -46,98 +147,469 @@ export class SystemComponent implements OnDestroy, AfterViewChecked {
         info.current = parseFloat((info.current / 1000).toFixed(1));
         info.coreVoltageActual = parseFloat((info.coreVoltageActual / 1000).toFixed(2));
         info.coreVoltage = parseFloat((info.coreVoltage / 1000).toFixed(2));
+
+        // Adaptive memory guard for logs
+        this.updateMaxLogsFromHeap(info.freeHeap);
+
         return info;
       }),
       shareReplay({ refCount: true, bufferSize: 1 })
     );
 
-    this.themeService.onThemeChange()
-      .subscribe(themeName => {
-        this.logoPrefix = themeName.name === 'default' ? '' : '_dark';
-      });
+    this.themeService.onThemeChange().subscribe((themeName) => {
+      this.logoPrefix = themeName.name === 'default' ? '' : '_dark';
+      this.cdr.markForCheck();
+    });
   }
 
+  /**
+   * Initializes cross-tab coordination and ensures filtered view is aligned with
+   * the current log buffer.
+   */
+  ngAfterViewInit(): void {
+    this.applyFilter();
+    this.setupBroadcastChannel();
+    window.addEventListener('pagehide', this.onPageHide);
+  }
+
+  /**
+   * Cleanup: close websocket, release cross-tab lock, stop timers and channels.
+   */
   ngOnDestroy(): void {
+    window.removeEventListener('pagehide', this.onPageHide);
+
     this.cleanupWebsocket();
+    this.lockHeartbeatStop();
+    this.releaseLogsLock();
+
+    this.bc?.close();
   }
 
+  /**
+   * Unsubscribes from websocket stream and forces closing the underlying socket.
+   * This is essential to free device-side sockets and avoid httpd accept errors.
+   */
   private cleanupWebsocket(): void {
-    // Unsubscribe from messages
     this.websocketSubscription?.unsubscribe();
     this.websocketSubscription = undefined;
-
-    // And force-close underlying socket
     this.websocketService.close();
   }
 
+  /**
+   * Toggles the visibility of logs and the websocket stream.
+   *
+   * Behavior:
+   * - When turning ON: tries to acquire cross-tab lock. If another tab owns it,
+   *   shows an info message and does not connect.
+   * - When turning OFF: closes websocket, clears logs (free memory), releases lock.
+   *
+   * Input: none
+   * Output: void
+   */
   public toggleLogs() {
+    // If we are about to turn logs ON, ensure single-tab ownership
+    if (!this.showLogs) {
+      if (!this.tryAcquireLogsLock()) {
+        // Show a friendly message (translation key optional)
+        const msg =
+          this.translateService.instant('SYSTEM.LOGS_ALREADY_OPEN_OTHER_TAB') ||
+          'Logs are already open in another browser tab.';
+        const title = this.translateService.instant('COMMON.INFO') || 'Info';
+        this.toastrService.warning(msg, title);
+        return;
+      }
+    }
+
     this.showLogs = !this.showLogs;
 
     if (this.showLogs) {
-      this.websocketSubscription = this.websocketService.connect().subscribe({
-        next: (val) => {
-          const valStr = String(val);
-          if (!this.logFilterText || valStr.toLowerCase().includes(this.logFilterText.toLowerCase())) {
-            this.logs.push(valStr);
-            if (this.logs.length > 256) {
-              this.logs.shift();
-            }
-          }
-        }
+      // Ensure initial render
+      this.applyFilter();
+
+      // Keep lock alive while websocket is running
+      this.lockHeartbeatStart();
+
+      // Process websocket outside Angular; only re-enter once per batch.
+      this.ngZone.runOutsideAngular(() => {
+        this.websocketSubscription = this.websocketService
+          .connect()
+          .pipe(
+            bufferTime(50),
+            rxFilter((batch) => batch.length > 0)
+          )
+          .subscribe({
+            next: (batch) => {
+              const lines = batch.map((v) => String(v));
+              this.ngZone.run(() => this.appendLogs(lines));
+            },
+          });
       });
+
+      this.cdr.markForCheck();
     } else {
       this.cleanupWebsocket();
+      this.clearLogs();
+
+      this.lockHeartbeatStop();
+      this.releaseLogsLock();
+
+      this.cdr.markForCheck();
     }
   }
 
-  ngAfterViewChecked(): void {
-    if (this.stopScroll == true) {
+  /**
+   * Updates the maximum number of stored log lines based on free device memory.
+   * Uses conservative thresholds to reduce memory pressure from long ANSI logs.
+   *
+   * Input:
+   *  @param freeHeap number - Free heap memory reported by the device (bytes)
+   *
+   * Output: void
+   * Side effects: updates `maxLogs`
+   */
+  private updateMaxLogsFromHeap(freeHeap: number) {
+    if (!freeHeap || freeHeap <= 0) {
+      this.maxLogs = 2000;
       return;
     }
-    if (this.scrollContainer?.nativeElement != null) {
-      this.scrollContainer.nativeElement.scrollTo({ left: 0, top: this.scrollContainer.nativeElement.scrollHeight, behavior: 'smooth' });
+
+    if (freeHeap < 100_000) this.maxLogs = 1000;
+    else if (freeHeap < 200_000) this.maxLogs = 2000;
+    else if (freeHeap < 400_000) this.maxLogs = 3000;
+    else if (freeHeap < 800_000) this.maxLogs = 5000;
+    else this.maxLogs = 8000;
+  }
+
+  /**
+   * Clears all log-related state and releases memory.
+   *
+   * Responsibilities:
+   *  - Cancels any active smooth-scroll animation
+   *  - Empties log buffers (`logs` and `filteredLogs`)
+   *  - Resets internal log ID counter
+   *  - Resets viewport scroll position
+   *  - Resets autoscroll pause state
+   *  - Triggers OnPush change detection
+   *
+   * Input: none
+   * Output: void
+   */
+  private clearLogs() {
+    this.stopAutoScrollAnimation();
+
+    this.logs = [];
+    this.filteredLogs = [];
+    this.nextLogId = 1;
+
+    this.viewport?.scrollToOffset(0);
+
+    this.stopScroll = false;
+
+    this.cdr.markForCheck();
+  }
+
+  /**
+   * Applies the current `logFilterText` to the main log buffer and updates
+   * `filteredLogs` which backs the virtual scroll viewport.
+   *
+   * Input: none
+   * Output: void
+   */
+  public applyFilter() {
+    const q = (this.logFilterText || '').toLowerCase().trim();
+    this.filteredLogs = !q ? this.logs.slice() : this.logs.filter((l) => l.text.toLowerCase().includes(q));
+    this.cdr.markForCheck();
+  }
+
+  /** TrackBy function for virtual scroll to reduce DOM churn. */
+  public trackByLogId = (_: number, log: LogLine) => log.id;
+
+  /**
+   * Appends a batch of new log lines to the internal log buffer.
+   *
+   * Responsibilities:
+   *  - Converts raw string lines into LogLine objects with incremental IDs
+   *  - Appends them to the main log buffer
+   *  - Enforces the adaptive `maxLogs` limit (drops oldest entries)
+   *  - Re-applies the active text filter
+   *  - Triggers OnPush change detection
+   *  - Schedules a frame-synchronized smooth auto-scroll update
+   *
+   * Input:
+   *  @param lines string[] - Raw log lines received from the websocket (already batched)
+   *
+   * Output: void
+   */
+  private appendLogs(lines: string[]) {
+    const newLines: LogLine[] = lines.map((text) => ({
+      id: this.nextLogId++,
+      text,
+    }));
+
+    this.logs.push(...newLines);
+
+    if (this.logs.length > this.maxLogs) {
+      this.logs.splice(0, this.logs.length - this.maxLogs);
+    }
+
+    const q = (this.logFilterText || '').toLowerCase().trim();
+    this.filteredLogs = !q ? this.logs.slice() : this.logs.filter((l) => l.text.toLowerCase().includes(q));
+
+    this.cdr.markForCheck();
+
+    if (this.showLogs && !this.stopScroll) {
+      this.scheduleSmoothFollowNextFrame();
     }
   }
 
+  /**
+   * Schedules a single frame-synchronized smooth-follow update.
+   * Ensures that only one RAF callback is queued at a time.
+   *
+   * Input: none
+   * Output: void
+   */
+  private scheduleSmoothFollowNextFrame() {
+    if (this.followRafScheduled) return;
+    if (this.stopScroll) return;
+
+    this.followRafScheduled = true;
+
+    requestAnimationFrame(() => {
+      this.followRafScheduled = false;
+      this.scheduleSmoothFollowIfSticky();
+    });
+  }
+
+  /**
+   * Toggles automatic scrolling of the log viewport.
+   *
+   * STOP -> START:
+   *  - jumps immediately to the latest log line (bottom),
+   *  - then resumes smooth follow for incoming logs.
+   *
+   * START -> STOP:
+   *  - cancels any pending requestAnimationFrame based smooth scrolling.
+   *
+   * Input: none
+   * Output: void
+   */
+  public toggleScrolling() {
+    this.stopScroll = !this.stopScroll;
+
+    if (this.stopScroll) {
+      this.stopAutoScrollAnimation();
+    } else {
+      this.jumpToBottomNow();
+      this.scheduleSmoothFollowIfSticky();
+    }
+
+    this.cdr.markForCheck();
+  }
+
+  /**
+   * Cancels active smooth-follow animation driven by requestAnimationFrame.
+   *
+   * Input: none
+   * Output: void
+   */
+  private stopAutoScrollAnimation() {
+    if (this.scrollRafId !== null) {
+      cancelAnimationFrame(this.scrollRafId);
+      this.scrollRafId = null;
+    }
+    this.followRafScheduled = false;
+  }
+
+  /**
+   * Immediately scrolls the virtual viewport to the last visible log line (bottom),
+   * without animation. Also synchronizes the internal smooth-follow target.
+   *
+   * Input: none
+   * Output: void
+   */
+  private jumpToBottomNow() {
+    const vp = this.viewport;
+    if (!vp) return;
+
+    const len = this.filteredLogs.length;
+    if (len <= 0) return;
+
+    // Ensures viewport measurements/range are up-to-date (useful after show/hide/layout changes).
+    vp.checkViewportSize();
+
+    const target = Math.max(0, (len - 1) * this.logItemSize);
+    vp.scrollToOffset(target);
+
+    this.scrollTargetOffset = target;
+    this.stopAutoScrollAnimation();
+  }
+
+  /**
+   * Returns true if the user is at (or near) the bottom of the log output.
+   * Prevents autoscroll when the user manually scrolls up.
+   *
+   * Input: none
+   * Output: boolean
+   */
+  private isNearBottom(): boolean {
+    const vp = this.viewport;
+    if (!vp) return true;
+
+    const dist = vp.measureScrollOffset('bottom');
+    return dist <= this.SCROLL_STICKY_THRESHOLD_PX;
+  }
+
+  /**
+   * Schedules/resumes smooth-follow scrolling when:
+   *  - autoscroll is enabled, and
+   *  - the user is near the bottom.
+   *
+   * Input: none
+   * Output: void
+   */
+  private scheduleSmoothFollowIfSticky() {
+    if (this.stopScroll) return;
+    if (!this.isNearBottom()) return;
+
+    const len = this.filteredLogs.length;
+    if (len <= 0) return;
+
+    this.scrollTargetOffset = Math.max(0, (len - 1) * this.logItemSize);
+
+    if (this.scrollRafId === null) {
+      this.runSmoothFollow();
+    }
+  }
+
+  /**
+   * Smooth-follow animation loop.
+   * Each frame moves the scroll position a fraction towards the latest target offset,
+   * creating a soft "overlap" feel.
+   *
+   * Input: none
+   * Output: void
+   */
+  private runSmoothFollow() {
+    if (this.stopScroll) {
+      this.stopAutoScrollAnimation();
+      return;
+    }
+
+    const vp = this.viewport;
+    if (!vp) {
+      this.scrollRafId = null;
+      return;
+    }
+
+    const current = vp.measureScrollOffset('top');
+    const target = this.scrollTargetOffset;
+    const diff = target - current;
+
+    if (Math.abs(diff) < 2) {
+      vp.scrollToOffset(target);
+      this.scrollRafId = null;
+      return;
+    }
+
+    // Easing factor: smaller = smoother, larger = tighter follow.
+    const step = diff * 0.22;
+    vp.scrollToOffset(current + step);
+
+    this.scrollRafId = requestAnimationFrame(() => this.runSmoothFollow());
+  }
+
+  /**
+   * Called after filter changes to optionally keep the viewport following the bottom.
+   *
+   * Input: none
+   * Output: void
+   */
+  public onFilterMaybeScroll() {
+    if (this.showLogs && !this.stopScroll) {
+      this.scheduleSmoothFollowIfSticky();
+    }
+  }
+
+  /**
+   * (Optional legacy helper) Scrolls to the bottom using `scrollToIndex`.
+   * You generally do NOT need this when smooth follow is enabled.
+   */
+  private scheduleScrollToBottomIfSticky() {
+    if (!this.isNearBottom()) return;
+    if (this.pendingScroll) return;
+
+    this.pendingScroll = true;
+    requestAnimationFrame(() => {
+      this.pendingScroll = false;
+
+      const vp = this.viewport;
+      if (!vp) return;
+
+      const len = this.filteredLogs.length;
+      if (len > 0) {
+        vp.scrollToIndex(len - 1, 'auto');
+      }
+    });
+  }
+
+  /**
+   * Initiates device restart with OTP flow, and displays a toast notification.
+   *
+   * Input: none
+   * Output: void
+   */
   public restart() {
-    this.otpAuth.ensureOtp$(
-      "",
-      this.translateService.instant('SECURITY.OTP_TITLE'),
-      this.translateService.instant('SECURITY.OTP_HINT'),
-      { disableOtp: true },
-    )
+    this.otpAuth
+      .ensureOtp$(
+        '',
+        this.translateService.instant('SECURITY.OTP_TITLE'),
+        this.translateService.instant('SECURITY.OTP_HINT'),
+        { disableOtp: true }
+      )
       .pipe(
         switchMap(({ totp }: EnsureOtpResult) =>
-          this.systemService.restart("", totp).pipe(
-            // drop session on reboot
-            tap(() => { }),
+          this.systemService.restart('', totp).pipe(
+            tap(() => {}),
             this.loadingService.lockUIUntilComplete()
           )
         ),
         catchError((err: HttpErrorResponse) => {
-          this.toastrService.danger(this.translateService.instant('SYSTEM.RESTART_FAILED'), this.translateService.instant('COMMON.ERROR'));
+          this.toastrService.danger(
+            this.translateService.instant('SYSTEM.RESTART_FAILED'),
+            this.translateService.instant('COMMON.ERROR')
+          );
           return of(null);
         })
       )
-      .subscribe(res => {
+      .subscribe((res) => {
         if (res !== null) {
-          this.toastrService.success(this.translateService.instant('SYSTEM.RESTART_SUCCESS'), this.translateService.instant('COMMON.SUCCESS'));
+          this.toastrService.success(
+            this.translateService.instant('SYSTEM.RESTART_SUCCESS'),
+            this.translateService.instant('COMMON.SUCCESS')
+          );
         }
       });
   }
 
+  /**
+   * Initiates device shutdown with OTP flow, and displays a toast notification.
+   *
+   * Input: none
+   * Output: void
+   */
   public shutdown() {
-    this.otpAuth.ensureOtp$(
-      "",
-      this.translateService.instant('SECURITY.OTP_TITLE'),
-      this.translateService.instant('SECURITY.OTP_HINT'),
-      { disableOtp: true },
-    )
+    this.otpAuth
+      .ensureOtp$(
+        '',
+        this.translateService.instant('SECURITY.OTP_TITLE'),
+        this.translateService.instant('SECURITY.OTP_HINT'),
+        { disableOtp: true }
+      )
       .pipe(
         switchMap(({ totp }: EnsureOtpResult) =>
-          this.systemService.shutdown("", totp).pipe(
-            // drop session on shutdown
-            tap(() => { }),
+          this.systemService.shutdown('', totp).pipe(
+            tap(() => {}),
             this.loadingService.lockUIUntilComplete()
           )
         ),
@@ -149,7 +621,7 @@ export class SystemComponent implements OnDestroy, AfterViewChecked {
           return of(null);
         })
       )
-      .subscribe(res => {
+      .subscribe((res) => {
         if (res !== null) {
           this.toastrService.success(
             this.translateService.instant('SYSTEM.SHUTDOWN_SUCCESS'),
@@ -159,7 +631,14 @@ export class SystemComponent implements OnDestroy, AfterViewChecked {
       });
   }
 
-
+  /**
+   * Returns a translated tooltip string based on RSSI levels.
+   *
+   * Input:
+   *  @param rssi number - WiFi RSSI in dBm
+   * Output:
+   *  string - translated tooltip label
+   */
   public getRssiTooltip(rssi: number): string {
     if (rssi <= -85) return this.translateService.instant('SYSTEM.SIGNAL_VERY_WEAK');
     if (rssi <= -75) return this.translateService.instant('SYSTEM.SIGNAL_WEAK');
@@ -168,12 +647,166 @@ export class SystemComponent implements OnDestroy, AfterViewChecked {
     return this.translateService.instant('SYSTEM.SIGNAL_EXCELLENT');
   }
 
+  /**
+   * Computes boot time from uptime seconds.
+   *
+   * Input:
+   *  @param uptimeSeconds number - device uptime in seconds
+   * Output:
+   *  number - timestamp (ms since epoch)
+   */
   public getBootTime(uptimeSeconds: number): number {
     return Date.now() - uptimeSeconds * 1000;
   }
 
+  /**
+   * Opens an external URL in a new tab with safe flags.
+   *
+   * Input:
+   *  @param url string - destination
+   * Output: void
+   */
   openLink(url: string): void {
-    // Open external link in a new tab
     window.open(url, '_blank', 'noopener,noreferrer');
+  }
+
+  /**
+   * Sets up BroadcastChannel listeners used to coordinate which tab is allowed
+   * to own the websocket connection.
+   *
+   * Input: none
+   * Output: void
+   */
+  private setupBroadcastChannel() {
+    if (!('BroadcastChannel' in window)) return;
+
+    this.bc = new BroadcastChannel('logs_ws_channel');
+    this.bc.onmessage = (ev) => {
+      const msg = ev.data as LogsBroadcastMessage;
+      if (!msg?.type) return;
+
+      if (msg.type === 'LOCK_ACQUIRED' && msg.ownerId !== this.TAB_ID) {
+        this.logsLockedByOtherTab = true;
+        this.logsLockOwnerId = msg.ownerId;
+        this.cdr.markForCheck();
+      }
+
+      if (msg.type === 'LOCK_RELEASED') {
+        this.logsLockedByOtherTab = false;
+        this.logsLockOwnerId = null;
+        this.cdr.markForCheck();
+      }
+    };
+  }
+
+  /**
+   * Tries to acquire the "logs master" lock. Only the lock owner may open the websocket.
+   * Uses a stale timeout so the lock can be recovered if a tab crashes.
+   *
+   * Input: none
+   * Output: boolean - true if this tab acquired the lock and may start logs.
+   */
+  private tryAcquireLogsLock(): boolean {
+    const now = Date.now();
+    const raw = localStorage.getItem(this.LOGS_LOCK_KEY);
+
+    if (raw) {
+      try {
+        const lock = JSON.parse(raw) as LogsLockRecord;
+
+        // If lock is fresh and owned by another tab, deny
+        const isFresh = (now - (lock.ts ?? 0)) < 15_000;
+        if (lock?.ownerId && lock.ownerId !== this.TAB_ID && isFresh) {
+          this.logsLockedByOtherTab = true;
+          this.logsLockOwnerId = lock.ownerId;
+          return false;
+        }
+      } catch {
+        // ignore and overwrite below
+      }
+    }
+
+    // Acquire lock for this tab
+    localStorage.setItem(this.LOGS_LOCK_KEY, JSON.stringify({ ownerId: this.TAB_ID, ts: now } as LogsLockRecord));
+    this.logsLockedByOtherTab = false;
+    this.logsLockOwnerId = this.TAB_ID;
+
+    // Notify other tabs
+    this.bc?.postMessage({ type: 'LOCK_ACQUIRED', ownerId: this.TAB_ID } satisfies LogsBroadcastMessage);
+
+    return true;
+  }
+
+  /**
+   * Refreshes the lock heartbeat timestamp so other tabs know this owner is still alive.
+   *
+   * Input: none
+   * Output: void
+   */
+  private refreshLogsLockHeartbeat() {
+    const raw = localStorage.getItem(this.LOGS_LOCK_KEY);
+    if (!raw) return;
+
+    try {
+      const lock = JSON.parse(raw) as LogsLockRecord;
+      if (lock.ownerId === this.TAB_ID) {
+        localStorage.setItem(this.LOGS_LOCK_KEY, JSON.stringify({ ownerId: this.TAB_ID, ts: Date.now() } as LogsLockRecord));
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  /**
+   * Releases the lock if (and only if) it is owned by this tab.
+   *
+   * Input: none
+   * Output: void
+   */
+  private releaseLogsLock() {
+    const raw = localStorage.getItem(this.LOGS_LOCK_KEY);
+    if (!raw) {
+      this.logsLockedByOtherTab = false;
+      this.logsLockOwnerId = null;
+      return;
+    }
+
+    try {
+      const lock = JSON.parse(raw) as LogsLockRecord;
+      if (lock.ownerId === this.TAB_ID) {
+        localStorage.removeItem(this.LOGS_LOCK_KEY);
+        this.bc?.postMessage({ type: 'LOCK_RELEASED', ownerId: this.TAB_ID } satisfies LogsBroadcastMessage);
+      }
+    } catch {
+      localStorage.removeItem(this.LOGS_LOCK_KEY);
+    }
+
+    this.logsLockedByOtherTab = false;
+    this.logsLockOwnerId = null;
+  }
+
+  /**
+   * Starts periodic heartbeat updates while logs are active, preventing other tabs
+   * from treating this lock as stale.
+   *
+   * Input: none
+   * Output: void
+   */
+  private lockHeartbeatStart() {
+    this.lockHeartbeatStop();
+    this.lockHeartbeatTimer = window.setInterval(() => this.refreshLogsLockHeartbeat(), 5000);
+  }
+
+  /**
+   * Stops periodic lock heartbeat updates.
+   *
+   * Input: none
+   * Output: void
+   */
+  private lockHeartbeatStop() {
+    if (this.lockHeartbeatTimer) {
+      clearInterval(this.lockHeartbeatTimer);
+      this.lockHeartbeatTimer = undefined;
+    }
   }
 }

--- a/main/http_server/axe-os/src/app/pages/system/system.component.ts
+++ b/main/http_server/axe-os/src/app/pages/system/system.component.ts
@@ -76,8 +76,8 @@ export class SystemComponent implements OnDestroy, AfterViewInit {
   public minBufferPx = 18 * 20;
   public maxBufferPx = 18 * 80;
 
-  /** Adaptive max log count (updated from device heap). */
-  private maxLogs = 3000;
+  /** Max log count (fixed limit). */
+  private maxLogs = 10000;
 
   /** Monotonic ID for stable `trackBy` in virtual scroll. */
   private nextLogId = 1;
@@ -148,7 +148,7 @@ export class SystemComponent implements OnDestroy, AfterViewInit {
         info.coreVoltageActual = parseFloat((info.coreVoltageActual / 1000).toFixed(2));
         info.coreVoltage = parseFloat((info.coreVoltage / 1000).toFixed(2));
 
-        // Adaptive memory guard for logs
+        // Fixed log limit (independent of device heap)
         this.updateMaxLogsFromHeap(info.freeHeap);
 
         return info;
@@ -258,26 +258,17 @@ export class SystemComponent implements OnDestroy, AfterViewInit {
   }
 
   /**
-   * Updates the maximum number of stored log lines based on free device memory.
-   * Uses conservative thresholds to reduce memory pressure from long ANSI logs.
+   * Sets the maximum number of stored log lines.
+   * The limit is fixed to 10,000 lines (independent of device free heap).
    *
    * Input:
-   *  @param freeHeap number - Free heap memory reported by the device (bytes)
+   *  @param _freeHeap number - Free heap memory reported by the device (bytes)
    *
    * Output: void
    * Side effects: updates `maxLogs`
    */
-  private updateMaxLogsFromHeap(freeHeap: number) {
-    if (!freeHeap || freeHeap <= 0) {
-      this.maxLogs = 2000;
-      return;
-    }
-
-    if (freeHeap < 100_000) this.maxLogs = 1000;
-    else if (freeHeap < 200_000) this.maxLogs = 2000;
-    else if (freeHeap < 400_000) this.maxLogs = 3000;
-    else if (freeHeap < 800_000) this.maxLogs = 5000;
-    else this.maxLogs = 8000;
+  private updateMaxLogsFromHeap(_freeHeap: number) {
+    this.maxLogs = 10000;
   }
 
   /**
@@ -330,7 +321,7 @@ export class SystemComponent implements OnDestroy, AfterViewInit {
    * Responsibilities:
    *  - Converts raw string lines into LogLine objects with incremental IDs
    *  - Appends them to the main log buffer
-   *  - Enforces the adaptive `maxLogs` limit (drops oldest entries)
+   *  - Enforces the `maxLogs` limit (drops oldest entries)
    *  - Re-applies the active text filter
    *  - Triggers OnPush change detection
    *  - Schedules a frame-synchronized smooth auto-scroll update

--- a/main/http_server/axe-os/src/app/pages/system/system.component.ts
+++ b/main/http_server/axe-os/src/app/pages/system/system.component.ts
@@ -33,7 +33,7 @@ import { OtpAuthService, EnsureOtpResult } from '../../services/otp-auth.service
 import { SystemService } from '../../services/system.service';
 import { WebsocketService } from '../../services/web-socket.service';
 
-type LogLine = { id: number; text: string };
+type LogLine = { id: number; text: string; ts: number };
 
 type LogsLockRecord = { ownerId: string; ts: number };
 type LogsBroadcastMessage =
@@ -335,6 +335,7 @@ export class SystemComponent implements OnDestroy, AfterViewInit {
     const newLines: LogLine[] = lines.map((text) => ({
       id: this.nextLogId++,
       text,
+      ts: Date.now(),
     }));
 
     this.logs.push(...newLines);
@@ -800,4 +801,81 @@ export class SystemComponent implements OnDestroy, AfterViewInit {
       this.lockHeartbeatTimer = undefined;
     }
   }
+
+
+  public formatLogForUi(text: string): string {
+    // Replace ESC[0;32mI -> ESC[0;32m₿ (keeps original ANSI styling)
+    return (text ?? '').replace(/\x1b\[0;32mI/g, '\x1b[0;32m₿');
+  }
+
+  public downloadLogs(): void {
+    const content = this.buildDownloadTextFromLogs();
+    const blob = new Blob([content], { type: 'text/plain;charset=utf-8' });
+
+    const url = window.URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = `logs_${this.formatFilenameStamp(new Date())}.txt`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    window.URL.revokeObjectURL(url);
+  }
+
+  private buildDownloadTextFromLogs(): string {
+    const out: string[] = [];
+
+    for (const l of this.logs) {
+      const time = this.formatHms(l.ts);
+
+      const rawLines = String(l.text ?? '').split(/\r?\n/);
+      for (const raw of rawLines) {
+        const cleaned = this.cleanLogLineForExport(raw);
+        if (!cleaned) continue;
+        out.push(`${time} ${cleaned}`);
+      }
+    }
+
+    return out.join('\n') + (out.length ? '\n' : '');
+  }
+
+  private cleanLogLineForExport(line: string): string {
+    let t = String(line ?? '');
+
+    // Replace the colored "I" marker directly (if present)
+    t = t.replace(/\x1b\[0;32mI/g, '₿');
+
+    // Strip ANSI sequences for a clean text file
+    t = this.stripAnsi(t);
+
+    // If it already starts with a plain "I ", convert that too
+    t = t.replace(/^I(\s)/, '₿$1');
+
+    // Drop empty lines
+    t = t.replace(/\r/g, '').trimEnd();
+    return t.trim().length ? t : '';
+  }
+
+  private stripAnsi(text: string): string {
+    return String(text ?? '').replace(/\x1b\[[0-9;]*m/g, '');
+  }
+
+  private formatHms(ts: number): string {
+    const d = new Date(ts);
+    const hh = String(d.getHours()).padStart(2, '0');
+    const mm = String(d.getMinutes()).padStart(2, '0');
+    const ss = String(d.getSeconds()).padStart(2, '0');
+    return `${hh}:${mm}:${ss}`;
+  }
+
+  private formatFilenameStamp(d: Date): string {
+    const yyyy = d.getFullYear();
+    const mm = String(d.getMonth() + 1).padStart(2, '0');
+    const dd = String(d.getDate()).padStart(2, '0');
+    const hh = String(d.getHours()).padStart(2, '0');
+    const mi = String(d.getMinutes()).padStart(2, '0');
+    const ss = String(d.getSeconds()).padStart(2, '0');
+    return `${yyyy}${mm}${dd}_${hh}${mi}${ss}`;
+  }
+
 }

--- a/main/http_server/axe-os/src/app/pages/system/system.module.ts
+++ b/main/http_server/axe-os/src/app/pages/system/system.module.ts
@@ -1,10 +1,11 @@
 import { NgModule } from '@angular/core';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { NbCardModule, NbButtonModule, NbIconModule } from '@nebular/theme';
+import { NbCardModule, NbButtonModule, NbIconModule, NbAlertModule } from '@nebular/theme';
 import { TranslateModule } from '@ngx-translate/core';
 import { SystemComponent } from './system.component';
-import { PipesModule} from '../../pipes/pipes.module';
+import { PipesModule } from '../../pipes/pipes.module';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 @NgModule({
   declarations: [
@@ -16,9 +17,11 @@ import { PipesModule} from '../../pipes/pipes.module';
     FormsModule,
     NbCardModule,
     NbButtonModule,
+    NbIconModule,
+    NbAlertModule,
     TranslateModule,
     PipesModule,
-    NbIconModule,
+    ScrollingModule,
   ],
   exports: [
     SystemComponent

--- a/main/http_server/axe-os/src/app/services/web-socket.service.ts
+++ b/main/http_server/axe-os/src/app/services/web-socket.service.ts
@@ -20,12 +20,25 @@ export class WebsocketService implements OnDestroy {
   }
 
   public close(): void {
-    // Ensure underlying websocket is really closed
-    if (this.socket$ && !this.socket$.closed) {
-      // complete() schickt Close-Frame und schließt den Socket
-      this.socket$.complete();
+    if (!this.socket$) return;
+
+    try {
+      // 1) Try to close gracefully (sends a Close frame)
+      if (!this.socket$.closed) {
+        this.socket$.complete();
+      }
+      // 2) Ensure the underlying native WebSocket is closed as well.
+      // RxJS WebSocketSubject wraps the native socket; in some shutdown scenarios
+      // (tab close / reload) we want to be extra sure the connection is terminated.
+      const ws: WebSocket | undefined = (this.socket$ as any)?._socket;
+      if (ws && (ws.readyState === WebSocket.OPEN || ws.readyState === WebSocket.CONNECTING)) {
+        ws.close(1000, 'client closing');
+      }
+    } catch {
+      // Ignore close errors — we just want to prevent leaking sockets
+    } finally {
+      this.socket$ = undefined;
     }
-    this.socket$ = undefined;
   }
 
   ngOnDestroy(): void {

--- a/main/http_server/axe-os/src/assets/i18n/de.json
+++ b/main/http_server/axe-os/src/assets/i18n/de.json
@@ -200,7 +200,8 @@
     "ABOUT_NERDQX_ORIGINAL": " <u>hier</u>",
     "SHUTDOWN": "Shutdown",
     "SHUTDOWN_SUCCESS": "System wird heruntergefahren",
-    "SHUTDOWN_FAILED": "Shutdown fehlgeschlagen"
+    "SHUTDOWN_FAILED": "Shutdown fehlgeschlagen",
+    "LOGS_ALREADY_OPEN_OTHER_TAB": "Logs sind bereits in einem anderen Tab geöffnet."
   },
   "SWARM": {
     "TITLE": "Schwarm-Verwaltung",

--- a/main/http_server/axe-os/src/assets/i18n/en.json
+++ b/main/http_server/axe-os/src/assets/i18n/en.json
@@ -200,7 +200,8 @@
     "ABOUT_NERDQX_ORIGINAL": " <u>here</u>",
     "SHUTDOWN": "Shutdown",
     "SHUTDOWN_SUCCESS": "System is shutting down",
-    "SHUTDOWN_FAILED": "Shutdown failed"
+    "SHUTDOWN_FAILED": "Shutdown failed",
+    "LOGS_ALREADY_OPEN_OTHER_TAB": "Logs are already open in another tab."
   },
   "SWARM": {
     "TITLE": "Swarm Management",

--- a/main/http_server/axe-os/src/assets/i18n/es.json
+++ b/main/http_server/axe-os/src/assets/i18n/es.json
@@ -200,7 +200,8 @@
     "ABOUT_NERDQX_ORIGINAL": " <u>aquí</u>",
     "SHUTDOWN": "Apagar",
     "SHUTDOWN_SUCCESS": "El sistema se está apagando",
-    "SHUTDOWN_FAILED": "Error al apagar el sistema"
+    "SHUTDOWN_FAILED": "Error al apagar el sistema",
+    "LOGS_ALREADY_OPEN_OTHER_TAB": "Los registros ya están abiertos en otra pestaña."
   },
   "SWARM": {
     "TITLE": "Gestión de Enjambre",

--- a/main/http_server/axe-os/src/assets/i18n/fr.json
+++ b/main/http_server/axe-os/src/assets/i18n/fr.json
@@ -200,7 +200,8 @@
     "ABOUT_NERDQX_ORIGINAL": " <u>ici</u>",
     "SHUTDOWN": "Arrêt",
     "SHUTDOWN_SUCCESS": "Le système est en cours d’arrêt",
-    "SHUTDOWN_FAILED": "Échec de l’arrêt du système"
+    "SHUTDOWN_FAILED": "Échec de l’arrêt du système",
+    "LOGS_ALREADY_OPEN_OTHER_TAB": "Les journaux sont déjà ouverts dans un autre onglet."
   },
   "SWARM": {
     "TITLE": "Gestion d'Essaim",


### PR DESCRIPTION
- Clicking “Show Logs” displays the logs across the entire page based on the viewport. The ‘Overview’ block is hidden.
- Clicking “Hide Logs” displays the “Overview” block again.
- Significantly improved filter function that also filters previous log entries and not just new ones after entering the filter.
- Memory is immediately freed up and previous logs are unloaded when you click on “Hide Logs.”
- Also functional in mobile viewports, in all theme variants.
- See below for details
- Tested with the log window open for over an hour, everything stable and functional.

<img width="1858" height="1153" alt="image" src="https://github.com/user-attachments/assets/3bbdbc72-1929-4403-9a06-76a2e62c4d59" />

# New features
- High-performance log rendering via cdk-virtual-scroll-viewport
-- Renders only the visible log lines instead of thousands of DOM nodes at once.
-- Result: significantly less DOM churn, more stable FPS, lower CPU load – especially at high log rates.
- Smooth “terminal-like” auto-scroll (soft follow)
-- Instead of hard scrollToBottom per line, a smooth follow mechanism runs (easing per requestAnimationFrame).
-- High-performance log rendering via cdk-virtual-scroll-viewport
-- Result: less “jumping,” better reading experience, no jerky jumps at high frequencies.
- Stop/start scrolling with “jump to bottom” on restart
-- “Stop scrolling” freezes the auto-scroll logic.
-- “Start scrolling” immediately jumps to the last entry and then continues with smooth follow.
- Cross-tab protection: only one tab may open logs/WebSocket (locking)
-- With localStoragelock + heartbeat + optional BroadcastChannelcoordination.
-- Result: prevents multiple parallel WebSocket connections with multiple browser tabs.
- UI note when logs are open in another tab
-- nb-alertinforms the user why “Show logs” is not connecting.
-- Internationalized via translation key.
- Memory release when “Hide Logs”
-- When deactivating: Close WebSocket, empty arrays, reset IDs, stop scroll animation.
-- Result: RAM in the browser is freed up, device is relieved, “fresh start” when next opened.
---
# Improvements / Optimizations
- WebSocket processing “outside Angular” + batch UI updates
-- ngZone.runOutsideAngular() + bufferTime(50) massively reduces change detection/rendering pressure.
-- Result: UI remains responsive, fewer CPU spikes, better performance on weak devices.
- Frame-synchronous update scheduling instead of setTimeout
-- Auto-scroll trigger is planned via requestAnimationFrame (instead of setTimeout).
-- Result: Updates happen precisely in time with the render cycle → less stuttering/jumps.
- OnPush ChangeDetection for log part
-- ChangeDetectionStrategy.OnPush + targeted markForCheck().
-- Result: Angular only renders when necessary, instead of with every WebSocket event.
- Stable trackBy for log lines
-- Each log line gets a monotonous id.
-- Result: Virtual Scroll can make optimal use of DOM reuse, fewer re-renders.
- (Optional) Adaptive log buffer limits (MAX_LOGS dependent on freeHeap)
-- Dynamic limit instead of static 3000.
-- Result: more aggressive limiting (more stable) on devices with little RAM, more history on devices with more RAM.
---
# Why these changes were necessary (problem → solution)
- Problem: UI lags/jumps at high log rates
-- Cause: many DOM elements + frequent scroll instructions + ChangeDetection per event.
-- Solution: Virtual scroll + batching + OnPush + RAF smooth follow.
- Problem: Logs are not “live” or appear delayed
-- Cause: Individual events lead to rendering overhead; browser “throttled” updates.
-- Solution: bufferTime(50) (or fine-tuning) + only enter Angular once per batch.
- Problem: Device becomes “unreachable” after a long period of time, httpd_accept_conn (23)
-- Cause: Too many open connections (HTTP keep-alive + multiple WebSockets per tab) → Socket/FD limit on ESP.
-- Solution: Cross-tab lock, clean close/release when “Hide Logs” and tab end (pagehide).
- Problem: Stop/start scrolling did not behave as expected
-- Cause: Sticky-bottom logic blocks when user scrolled up.
-- Solution: Explicit jumpToBottomNow() + smooth follow afterwards when “start scrolling”.
- Problem: Hide Logs should free up memory
-- Cause: Arrays + possibly ANSI rendering + scroll RAF remain in memory.
-- Solution: clearLogs()empties buffers, stops RAF, resets IDs, optional viewport reset.
---
# Notable Implementation Decisions
- Why virtual scroll instead of “just CSS height/overflow”?
-- CSS overflow does not prevent 3000+ nodes from being in the DOM.
-- Virtual scroll scales at high log rates because the DOM remains consistently small.
- Why bufferTime(50) instead of bufferTime(0)?
-- 0ms almost generates event-per-event updates again → CPU/DOM overhead.
-- 50ms is a good tradeoff: “almost live” + significantly less rendering load.
- Why requestAnimationFrame instead of setTimeout?
-- RAF is render-synchronous and results in smoother movements.
-- setTimeout can fire in the middle of a frame → visual stuttering.
- Why cross-tab lock via localStorage + heartbeat?
-- Only one WebSocket per device prevents FD/socket exhaustion.
-- Heartbeat prevents “hanging locks” when tabs crash (stale timeout).
---
# Changes to modules / dependencies
- NbAlertModule imported
-- So that nb-alert is available in the template.
- ScrollingModule already necessary (CDK Virtual Scroll)
## i18n / Translation additions
- New key(s), e.g.:
-- SYSTEM.LOGS_ALREADY_OPEN_OTHER_TAB
-- (optional) SYSTEM.LOGS_LOCK_RELEASED / SYSTEM.LOGS_LOCK_ACQUIRED if you want more UI feedback