### PR TITLE
Bump up fault current to 160A on NerdOctaxe Gamma with TPS53647

### DIFF
--- a/main/boards/nerdoctaxegamma.cpp
+++ b/main/boards/nerdoctaxegamma.cpp
@@ -79,7 +79,7 @@ NerdOctaxeGamma::NerdOctaxeGamma() : NerdQaxePlus2() {
         // Configure for 4-phase operation (uses inherited frequency limits)
         m_numPhases = 4;
         m_imax = 180;        // 33.2kΩ → 180A max (45A per phase with 4 phases)
-        m_ifault = 140.0;
+        m_ifault = 160.0;
         m_maxPin = 200.0;
         m_minPin = 100.0;
         m_minCurrentA = 0.0f;


### PR DESCRIPTION
For most Nerd* miners fault current is set 5A below max current, for Octaxe with TPS53647 it is set 40A below the max, which causes OC error on some boards that normally run at about 130A, but occasionally can jump over 140A for short periods of time. Bumping up fault current to 160A, 20A below the set max of 180A fixes the issue and should still be considered safe.