### PR TITLE
Warmup logic & MISC

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/README.md
+++ b/main/http_server/axe-os/src/app/pages/home/README.md
@@ -99,7 +99,41 @@ When loading, best-effort migration is performed (v0/v1 shapes are accepted) and
 ## Debug Hooks
 
 `chart/home.debug-hooks.ts` installs `globalThis.__nerdCharts`.
-Typical keys:
+
+### Enable hooks
+Some builds only install the lightweight bootstrap. In that case, run:
+
+```js
+__nerdCharts.enable(true)  // persist across reloads
+// or:
+__nerdCharts.enable()
+```
+
+You can inspect available commands via:
+
+```js
+__nerdCharts.list()
+__nerdCharts.help()
+```
+
+### Useful commands
+
+```js
+// Clear history (in-memory, immediate)
+__nerdCharts.clearChartHistoryNow()
+
+// Clear history once (persists a flag + seeds timestamps; reload to apply)
+__nerdCharts.clearChartHistoryOnce(); location.reload()
+
+// Force a render tick of the history-drain loop
+__nerdCharts.flushHistoryDrainRender()
+
+// Restart device (optional hook; may require a TOTP depending on backend configuration)
+__nerdCharts.restart()
+__nerdCharts.restart("123456")
+```
+
+### Storage keys (typical)
 - `__nerdCharts_debugMode` (debug active)
 - `__nerdCharts_axisPaddingOverrideEnabled` / `__nerdCharts_axisPadding` (axis padding overrides)
 - `__nerdCharts_clearChartHistoryOnce` (delete once)
@@ -137,6 +171,11 @@ The defaults are logically grouped in `HOME_CFG`. Here is a practical overview (
 - minimum tick steps (more stable axis for small ranges)
 - used in: `chart/home.axis-scale.ts`
 
+**Axis / X viewport**
+- `HOME_CFG.xAxis.fixedWindowMs`
+- Implemented time window for the X axis (milliseconds). Keeps the viewport stable (e.g. always show the last 1h), even if there are only a few points.
+- Used in: `home.component.experimental.ts` (sets `scales.x.min/max`), `chart/home.axis-scale.ts` (bounds computed for the active window), `chart/home.chart-state.ts` (trim history to the same window)
+
 **Axis / “latest” views**
 - `HOME_CFG.tempScale.latestPadC`
 - Temperature axis around +/- X°C around the latest values (previously hardcoded `3`)
@@ -168,6 +207,40 @@ The defaults are logically grouped in `HOME_CFG`. Here is a practical overview (
 **Temp scale (“latest” zoom)**
 The `latest` view deliberately uses a fixed band around the latest measurement value to keep small changes visible.
 The band can be adjusted via `HOME_CFG.tempScale.latestPadC`.
+
+**Warmup / Restart gating**
+These knobs control when specific series are allowed to appear after a miner restart (to avoid “half-valid” ramps and visual chaos).
+- `HOME_CFG.warmup.tempMinValidC` / `HOME_CFG.warmup.tempMaxValidC`
+  - Plausibility bounds used to decide whether temperature samples count as “valid” for warmup sequencing.
+  - Used in: `home.warmup.ts`
+- `HOME_CFG.warmup.vregDelayMs` / `HOME_CFG.warmup.asicDelayMs` / `HOME_CFG.warmup.hash1mDelayMs`
+  - Delays (ms) between warmup stages before enabling the next plot (VR temp → ASIC temp → HR 1m).
+  - Used in: `home.warmup.ts`, `home.component.experimental.ts` (wiring)
+- `HOME_CFG.warmup.restartDetectStreak`
+  - How many consecutive “boot-like” polls are required before we treat the situation as a restart.
+  - Used in: `home.warmup.ts`
+
+**Sanitizing (raw sample → plot)**
+Invalid samples become `NaN` which produces a gap instead of a misleading line.
+- `HOME_CFG.sanitize.tempMinC` / `HOME_CFG.sanitize.tempMaxC`
+- `HOME_CFG.sanitize.hashrateMinHs`
+- Used in: `home.component.experimental.ts` (sanitizeLoadedHistory + live update path)
+
+**Startup / GraphGuard behavior**
+Tuning for how we treat hashrate steps/spikes right after a restart.
+- `HOME_CFG.startup.bypassGuardSamples`
+  - Number of initial samples per series that can bypass GraphGuard once startup is “unlocked”.
+- `HOME_CFG.startup.expectedUnlockRatio`
+  - Startup unlock ratio: live must reach `expected * ratio` before bypassing is allowed.
+- `HOME_CFG.startup.hr1mSmoothWindowMs`
+  - Length of the post-restart “super smooth” window for the 1m series (ms).
+- `HOME_CFG.startup.hr1mConfirmStartup` / `HOME_CFG.startup.hr1mConfirmNormal`
+  - GraphGuard confirmSamples used during the smooth window vs. normal running.
+- `HOME_CFG.startup.hr1mReloadAfterSmooth`
+  - Optional one-time auto-reload after the smooth window ends (only after a detected restart).
+- `HOME_CFG.startup.hr1mReloadCooldownMs`
+  - Session-scoped cooldown to prevent reload loops.
+- Used in: `home.component.experimental.ts`, `chart/home.graph-guard.ts`, `home.warmup.ts`
 
 **UI Defaults + Persistence (experimental only)**
 - `HOME_CFG.uiDefaults.viewMode` / `HOME_CFG.uiDefaults.legendHidden`

--- a/main/http_server/axe-os/src/app/pages/home/README.md
+++ b/main/http_server/axe-os/src/app/pages/home/README.md
@@ -180,6 +180,26 @@ The defaults are logically grouped in `HOME_CFG`. Here is a practical overview (
 - Tick spacing for the time axis (milliseconds). Controls the generated tick marks/labels (e.g. 15-minute labels `:00, :15, :30, :45`) without shifting the viewport end.
 - Used in: `chart/home.chart.factory.ts`
 
+- `HOME_CFG.colors.chartGridColor`
+- Gridline color of the chart. Default: `#80808040`.
+- Used in: `chart/home.chart.factory.ts`, `chart/home.chart.theme.ts`
+
+- `HOME_CFG.colors.textFallback`
+- Fallback text color if the CSS variable `--card-text-color` is not yet available (e.g., during early boot).
+- Used in: `chart/home.chart.theme.ts`
+
+- `HOME_CFG.colors.hashrateBase`
+- Base color for the hashrate series (1m/10m/1h).
+- Used in: `chart/home.chart.datasets.ts`
+
+- `HOME_CFG.colors.vregTemp` / `HOME_CFG.colors.asicTemp`
+- Line/fill colors for the temperature series.
+- Used in: `chart/home.chart.datasets.ts`
+
+- `HOME_CFG.colors.pillsText` / `HOME_CFG.colors.pillsDebugStroke`
+- Default text color and debug outline for value pills.
+- Used in: `plugins/value-pills.plugin.ts`
+
 **Axis / “latest” views**
 - `HOME_CFG.tempScale.latestPadC`
 - Temperature axis around +/- X°C around the latest values (previously hardcoded `3`)

--- a/main/http_server/axe-os/src/app/pages/home/README.md
+++ b/main/http_server/axe-os/src/app/pages/home/README.md
@@ -176,6 +176,10 @@ The defaults are logically grouped in `HOME_CFG`. Here is a practical overview (
 - Implemented time window for the X axis (milliseconds). Keeps the viewport stable (e.g. always show the last 1h), even if there are only a few points.
 - Used in: `home.component.experimental.ts` (sets `scales.x.min/max`), `chart/home.axis-scale.ts` (bounds computed for the active window), `chart/home.chart-state.ts` (trim history to the same window)
 
+- `HOME_CFG.xAxis.tickStepMs`
+- Tick spacing for the time axis (milliseconds). Controls the generated tick marks/labels (e.g. 15-minute labels `:00, :15, :30, :45`) without shifting the viewport end.
+- Used in: `chart/home.chart.factory.ts`
+
 **Axis / “latest” views**
 - `HOME_CFG.tempScale.latestPadC`
 - Temperature axis around +/- X°C around the latest values (previously hardcoded `3`)

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.axis-scale.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.axis-scale.ts
@@ -53,6 +53,27 @@ export interface ComputedAxisBounds {
   };
 }
 
+/**
+ * Compute a width X window.
+ *
+ * Chart.js will auto-fit the x-range to existing data unless min/max are set.
+ * This helper keeps the viewport stable (e.g. always 1 hour), even when only
+ * a few points exist (or right after the history has been cleared).
+ */
+export function computeXWindow(
+  labels: number[],
+  windowMs: number,
+  nowMs: number = Date.now(),
+): { xMinMs: number; xMaxMs: number } {
+  const safeWindow = Math.max(0, Math.round(Number(windowMs) || 0));
+
+  const last = Array.isArray(labels) && labels.length ? Number(labels[labels.length - 1]) : NaN;
+  const xMaxMs = Number.isFinite(last) ? Math.max(nowMs, last) : nowMs;
+  const xMinMs = xMaxMs - safeWindow;
+
+  return { xMinMs, xMaxMs };
+}
+
 function isFiniteNumber(v: any): v is number {
   return typeof v === 'number' && Number.isFinite(v);
 }

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.axis-scale.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.axis-scale.ts
@@ -136,7 +136,8 @@ export function computeAxisBounds(input: AxisScaleInputs): ComputedAxisBounds {
     const padTop = clamp(Math.max(range * padPctTop, minPadHs, flatPad), 0, maxAbs * maxPadPctOfMax);
     const padBottom = clamp(Math.max(range * padPctBottom, minPadHs, flatPad), 0, maxAbs * maxPadPctOfMax);
 
-    let adjMin = hm.mn - padBottom;
+    // Never allow negative minima (hashrate cannot be negative).
+    let adjMin = Math.max(0, hm.mn - padBottom);
     let adjMax = hm.mx + padTop;
 
     const live = input.liveRefHs;
@@ -167,8 +168,11 @@ export function computeAxisBounds(input: AxisScaleInputs): ComputedAxisBounds {
     if (stepThs < input.hashrateMinStepThs) stepThs = input.hashrateMinStepThs;
 
     const stepHs = stepThs * HS_PER_THS;
-    const minAligned = Math.floor(adjMin / stepHs) * stepHs;
+    let minAligned = Math.floor(adjMin / stepHs) * stepHs;
     const maxAligned = Math.ceil(adjMax / stepHs) * stepHs;
+
+    // Clamp again after alignment (alignment can drop slightly below 0).
+    minAligned = Math.max(0, minAligned);
 
     out.y = {
       min: minAligned,
@@ -180,7 +184,8 @@ export function computeAxisBounds(input: AxisScaleInputs): ComputedAxisBounds {
 
   // Temperature axis
   if (tm.mn !== undefined && tm.mx !== undefined) {
-    const targetMin = tm.mn - 2;
+    // Temps cannot be negative; clamp min to 0 to avoid whitespace artifacts.
+    const targetMin = Math.max(0, tm.mn - 2);
     const targetMax = tm.mx + 3;
 
     const maxTicks = Math.max(2, Math.round(Number(input.maxTicks || 7)));
@@ -197,8 +202,10 @@ export function computeAxisBounds(input: AxisScaleInputs): ComputedAxisBounds {
     }
     if (stepC < input.tempMinStepC) stepC = input.tempMinStepC;
 
-    const minAligned = Math.floor(targetMin / stepC) * stepC;
+    let minAligned = Math.floor(targetMin / stepC) * stepC;
     const maxAligned = Math.ceil(targetMax / stepC) * stepC;
+
+    minAligned = Math.max(0, minAligned);
 
     out.y_temp = {
       min: minAligned,

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.axis-scale.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.axis-scale.ts
@@ -68,7 +68,8 @@ export function computeXWindow(
   const safeWindow = Math.max(0, Math.round(Number(windowMs) || 0));
 
   const last = Array.isArray(labels) && labels.length ? Number(labels[labels.length - 1]) : NaN;
-  const xMaxMs = Number.isFinite(last) ? Math.max(nowMs, last) : nowMs;
+  const xMaxRaw = Number.isFinite(last) ? Math.max(nowMs, last) : nowMs;
+  const xMaxMs = xMaxRaw;
   const xMinMs = xMaxMs - safeWindow;
 
   return { xMinMs, xMaxMs };

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.chart.datasets.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.chart.datasets.ts
@@ -130,6 +130,8 @@ export function createHomeDatasets(opts: { t: (key: string) => string; series: H
     type: 'line',
     label: t('HOME.HASHRATE_1D'),
     data: series.hr1d,
+    hidden: true,
+    excludeFromLegend: true,
     yAxisID: 'y',
     fill: false,
     backgroundColor: hrColor(0),

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.chart.datasets.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.chart.datasets.ts
@@ -1,3 +1,5 @@
+import { HOME_CFG } from '../home.cfg';
+
 // Auto-extracted from the original HomeExperimentalComponent constructor.
 // Visual/design layer only.
 
@@ -13,7 +15,7 @@ export interface HomeChartSeriesRefs {
 
 export function createHomeDatasets(opts: { t: (key: string) => string; series: HomeChartSeriesRefs }): any[] {
   const { t, series } = opts;
-  const HR_BASE_COLOR = '#a564f6';
+  const HR_BASE_COLOR = HOME_CFG.colors.hashrateBase;
 
   function hrColor(alpha: number = 1): string {
     if (alpha >= 1) return HR_BASE_COLOR;
@@ -40,7 +42,7 @@ export function createHomeDatasets(opts: { t: (key: string) => string; series: H
     const ctx = chart?.ctx;
     const chartArea = chart?.chartArea;
 
-    const baseHex = '#2DA8B7';
+    const baseHex = HOME_CFG.colors.vregTemp;
     const topAlpha = 0.01;
     const bottomAlpha = 0.12;
 
@@ -63,7 +65,7 @@ export function createHomeDatasets(opts: { t: (key: string) => string; series: H
     const ctx = chart?.ctx;
     const chartArea = chart?.chartArea;
 
-    const baseHex = '#C84847';
+    const baseHex = HOME_CFG.colors.asicTemp;
     const topAlpha = 0.01;
     const bottomAlpha = 0.21;
 
@@ -148,7 +150,7 @@ export function createHomeDatasets(opts: { t: (key: string) => string; series: H
     data: series.vregTemp,
     yAxisID: 'y_temp',
     fill: true,
-    borderColor: '#2DA8B7',
+    borderColor: HOME_CFG.colors.vregTemp,
     backgroundColor: (context: any) => vrTempAreaGradient(context),
     tension: .4,
     cubicInterpolationMode: 'monotone',
@@ -161,7 +163,7 @@ export function createHomeDatasets(opts: { t: (key: string) => string; series: H
     data: series.asicTemp,
     yAxisID: 'y_temp',
     fill: true,
-    borderColor: '#C84847',
+    borderColor: HOME_CFG.colors.asicTemp,
     backgroundColor: (context: any) => asicTempAreaGradient(context),
     tension: .4,
     cubicInterpolationMode: 'monotone',

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.chart.factory.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.chart.factory.ts
@@ -32,6 +32,10 @@ export function createHomeChartConfig(deps: HomeChartFactoryDeps): HomeChartConf
         labels: {
           // color set by theme helper
           sort: (a: any, b: any) => a.datasetIndex - b.datasetIndex,
+          filter: (legendItem: any, data: any) => {
+            const ds = data?.datasets?.[legendItem?.datasetIndex];
+            return !ds?.excludeFromLegend;
+          },
         },
         onClick: (_evt: any, legendItem: any, legend: any) => {
           const chart = legend.chart;

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.chart.factory.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.chart.factory.ts
@@ -1,4 +1,5 @@
 import { Chart } from 'chart.js';
+import { HOME_CFG } from '../home.cfg';
 import { applyHomeDatasetRenderOrder, createHomeDatasets, HomeChartSeriesRefs } from './home.chart.datasets';
 
 export interface HomeChartFactoryDeps {
@@ -84,13 +85,40 @@ export function createHomeChartConfig(deps: HomeChartFactoryDeps): HomeChartConf
       x: {
         type: 'time',
         time: {
-          unit: 'hour',
+          // 1h viewport is enforced elsewhere via scales.x.min/max.
+          // Generate ticks every 15 minutes for a calmer, more informative axis.
+          unit: 'minute',
+          stepSize: Math.max(1, Math.round((Number(HOME_CFG.xAxis.tickStepMs) || 0) / 60000)),
           displayFormats: {
+            minute: deps.getTimeFormatIs12h() ? 'h:mm A' : 'HH:mm',
             hour: deps.getTimeFormatIs12h() ? 'h:mm A' : 'HH:mm',
           },
         },
+        // Chart.js sometimes chooses very dense minute ticks depending on adapter/locale.
+        // Force a predictable tick set at 15-minute boundaries for the current viewport.
+        afterBuildTicks: (scale: any) => {
+          const STEP_MS = Math.max(1, Math.round(Number(HOME_CFG.xAxis.tickStepMs) || 0));
+          const min = Number(scale?.min);
+          const max = Number(scale?.max);
+          if (!Number.isFinite(min) || !Number.isFinite(max) || STEP_MS <= 0) return;
+
+          const start = Math.ceil(min / STEP_MS) * STEP_MS;
+          const ticks: any[] = [];
+          for (let t = start; t <= max; t += STEP_MS) {
+            ticks.push({ value: t });
+          }
+
+          // Make sure we always have at least 2 ticks so the axis doesn't look "broken".
+          if (ticks.length < 2) {
+            ticks.length = 0;
+            ticks.push({ value: min }, { value: max });
+          }
+
+          scale.ticks = ticks;
+        },
         ticks: {
           // color set by theme helper
+          autoSkip: false,
         },
         grid: {
           color: '#80808080',

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.chart.factory.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.chart.factory.ts
@@ -121,7 +121,7 @@ export function createHomeChartConfig(deps: HomeChartFactoryDeps): HomeChartConf
           autoSkip: false,
         },
         grid: {
-          color: '#80808080',
+          color: HOME_CFG.colors.chartGridColor,
           drawBorder: false,
           display: true,
         },
@@ -147,7 +147,7 @@ export function createHomeChartConfig(deps: HomeChartFactoryDeps): HomeChartConf
           callback: (value: number) => `${Math.round(Number(value))} °C`,
         },
         grid: {
-          color: '#80808080',
+          color: HOME_CFG.colors.chartGridColor,
           drawBorder: false,
         },
       },

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.chart.theme.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.chart.theme.ts
@@ -1,3 +1,5 @@
+import { HOME_CFG } from '../home.cfg';
+
 // Theme helpers for Home chart.
 
 export interface HomeChartTheme {
@@ -8,10 +10,10 @@ export interface HomeChartTheme {
 
 export function readHomeChartTheme(): HomeChartTheme {
   const bodyStyle = getComputedStyle(document.body);
-  const text = (bodyStyle.getPropertyValue('--card-text-color') || '').trim() || '#e5e7eb';
+  const text = (bodyStyle.getPropertyValue('--card-text-color') || '').trim() || HOME_CFG.colors.textFallback;
 
-  // Keep the original semi-transparent grey grid.
-  const gridColor = '#80808080';
+  // Use centrally configured grid color.
+  const gridColor = HOME_CFG.colors.chartGridColor;
 
   return {
     textColor: text,

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.debug-hooks.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.debug-hooks.ts
@@ -20,6 +20,9 @@ export interface NerdChartsDebugDeps {
   setHashrateMinTickStep: (ths: number) => void;
   dumpAxisScale: () => any;
   flushHistoryDrainRender: () => void;
+
+  // System actions (optional)
+  restart?: (totp?: string) => any;
 }
 
 export interface NerdChartsDebugKeys {
@@ -113,6 +116,20 @@ export function installNerdChartsDebugHooks(globalObj: any, deps: NerdChartsDebu
 
   obj.flushHistoryDrainRender = () => deps.flushHistoryDrainRender();
 
+  // Device restart (calls backend restart endpoint). Optional so existing builds don't break.
+  obj.restart = (totp?: string) => {
+    try {
+      if (typeof deps.restart !== 'function') {
+        return { ok: false, error: 'restart hook not installed' };
+      }
+      return deps.restart(totp);
+    } catch (e: any) {
+      // eslint-disable-next-line no-console
+      console.warn('[nerdCharts] restart failed', e);
+      return { ok: false, error: String(e) };
+    }
+  };
+
   obj.list = () => Object.keys(obj).sort();
 
   obj.help = () => ({
@@ -124,6 +141,9 @@ export function installNerdChartsDebugHooks(globalObj: any, deps: NerdChartsDebu
       clearChartHistoryNow: 'clearChartHistoryNow()',
       clearChartHistoryOnce: 'clearChartHistoryOnce(); location.reload()',
       flushHistoryDrainRender: 'flushHistoryDrainRender()',
+    },
+    system: {
+      restart: 'restart(totp?: string)',
     },
     axes: {
       setAxisPadding: 'setAxisPadding({ hashPadPctTop?, hashPadPctBottom?, hashMinPadThs?, hashFlatPadPctOfMax?, hashMaxPadPctOfMax?, tempPadPct?, tempMinPadC?, debug?, persist? })',

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.warmup.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.warmup.ts
@@ -1,0 +1,218 @@
+export type WarmupStage =
+  | 'READY'
+  | 'LOCKED'
+  | 'VREG_DELAY'
+  | 'WAIT_ASIC'
+  | 'ASIC_DELAY'
+  | 'WAIT_HASH_LIVE'
+  | 'HASH_DELAY'
+  | 'WAIT_HASH_FLOW';
+
+export interface HomeWarmupCfg {
+  tempMinValidC: number;
+  tempMaxValidC: number;
+  vregDelayMs: number;
+  asicDelayMs: number;
+  hash1mDelayMs: number;
+  restartDetectStreak: number;
+}
+
+export interface WarmupLiveInputs {
+  nowMs: number;
+  vregTempC?: number | null;
+  asicTempC?: number | null;
+  liveHashrateHs?: number | null;
+  expectedHashrateHs?: number | null;
+  /** True if we currently consider the system "alive" (used for restart detection). */
+  systemOk?: boolean | null;
+  /** True if live hashrate reached the startup unlock ratio vs expected (used for 1m warmup gate). */
+  unlockOk?: boolean | null;
+}
+
+function isFiniteNumber(v: any): v is number {
+  return typeof v === 'number' && Number.isFinite(v);
+}
+
+function isTempValidForWarmup(v: any, cfg: HomeWarmupCfg): boolean {
+  if (!isFiniteNumber(v)) return false;
+  return v >= cfg.tempMinValidC && v <= cfg.tempMaxValidC;
+}
+
+/**
+ * Warmup/Restart state machine.
+ *
+ * Goal: after a miner restart, charts should not resume until sensors/hashrate are sane,
+ * and then resume in a controlled order with small delays.
+ */
+export class HomeWarmupMachine {
+  private cfg: HomeWarmupCfg;
+  private stage: WarmupStage = 'READY';
+  private stageSinceMs = 0;
+
+  private bootLikeStreak = 0;
+  private breakPending = false;
+
+  // Series enable flags (used by component to gate data pushes)
+  private vregEnabled = true;
+  private asicEnabled = true;
+  private hr1mEnabled = true;
+  private otherHashEnabled = true;
+
+  // Flow detector for 1m (we require at least one finite sample)
+  private hr1mFlow = true;
+
+  constructor(cfg: HomeWarmupCfg) {
+    this.cfg = { ...cfg };
+  }
+
+  /** Hard reset (used when we detect a restart/boot situation). */
+  reset(nowMs: number): void {
+    this.stage = 'LOCKED';
+    this.stageSinceMs = nowMs;
+    this.bootLikeStreak = 0;
+    this.breakPending = true;
+
+    this.vregEnabled = false;
+    this.asicEnabled = false;
+    this.hr1mEnabled = false;
+    this.otherHashEnabled = false;
+    this.hr1mFlow = false;
+  }
+
+  /**
+   * Observe live system values to advance warmup stages.
+   * Call once per info-poll tick.
+   */
+  observeLive(input: WarmupLiveInputs): void {
+    const nowMs = input.nowMs;
+
+    const vregOk = isTempValidForWarmup(input.vregTempC, this.cfg);
+    const asicOk = isTempValidForWarmup(input.asicTempC, this.cfg);
+    const liveHs = isFiniteNumber(input.liveHashrateHs) ? (input.liveHashrateHs as number) : 0;
+    const liveOk = isFiniteNumber(liveHs) && liveHs > 0;
+
+    const expectedHs = isFiniteNumber(input.expectedHashrateHs) ? (input.expectedHashrateHs as number) : 0;
+    const systemOk = input.systemOk !== false; // default true
+    // Warmup uses an explicit unlock signal (computed by component from pill live vs expected).
+    const unlockOk = input.unlockOk === true;
+
+    // Restart detection should not rely on temperatures falling quickly.
+    // We use "systemOk" and the startup-unlock signal to detect restart/boot even if temps remain high.
+    // Frequency changes are safe because unlockOk stays true once live reaches the expected ratio.
+    const bootLike = (!systemOk) || (!unlockOk && (!liveOk || !vregOk || !asicOk));
+    if (bootLike) this.bootLikeStreak += 1;
+    else this.bootLikeStreak = 0;
+
+    if (this.stage === 'READY') {
+      if (this.bootLikeStreak >= Math.max(1, Math.round(this.cfg.restartDetectStreak))) {
+        this.reset(nowMs);
+      }
+      return;
+    }
+
+    // Warmup progression
+    switch (this.stage) {
+      case 'LOCKED': {
+        if (vregOk) {
+          this.stage = 'VREG_DELAY';
+          this.stageSinceMs = nowMs;
+        }
+        break;
+      }
+
+      case 'VREG_DELAY': {
+        if (nowMs - this.stageSinceMs >= Math.max(0, this.cfg.vregDelayMs)) {
+          this.vregEnabled = true;
+          this.stage = 'WAIT_ASIC';
+          this.stageSinceMs = nowMs;
+        }
+        break;
+      }
+
+      case 'WAIT_ASIC': {
+        if (asicOk) {
+          this.stage = 'ASIC_DELAY';
+          this.stageSinceMs = nowMs;
+        }
+        break;
+      }
+
+      case 'ASIC_DELAY': {
+        if (nowMs - this.stageSinceMs >= Math.max(0, this.cfg.asicDelayMs)) {
+          this.asicEnabled = true;
+          this.stage = 'WAIT_HASH_LIVE';
+          this.stageSinceMs = nowMs;
+        }
+        break;
+      }
+
+      case 'WAIT_HASH_LIVE': {
+        // Start 1m only once the live hashrate is present AND the startup unlock condition is met
+        // (computed from live pill vs expected). This enforces the "75% expected" requirement.
+        if (liveOk && unlockOk) {
+          this.stage = 'HASH_DELAY';
+          this.stageSinceMs = nowMs;
+        }
+        break;
+      }
+
+      case 'HASH_DELAY': {
+        if (nowMs - this.stageSinceMs >= Math.max(0, this.cfg.hash1mDelayMs)) {
+          this.hr1mEnabled = true;
+          this.stage = 'WAIT_HASH_FLOW';
+          this.stageSinceMs = nowMs;
+        }
+        break;
+      }
+
+      case 'WAIT_HASH_FLOW': {
+        // Flow is confirmed via notifyHr1mFlow().
+        break;
+      }
+    }
+  }
+
+  /** Tell warmup that the 1m series actually received a finite sample. */
+  notifyHr1mFlow(nowMs: number): void {
+    if (this.hr1mFlow) return;
+    this.hr1mFlow = true;
+
+    if (this.stage === 'WAIT_HASH_FLOW') {
+      this.otherHashEnabled = true;
+      this.stage = 'READY';
+      this.stageSinceMs = nowMs;
+    }
+  }
+
+  /**
+   * If true, the component should insert a single "break" sample (NaNs) once.
+   * This cleanly ends curves before the restart gap.
+   */
+  consumeBreakPending(): boolean {
+    if (!this.breakPending) return false;
+    this.breakPending = false;
+    return true;
+  }
+
+  getStage(): WarmupStage {
+    return this.stage;
+  }
+
+  isVregEnabled(): boolean {
+    return this.vregEnabled;
+  }
+  isAsicEnabled(): boolean {
+    return this.asicEnabled;
+  }
+  isHr1mEnabled(): boolean {
+    return this.hr1mEnabled;
+  }
+  isOtherHashEnabled(): boolean {
+    return this.otherHashEnabled;
+  }
+
+  /** True if we are currently suppressing ALL updates (restart window). */
+  isLocked(): boolean {
+    return this.stage === 'LOCKED' || this.stage === 'VREG_DELAY';
+  }
+}

--- a/main/http_server/axe-os/src/app/pages/home/chart/index.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/index.ts
@@ -9,3 +9,4 @@ export * from './home.chart.datasets';
 export * from './home.debug-hooks';
 export * from './home.graph-guard';
 export * from './home.axis-scale';
+export * from './home.warmup';

--- a/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
@@ -446,9 +446,9 @@ export const HOME_CFG: HomeCfg = {
     // Absolute sanity cap for temps.
     tempMaxValidC: 130,
     // Sequencing delays (after first valid sample of each stage)
-    vregDelayMs: 2500,
-    asicDelayMs: 500,
-    hash1mDelayMs: 1500,
+    vregDelayMs: 1337,
+    asicDelayMs: 750,
+    hash1mDelayMs: 250,
     // Hard-cut immediately on the strong signature (temps drop below min + no live hashrate).
     // The streak is only a fallback and should stay low to prevent any 0-line dip.
     restartDetectStreak: 1,
@@ -468,14 +468,14 @@ export const HOME_CFG: HomeCfg = {
 
   startup: {
     bypassGuardSamples: 0,
-    expectedUnlockRatio: 0.75,
+    expectedUnlockRatio: 0.98,
     // Super smooth startup: apply stronger GraphGuard confirmation for 1m for a short window after restart.
-    hr1mSmoothWindowMs: 120_000, // 2 minutes
+    hr1mSmoothWindowMs: 15_000, // 15 seconds
     hr1mConfirmStartup: 5,
     hr1mConfirmNormal: 3,
     // Optional: reload the page after the smooth window finishes.
     // Guarded to trigger only once per miner restart (hard cut) and session-cooled down.
-    hr1mReloadAfterSmooth: true,
+    hr1mReloadAfterSmooth: false,
     hr1mReloadCooldownMs: 600_000, // 10 minutes
   },
 };

--- a/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
@@ -224,6 +224,15 @@ export interface HomeCfg {
   };
   uiDefaults: HomeUiDefaults;
   axisPadding: AxisPaddingCfg;
+  /**
+   * Implement X-axis viewport size in milliseconds.
+   *
+   * Used to keep the plot area visually stable (e.g. always show a full 1h window)
+   * even if there are only a few points right after a cold start / localStorage clear.
+   */
+  xAxis: {
+    fixedWindowMs: number;
+  };
   yAxis: {
     hashrateMaxTicksDefault: number;
     hashrateTickCountClamp: TickCountClamp;
@@ -358,6 +367,10 @@ export const HOME_CFG: HomeCfg = {
       flatPadC: 2.0,
       maxPadC: 8.0,
     },
+  },
+  xAxis: {
+    // Keep X viewport stable and visually calm: always show a full hour.
+    fixedWindowMs: 60 * 60 * 1000,
   },
 
   yAxis: {

--- a/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
@@ -230,6 +230,24 @@ export interface HomeCfg {
    * Used to keep the plot area visually stable (e.g. always show a full 1h window)
    * even if there are only a few points right after a cold start / localStorage clear.
    */
+
+  colors: {
+    /** Grid line color for the chart. Keep it fairly light to reduce visual noise. */
+    chartGridColor: '#80808040',
+    /** Fallback text color if CSS var is missing (e.g. during early boot). */
+    textFallback: '#e5e7eb',
+
+    /** Dataset base colors (centralized so visuals can be tweaked in one place). */
+    hashrateBase: '#a564f6',
+    vregTemp: '#2DA8B7',
+    asicTemp: '#C84847',
+
+    /** Value pills defaults */
+    pillsText: '#ffffff',
+    /** Debug outline stroke used by the pills plugin (only visible in debug mode). */
+    pillsDebugStroke: '#ff00ff',
+  },
+
   xAxis: {
     fixedWindowMs: number;
     /** Tick spacing for the time axis (ms). Used for deterministic 15m labels/grid. */
@@ -373,7 +391,15 @@ export const HOME_CFG: HomeCfg = {
       maxPadC: 8.0,
     },
   },
-
+  colors: {
+    chartGridColor: '#80808040',
+    textFallback: '#e5e7eb',
+    hashrateBase: '#a564f6',
+    vregTemp: '#2DA8B7',
+    asicTemp: '#C84847',
+    pillsText: '#ffffff',
+    pillsDebugStroke: '#ff00ff',
+  },
   xAxis: {
     // Keep X viewport stable and visually calm: always show a full hour.
     fixedWindowMs: 60 * 60 * 1000,
@@ -381,7 +407,6 @@ export const HOME_CFG: HomeCfg = {
     // Deterministic time-axis ticks / grid (e.g. 15-minute labels: :00, :15, :30, :45)
     tickStepMs: 15 * 60 * 1000,
   },
-
   yAxis: {
     hashrateMaxTicksDefault: 5,
     hashrateTickCountClamp: {

--- a/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
@@ -346,7 +346,10 @@ export const HOME_CFG: HomeCfg = {
     viewMode: 'bars',
     // Default hidden datasets (Chart.js style: hidden=true).
     legendHidden: {
-      // Example: hr1d: true,
+      // Initial defaults (applied only if the user has no persisted legend selection yet).
+      hr10m: true,
+      hr1h: true,
+      hr1d: true,
     },
   },
 

--- a/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
@@ -235,6 +235,77 @@ export interface HomeCfg {
     hashrate1m: Hashrate1mSmoothingCfg;
   };
   tempScale: TempScaleCfg;
+
+  // ---- Warmup / restart gating
+
+  /**
+   * Warmup/Restart sequencing so graphs don't "fall apart" after miner restarts.
+   *
+   * This is used by HomeExperimentalComponent + home.warmup.ts.
+   */
+  warmup: {
+    /** Minimum plausible temperature that counts as "valid" for warmup gating. */
+    tempMinValidC: number;
+    /** Hard cap for temperatures (sanity). */
+    tempMaxValidC: number;
+
+    /** Delay after first valid VR temp sample before enabling VR temp plot. */
+    vregDelayMs: number;
+    /** Delay after VR is enabled and first valid ASIC temp sample was seen. */
+    asicDelayMs: number;
+    /** Delay after ASIC is enabled and live hashrate is present before enabling HR 1m plot. */
+    hash1mDelayMs: number;
+
+    /** How many consecutive "boot-like" polls are required to treat as restart. */
+    restartDetectStreak: number;
+  };
+
+  /**
+   * Raw-sample sanitizing to avoid impossible values entering the plot.
+   * (Invalid samples become NaN -> visual gap)
+   */
+  sanitize: {
+    tempMinC: number;
+    tempMaxC: number;
+    hashrateMinHs: number;
+  };
+
+  /**
+   * Startup behavior knobs around GraphGuard.
+   */
+  startup: {
+    /**
+     * Number of initial samples (per hashrate series) that bypass GraphGuard
+     * once startup is "unlocked" (expected vs live reached).
+     */
+    bypassGuardSamples: number;
+    /** Unlock ratio: live must reach expected*ratio once (per restart) before bypass can be used. */
+    expectedUnlockRatio: number;
+
+    /**
+     * 1m hashrate GraphGuard behavior:
+     * After a restart, we run in a "super smooth" mode for a short window to suppress
+     * short-lived dips (e.g. 2–3 ticks). Afterwards, we switch to a snappier mode.
+     */
+    hr1mSmoothWindowMs: number;
+    /** GraphGuard confirmSamples used during the smooth startup window. */
+    hr1mConfirmStartup: number;
+    /** GraphGuard confirmSamples used after the smooth startup window ("snappier"). */
+    hr1mConfirmNormal: number;
+
+    /**
+     * Optional: after the 1m smooth window ends, force a single browser reload (F5/Cmd+R).
+     * Guarded to trigger ONLY after a miner restart (hard cut) and only once per restart.
+     */
+    hr1mReloadAfterSmooth: boolean;
+
+    /**
+     * Cooldown for the optional auto-reload to avoid reload loops (session-scoped).
+     * If the user refreshes manually, we will not auto-reload again until this cooldown passes.
+     */
+    hr1mReloadCooldownMs: number;
+
+  };
 }
 
 /**
@@ -305,10 +376,15 @@ export const HOME_CFG: HomeCfg = {
   graphGuard: {
     cfg: {
       confirmSamples: 2,
-      liveRefTolerance: 0.15,
+      // Live reference tolerance (pool sum) used to suppress short-lived history dips
+      // that do not match the live reference.
+      // Example: a dip from 6.35 TH/s to 5.82 TH/s is ~8.35% and should be rejected
+      // when the live reference is stable.
+      liveRefTolerance: 0.06,
       bigStepRel: 0.20,
-      liveRefStableSamples: 3,
-      liveRefStableRel: 0.08,
+      // Require live reference to be genuinely stable before gating history samples.
+      liveRefStableSamples: 2,
+      liveRefStableRel: 0.05,
     },
     thresholds: {
       // Previously hardcoded relThresholds in updateChartData/sanitizeLoadedHistory.
@@ -346,5 +422,44 @@ export const HOME_CFG: HomeCfg = {
   tempScale: {
     // Previously hardcoded as +/- 3°C around latest min/max.
     latestPadC: 3,
+  },
+
+  warmup: {
+    // Keep boot sensor junk (0..9°C) from unlocking warmup.
+    tempMinValidC: 10,
+    // Absolute sanity cap for temps.
+    tempMaxValidC: 130,
+    // Sequencing delays (after first valid sample of each stage)
+    vregDelayMs: 2500,
+    asicDelayMs: 500,
+    hash1mDelayMs: 1500,
+    // Hard-cut immediately on the strong signature (temps drop below min + no live hashrate).
+    // The streak is only a fallback and should stay low to prevent any 0-line dip.
+    restartDetectStreak: 1,
+  },
+
+  sanitize: {
+    // Never plot 0°C either: in practice this is a boot/sensor artifact for these miners.
+    // (Real operating temps are far above this; treating 0 as invalid prevents "spikes" to the 0-line,
+    // including after page refresh when history is reloaded.)
+    tempMinC: 0.1,
+    tempMaxC: 130,
+    // Hashrate is in H/s in the chart.
+    // NOTE: A value of 0 during runtime is a boot/restart artifact in practice and should never be plotted.
+    // Keep this tiny so legitimate low values (if any) still render.
+    hashrateMinHs: 1,
+  },
+
+  startup: {
+    bypassGuardSamples: 0,
+    expectedUnlockRatio: 0.75,
+    // Super smooth startup: apply stronger GraphGuard confirmation for 1m for a short window after restart.
+    hr1mSmoothWindowMs: 120_000, // 2 minutes
+    hr1mConfirmStartup: 5,
+    hr1mConfirmNormal: 3,
+    // Optional: reload the page after the smooth window finishes.
+    // Guarded to trigger only once per miner restart (hard cut) and session-cooled down.
+    hr1mReloadAfterSmooth: true,
+    hr1mReloadCooldownMs: 600_000, // 10 minutes
   },
 };

--- a/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.cfg.ts
@@ -232,6 +232,8 @@ export interface HomeCfg {
    */
   xAxis: {
     fixedWindowMs: number;
+    /** Tick spacing for the time axis (ms). Used for deterministic 15m labels/grid. */
+    tickStepMs: number;
   };
   yAxis: {
     hashrateMaxTicksDefault: number;
@@ -371,9 +373,13 @@ export const HOME_CFG: HomeCfg = {
       maxPadC: 8.0,
     },
   },
+
   xAxis: {
     // Keep X viewport stable and visually calm: always show a full hour.
     fixedWindowMs: 60 * 60 * 1000,
+
+    // Deterministic time-axis ticks / grid (e.g. 15-minute labels: :00, :15, :30, :45)
+    tickStepMs: 15 * 60 * 1000,
   },
 
   yAxis: {

--- a/main/http_server/axe-os/src/app/pages/home/home.component.experimental.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.experimental.ts
@@ -18,6 +18,7 @@ import {
   createSystemInfoPolling$,
   installNerdChartsDebugBootstrap,
   GraphGuard,
+  computeXWindow,
   computeAxisBounds,
   applyAxisBoundsToChartOptions,
   HomeWarmupMachine,
@@ -44,6 +45,26 @@ import {
 
 export class HomeExperimentalComponent implements AfterViewChecked, OnInit, OnDestroy {
   @ViewChild('myChart') ctx!: ElementRef<HTMLCanvasElement>;
+
+  private applyXWindowToChart(xMinMs: number, xMaxMs: number): void {
+    // Update shared chart options (used on theme refresh etc.)
+    try {
+      const x = (this.chartOptions as any)?.scales?.x;
+      if (x) {
+        x.min = xMinMs;
+        x.max = xMaxMs;
+      }
+    } catch {}
+
+    // Update the live chart instance options so the viewport changes immediately
+    try {
+      const x = (this.chart as any)?.options?.scales?.x;
+      if (x) {
+        x.min = xMinMs;
+        x.max = xMaxMs;
+      }
+    } catch {}
+  }
 
   // --- GraphGuard
   // Step-Confirmation: how many consecutive "suspicious" samples in the same direction
@@ -824,15 +845,15 @@ private setAxisPadding(cfg: any, persist: boolean = false): void {
 
     if (!this.chart || !this.chartOptions?.scales) return;
 
+    // Always enforce a stable X-window (e.g. 1h), regardless of how many points exist.
+    const { xMinMs, xMaxMs } = computeXWindow(this.dataLabel || [], HOME_CFG.xAxis.fixedWindowMs);
+    this.applyXWindowToChart(xMinMs, xMaxMs);
+
     const labels = this.dataLabel || [];
 
+    // If there are no labels yet, we still keep the fixed X-window (handled above),
+    // but we can't compute Y-bounds without data.
     if (!labels.length) return;
-
-    const xScale: any = (this.chart as any).scales?.x;
-    const xMaxMs = Number.isFinite(xScale?.max) ? Number(xScale.max) : labels[labels.length - 1];
-    let xMinMs = Number.isFinite(xScale?.min) ? Number(xScale.min) : labels[Math.max(0, labels.length - (this.axisPadCfg?.hashrate?.windowPoints ?? 180))];
-
-    if (!Number.isFinite(xMinMs)) xMinMs = labels[0];
 
     const hr10m = this.chart.isDatasetVisible(1) ? this.dataData10m : null;
     const hr1h = this.chart.isDatasetVisible(2) ? this.dataData1h : null;
@@ -1353,7 +1374,8 @@ private setAxisPadding(cfg: any, persist: boolean = false): void {
 
   private filterOldData(): void {
     const now = new Date().getTime();
-    this.chartState.trimToLastHour(now);
+    // Keep the in-memory series consistent with the configured x-axis viewport.
+    this.chartState.trimToWindow(now);
 
     if (this.chartState.labels.length) {
       this.storeTimestamp(this.chartState.labels[this.chartState.labels.length - 1]);

--- a/main/http_server/axe-os/src/app/pages/home/home.component.experimental.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.experimental.ts
@@ -20,6 +20,7 @@ import {
   GraphGuard,
   computeAxisBounds,
   applyAxisBoundsToChartOptions,
+  HomeWarmupMachine,
 } from './chart';
 
 import { NbThemeService } from '@nebular/theme';
@@ -58,6 +59,8 @@ export class HomeExperimentalComponent implements AfterViewChecked, OnInit, OnDe
   private graphGuardLiveRefStableSamples: number = HOME_CFG.graphGuard.cfg.liveRefStableSamples;
   private graphGuardLiveRefStableRel: number = HOME_CFG.graphGuard.cfg.liveRefStableRel;
   private lastLivePoolSumHs: number = 0;
+  // Timestamp of the last inserted NaN break-point (hard cut). Used to avoid collisions with history timestamps
+  private lastHardBreakTs: number = 0;
   // Controls how many tick labels are shown on the left hashrate Y axis (Chart.js 'maxTicksLimit').
   private hashrateYAxisMaxTicks: number = HOME_CFG.yAxis.hashrateMaxTicksDefault;
   private hashrateYAxisMinStepThs: number = HOME_CFG.yAxis.minTickSteps.hashrateMinStepThs;
@@ -185,6 +188,31 @@ export class HomeExperimentalComponent implements AfterViewChecked, OnInit, OnDe
   private readonly debugModeKey: string = "__nerdCharts_debugMode";
   // Adaptive axis padding so lines don't stick to frame; tweak here.
   private axisPadCfg = createAxisPaddingCfg();
+
+  // --- Warmup / restart gating (controlled start sequence after miner restarts)
+  private readonly warmupMachine = new HomeWarmupMachine(HOME_CFG.warmup);
+  private warmupStagePrev: string = this.warmupMachine.getStage();
+
+  // --- Startup behavior for hashrate (GraphGuard bypass for initial points)
+  private expectedHashrateHsLast: number = 0;
+  private startupUnlocked: boolean = false;
+  private bypassRemaining: Record<string, number> = {};
+  // 1m hashrate plotting must not start from 0 after restart; gate the very first plotted point.
+  private hr1mStarted: boolean = false;
+  // Timestamp (ms) when the first visible 1m hashrate point was plotted after a restart.
+  // Used for "super smooth" startup: temporarily require more confirmation before accepting
+  // short-lived dips. After the window, we switch to a snappier confirmation level.
+  private hr1mStartTsMs: number | null = null;
+  // Smooth startup should only trigger after an actual miner restart (hard cut), not on normal page loads.
+  private hr1mSmoothArmed: boolean = false;
+  private hr1mRestartTokenMs: number | null = null;
+  private hr1mReloadTimer: any = null;
+  private readonly hr1mReloadConsumedKey: string = '__nerdCharts_hr1mReloadConsumedToken';
+  private readonly hr1mReloadCooldownUntilKey: string = '__nerdCharts_hr1mReloadCooldownUntil';
+  // NOTE: For hashrate charts, the pill/live value is used ONLY as a warmup gate signal.
+  // The plotted data continues to come from the history series (as before).
+  // To avoid a visible "shoot" or a brief drop right after restart, we simply do NOT start
+  // plotting 1m until the HISTORY 1m value itself is valid and has reached the expected unlock ratio.
 
   private debugAxisPadding: boolean = false;
   private readonly axisPadOverrideEnabledKey: string = '__nerdCharts_axisPaddingOverrideEnabled';
@@ -350,6 +378,42 @@ export class HomeExperimentalComponent implements AfterViewChecked, OnInit, OnDe
         if (!this.chart) {
           return;
         }
+
+        // --- Warmup / startup signals (use live values, not history series)
+        // expectedHashRate$ returns an "expected" value used in UI. For internal comparisons
+        // we keep everything in H/s to match live pool sums and chart values.
+        try {
+          const expectedGh = Math.floor(Number(info.frequency) * ((Number(info.smallCoreCount) * Number(info.asicCount)) / 1000));
+          const expectedHs = Number.isFinite(expectedGh) && expectedGh > 0 ? expectedGh * 1e9 : 0;
+          this.expectedHashrateHsLast = expectedHs;
+        } catch {
+          this.expectedHashrateHsLast = 0;
+        }
+
+        const nowMs = Date.now();
+        const liveHs = this.getPoolHashrateHsSum();
+        const unlockRatio = Number(HOME_CFG.startup.expectedUnlockRatio ?? 0.75);
+        // 1m hashrate warmup gate: only unlock once expected is known and live reaches
+        // the configured ratio (e.g. 75%). If expected is 0/unknown, keep locked.
+        const unlockOk = this.expectedHashrateHsLast > 0
+          ? (Number.isFinite(liveHs) && liveHs >= this.expectedHashrateHsLast * unlockRatio)
+          : false;
+
+        // "systemOk" is a cheap proxy to detect restarts even if temperatures remain high.
+        // After a real restart, expectedHashrate/frequency often drops to 0 or becomes unstable for a moment.
+        const systemOk = Number.isFinite(this.expectedHashrateHsLast) && this.expectedHashrateHsLast > 0;
+        this.warmupMachine.observeLive({
+          nowMs,
+          vregTempC: (info as any).vrTemp,
+          asicTempC: (info as any).temp,
+          liveHashrateHs: liveHs,
+          expectedHashrateHs: this.expectedHashrateHsLast,
+          systemOk,
+          unlockOk,
+        });
+
+        // Track stage changes (useful for debug, but also allows future hooks).
+        this.warmupStagePrev = this.warmupMachine.getStage();
 
         // Only drain on cold start (no cached points yet)
         if (this.dataLabel.length === 0) {
@@ -625,6 +689,8 @@ ngOnInit() {
     // Clean up theme subscription to avoid memory leaks when navigating away.
     this.themeSubscription?.unsubscribe();
     this.historyDrainer?.stop();
+    // Cancel any pending auto-reload timer.
+    this.clearHr1mReloadTimer();
     if (this.timeFormatListener) {
       window.removeEventListener('timeFormatChanged', this.timeFormatListener);
     }
@@ -795,6 +861,161 @@ private setAxisPadding(cfg: any, persist: boolean = false): void {
     applyAxisBoundsToChartOptions(this.chartOptions, bounds);
   }
 
+  // --- Sanitizing helpers (invalid samples become NaN => visual gap / never plotted)
+
+  private sanitizeHashrateHs(v: any): number {
+    const n = Number(v);
+    if (!Number.isFinite(n)) return NaN;
+    if (n < HOME_CFG.sanitize.hashrateMinHs) return NaN;
+    return n;
+  }
+
+  private sanitizeTempC(v: any): number {
+    const n = Number(v);
+    if (!Number.isFinite(n)) return NaN;
+    // Never plot negative temps or crazy sensor values. Warmup gating is handled separately.
+    if (n < HOME_CFG.sanitize.tempMinC) return NaN;
+    if (n > HOME_CFG.sanitize.tempMaxC) return NaN;
+    return n;
+  }
+
+  // --- Optional: one-time page reload after smooth 1m startup (only after miner restart)
+
+  private clearHr1mReloadTimer(): void {
+    if (this.hr1mReloadTimer != null) {
+      try { clearTimeout(this.hr1mReloadTimer); } catch {}
+      this.hr1mReloadTimer = null;
+    }
+  }
+
+  private scheduleHr1mReloadAfterSmooth(): void {
+    if (!HOME_CFG.startup.hr1mReloadAfterSmooth) return;
+    if (!this.hr1mSmoothArmed) return;
+    if (this.hr1mRestartTokenMs == null) return;
+
+    const windowMs = Math.max(0, Math.round(Number(HOME_CFG.startup.hr1mSmoothWindowMs ?? 0)));
+    if (!windowMs) return;
+
+    // Guard: only once per restart token (session-scoped) + cooldown to avoid loops.
+    const token = String(this.hr1mRestartTokenMs);
+    try {
+      const consumed = sessionStorage.getItem(this.hr1mReloadConsumedKey);
+      if (consumed === token) {
+        this.hr1mSmoothArmed = false;
+        return;
+      }
+
+      const now = Date.now();
+      const cooldownUntil = Number(sessionStorage.getItem(this.hr1mReloadCooldownUntilKey) ?? 0);
+      if (Number.isFinite(cooldownUntil) && cooldownUntil > now) {
+        this.hr1mSmoothArmed = false;
+        return;
+      }
+
+      sessionStorage.setItem(this.hr1mReloadConsumedKey, token);
+      const cooldownMs = Math.max(0, Math.round(Number(HOME_CFG.startup.hr1mReloadCooldownMs ?? 0)));
+      if (cooldownMs) {
+        sessionStorage.setItem(this.hr1mReloadCooldownUntilKey, String(now + cooldownMs));
+      }
+    } catch {
+      // If sessionStorage is not available, still try to reload (best effort).
+    }
+
+    this.clearHr1mReloadTimer();
+    this.hr1mSmoothArmed = false; // ensure we don't schedule twice for the same restart
+    this.hr1mReloadTimer = setTimeout(() => {
+      try {
+        window.location.reload();
+      } catch {
+        try { (location as any).reload(); } catch {}
+      }
+    }, windowMs);
+  }
+
+  /**
+   * Inserts a single NaN break-point across all series to create a hard visual cut.
+   * This is used on restarts so charts don't "fall" to 0 but end cleanly.
+   */
+  private insertHardBreakSample(breakAtMs: number): void {
+    // Reset startup/bypass state per restart.
+    this.startupUnlocked = false;
+    this.bypassRemaining = {};
+    this.hr1mStarted = false;
+    this.hr1mStartTsMs = null;
+
+    // Cancel any pending auto-reload from a previous restart cycle.
+    this.clearHr1mReloadTimer();
+
+    // Arm smooth-start behavior ONLY after an actual restart/hard cut.
+    // This prevents smooth mode (and optional reload) from triggering on normal page loads/refreshes.
+    this.hr1mSmoothArmed = true;
+
+    // Start a fresh guard baseline for the new post-restart segment.
+    // (Otherwise the first post-restart point may be compared against stale pre-restart state.)
+    try { this.graphGuardEngine.reset(); } catch {}
+
+    const last = this.dataLabel.length ? this.dataLabel[this.dataLabel.length - 1] : 0;
+    const ts = Math.max(Number(breakAtMs) || Date.now(), last > 0 ? last + 1 : 0);
+    if (last > 0 && ts <= last) return;
+
+    // Remember the break timestamp to prevent a later in-place overwrite when the next
+    // history point happens to have the same timestamp (would remove the visual gap).
+    this.lastHardBreakTs = ts;
+
+    // Use the break timestamp as a per-restart token for "run once" logic.
+    this.hr1mRestartTokenMs = ts;
+
+    this.dataLabel.push(ts);
+    this.dataData1m.push(NaN);
+    this.dataData10m.push(NaN);
+    this.dataData1h.push(NaN);
+    this.dataData1d.push(NaN);
+    this.dataVregTemp.push(NaN);
+    this.dataAsicTemp.push(NaN);
+
+    // Advance stored timestamp so polling doesn't keep refetching the same restart window.
+    this.storeTimestamp(ts);
+  }
+
+  private ensureStartupUnlocked(livePoolSumHs: number): void {
+    if (this.startupUnlocked) return;
+
+    const live = Number(livePoolSumHs);
+    const expected = Number(this.expectedHashrateHsLast);
+    if (!Number.isFinite(live) || live <= 0) return;
+    if (!Number.isFinite(expected) || expected <= 0) return;
+
+    const ratio = Number(HOME_CFG.startup.expectedUnlockRatio ?? 0.75);
+    if (live >= expected * ratio) {
+      this.startupUnlocked = true;
+      const n = Math.max(0, Math.round(Number(HOME_CFG.startup.bypassGuardSamples ?? 0)));
+      this.bypassRemaining = {
+        // Do NOT bypass GraphGuard for 1m hashrate.
+        // The 1m history stream can emit a short transient low plateau shortly after restart
+        // (typically 2–3 ticks) even though the miner is already hashing steadily.
+        // Bypassing the guard for 1m would let that dip through and create the visible "Zack".
+        // We keep the optional bypass for the slower series only.
+        hashrate_1m: 0,
+        hashrate_10m: n,
+        hashrate_1h: n,
+        hashrate_1d: n,
+      };
+    }
+  }
+
+  private shouldBypassHashGuard(key: string): boolean {
+    if (!this.startupUnlocked) return false;
+    const left = Math.max(0, Math.round(Number(this.bypassRemaining?.[key] ?? 0)));
+    return left > 0;
+  }
+
+  private consumeBypassHashGuard(key: string): void {
+    if (!this.startupUnlocked) return;
+    const left = Math.max(0, Math.round(Number(this.bypassRemaining?.[key] ?? 0)));
+    if (left <= 0) return;
+    this.bypassRemaining[key] = left - 1;
+  }
+
   private updateChartData(data: any): void {
     if (!data) return;
 
@@ -842,43 +1063,181 @@ private setAxisPadding(cfg: any, persist: boolean = false): void {
 
     newData.sort((a, b) => a.timestamp - b.timestamp);
 
+    // If a restart was detected (warmup reset), insert a single NaN "break" sample
+    // to end all curves cleanly. We place it just before the next incoming history point
+    // so it can never be overwritten by a duplicate timestamp.
+    if (this.warmupMachine.consumeBreakPending()) {
+      const nextTs = newData.length ? Number(newData[0].timestamp) : Date.now();
+      const breakAt = Number.isFinite(nextTs) ? (nextTs - 1) : Date.now();
+      this.insertHardBreakSample(breakAt);
+    }
+
     // Append only new data (spike-guarded, line-break free)
     // If we push duplicates, Chart.js draws a vertical segment at the same X ("treppenhaus").
     for (const entry of newData) {
+      // If we inserted a hard NaN break-point, ensure the next incoming history sample
+      // cannot overwrite it via the duplicate-timestamp in-place update path.
+      if (this.lastHardBreakTs && Number(entry.timestamp) <= this.lastHardBreakTs) {
+        entry.timestamp = this.lastHardBreakTs + 1;
+      }
+      // Warmup gates (progress is driven by live values from polling)
+      const vregEnabled = this.warmupMachine.isVregEnabled();
+      const asicEnabled = this.warmupMachine.isAsicEnabled();
+      const hr1mEnabled = this.warmupMachine.isHr1mEnabled();
+      const otherHashEnabled = this.warmupMachine.isOtherHashEnabled();
+
+      // Startup unlock for optional GraphGuard bypass (uses hashrate pill / live pool sum)
+      this.ensureStartupUnlocked(livePoolSum);
+
+      // Sanitize raw inputs (invalid => NaN => never plotted)
+      const hr1mRaw = this.sanitizeHashrateHs(entry.hashrate_1m);
+      const hr10mRaw = this.sanitizeHashrateHs(entry.hashrate_10m);
+      const hr1hRaw = this.sanitizeHashrateHs(entry.hashrate_1h);
+      const hr1dRaw = this.sanitizeHashrateHs(entry.hashrate_1d);
+      const vregRaw = this.sanitizeTempC(entry.vregTemp);
+      const asicRaw = this.sanitizeTempC(entry.asicTemp);
+
+      // 1m hashrate: avoid starting from 0/low history samples.
+      // When warmup enables 1m, we seed the first visible point from the live pill.
+      // Afterwards, if the history 1m value is still bogus (<=0 / NaN) but the pill is live,
+      // we keep plotting the live pill as a proxy to prevent brief drops.
+            // 1m hashrate start gating:
+      // - Pill/live is ONLY used to decide when we're allowed to start (startupUnlocked).
+      // - The plotted value still comes from the history (hr1mRaw), as before.
+      // - To avoid any visible "shoot" from 0 or a short drop, we only start once the HISTORY 1m
+      //   itself is valid and has reached the expected unlock ratio as well.
+      let hr1mCandidate: number = NaN;
+      if (hr1mEnabled) {
+        const expectedHs = Number(this.expectedHashrateHsLast);
+        const ratio = Number(HOME_CFG.startup.expectedUnlockRatio ?? 0.75);
+        const histOk = Number.isFinite(hr1mRaw) && hr1mRaw > 0;
+
+        // Require the history value to also be at/above the unlock ratio on first start.
+        // After start, we keep using the history value (GraphGuard will smooth rare glitches).
+        const histUnlockOk = (expectedHs > 0)
+          ? (histOk && hr1mRaw >= expectedHs * ratio)
+          : histOk;
+
+        if (!this.hr1mStarted) {
+          if (this.startupUnlocked && histUnlockOk) {
+            this.hr1mStarted = true;
+            // Smooth startup + optional reload should only trigger after an actual restart (hard cut).
+            // On normal page loads, we keep snappy behavior (no smooth window).
+            if (this.hr1mSmoothArmed) {
+              this.hr1mStartTsMs = Number(entry.timestamp);
+              this.scheduleHr1mReloadAfterSmooth();
+            } else {
+              this.hr1mStartTsMs = null;
+            }
+            hr1mCandidate = hr1mRaw;
+          } else {
+            hr1mCandidate = NaN;
+          }
+        } else {
+          hr1mCandidate = hr1mRaw;
+        }
+      }
+      // --- Restart hard-cut detection based on incoming history samples.
+      // We intentionally do NOT rely on temperatures dropping quickly.
+      // If live hashrate (pill) is gone and the history starts emitting boot/glitch samples
+      // (0/NaN temps or 0 hashrate), we cut immediately so the curve doesn't fall to the 0-line.
+      const liveOkNow = Number.isFinite(livePoolSum) && livePoolSum > 0;
+      const stageNow = this.warmupMachine.getStage();
+      const historyHr1m = Number(entry.hashrate_1m);
+      const restartMarker = (!liveOkNow) && (
+        (!Number.isFinite(vregRaw) || !Number.isFinite(asicRaw)) || (Number.isFinite(historyHr1m) && historyHr1m <= 0)
+      );
+
+      if (stageNow === 'READY' && restartMarker) {
+        this.warmupMachine.reset(entry.timestamp);
+        // Consume the break flag immediately and insert the cut at the current timestamp.
+        this.warmupMachine.consumeBreakPending();
+        // Place the break just before the first post-restart timestamp so the cut
+        // can't be overwritten by an in-place update at the same X.
+        this.insertHardBreakSample(entry.timestamp - 1);
+        // Do not append this (bogus) sample; also advance the stored timestamp.
+        this.storeTimestamp(entry.timestamp);
+        continue;
+      }
+
+      // While locked (restart window / VR delay), do not append any new points (no tracking).
+      // Curves were already terminated via the break marker.
+      if (this.warmupMachine.isLocked()) {
+        this.storeTimestamp(entry.timestamp);
+        continue;
+      }
+
+      const applyHash = (key: string, v: number, thr: number): number => {
+        if (!Number.isFinite(v)) return NaN;
+        // Optional startup bypass for GraphGuard: allow the first N samples after warmup
+        // to be plotted unguarded (prevents brief artificial drops caused by an unstable
+        // live reference right after restart). This does NOT trigger on frequency changes
+        // because startupUnlocked is only set once when live reaches the expected ratio.
+        if (this.shouldBypassHashGuard(key)) {
+          this.consumeBypassHashGuard(key);
+          return v;
+        }
+        // Super smooth startup for 1m: for ~2 minutes after restart-start, require more
+        // confirmation to accept short-lived dips (prevents 2-3 tick artifacts). After
+        // that, switch to a snappier confirmation level.
+        let confirmOverride: number | undefined = undefined;
+        if (key === 'hashrate_1m') {
+          if (this.hr1mStarted) {
+            const start = this.hr1mStartTsMs;
+            const inStartupWindow = start != null && (Number(entry.timestamp) - start) <= HOME_CFG.startup.hr1mSmoothWindowMs;
+            confirmOverride = inStartupWindow ? HOME_CFG.startup.hr1mConfirmStartup : HOME_CFG.startup.hr1mConfirmNormal;
+          } else {
+            // If not started yet (or restored from storage), default to snappy.
+            confirmOverride = HOME_CFG.startup.hr1mConfirmNormal;
+          }
+        }
+
+        return this.enableHashrateSpikeGuard
+          ? this.graphGuardEngine.apply(key, v, thr, livePoolSum, confirmOverride)
+          : v;
+      };
+
+      const applyTemp = (key: string, v: number, thr: number): number => {
+        if (!Number.isFinite(v)) return NaN;
+        return this.graphGuardEngine.apply(key, v, thr);
+      };
+
       const lastIdx = this.dataLabel.length - 1;
       if (lastIdx >= 0 && this.dataLabel[lastIdx] === entry.timestamp) {
-        this.dataData1m[lastIdx] = this.enableHashrateSpikeGuard
-          ? this.graphGuardEngine.apply('hashrate_1m', entry.hashrate_1m, HOME_CFG.graphGuard.thresholds.hashrate1m, livePoolSum)
-          : entry.hashrate_1m;
-        this.dataVregTemp[lastIdx] = this.graphGuardEngine.apply('vregTemp', entry.vregTemp, HOME_CFG.graphGuard.thresholds.vregTemp);
-        this.dataAsicTemp[lastIdx] = this.graphGuardEngine.apply('asicTemp', entry.asicTemp, HOME_CFG.graphGuard.thresholds.asicTemp);
-        this.dataData10m[lastIdx] = this.enableHashrateSpikeGuard
-          ? this.graphGuardEngine.apply('hashrate_10m', entry.hashrate_10m, HOME_CFG.graphGuard.thresholds.hashrate10m, livePoolSum)
-          : entry.hashrate_10m;
-        this.dataData1h[lastIdx] = this.enableHashrateSpikeGuard
-          ? this.graphGuardEngine.apply('hashrate_1h', entry.hashrate_1h, HOME_CFG.graphGuard.thresholds.hashrate1h, livePoolSum)
-          : entry.hashrate_1h;
-        this.dataData1d[lastIdx] = this.enableHashrateSpikeGuard
-          ? this.graphGuardEngine.apply('hashrate_1d', entry.hashrate_1d, HOME_CFG.graphGuard.thresholds.hashrate1d, livePoolSum)
-          : entry.hashrate_1d;
+        // In-place update for duplicate timestamp (keep gating + sanitizing)
+        this.dataVregTemp[lastIdx] = vregEnabled ? applyTemp('vregTemp', vregRaw, HOME_CFG.graphGuard.thresholds.vregTemp) : NaN;
+        this.dataAsicTemp[lastIdx] = asicEnabled ? applyTemp('asicTemp', asicRaw, HOME_CFG.graphGuard.thresholds.asicTemp) : NaN;
+
+        const hr1mOut = hr1mEnabled
+          ? applyHash('hashrate_1m', hr1mCandidate, HOME_CFG.graphGuard.thresholds.hashrate1m)
+          : NaN;
+        this.dataData1m[lastIdx] = hr1mOut;
+        if (hr1mEnabled && Number.isFinite(hr1mOut)) {
+          this.warmupMachine.notifyHr1mFlow(entry.timestamp);
+        }
+
+        this.dataData10m[lastIdx] = otherHashEnabled ? applyHash('hashrate_10m', hr10mRaw, HOME_CFG.graphGuard.thresholds.hashrate10m) : NaN;
+        this.dataData1h[lastIdx] = otherHashEnabled ? applyHash('hashrate_1h', hr1hRaw, HOME_CFG.graphGuard.thresholds.hashrate1h) : NaN;
+        this.dataData1d[lastIdx] = otherHashEnabled ? applyHash('hashrate_1d', hr1dRaw, HOME_CFG.graphGuard.thresholds.hashrate1d) : NaN;
         continue;
       }
 
       this.dataLabel.push(entry.timestamp);
-      this.dataData1m.push(this.enableHashrateSpikeGuard
-        ? this.graphGuardEngine.apply('hashrate_1m', entry.hashrate_1m, HOME_CFG.graphGuard.thresholds.hashrate1m, livePoolSum)
-        : entry.hashrate_1m);
-      this.dataVregTemp.push(this.graphGuardEngine.apply('vregTemp', entry.vregTemp, HOME_CFG.graphGuard.thresholds.vregTemp));
-      this.dataAsicTemp.push(this.graphGuardEngine.apply('asicTemp', entry.asicTemp, HOME_CFG.graphGuard.thresholds.asicTemp));
-      this.dataData10m.push(this.enableHashrateSpikeGuard
-        ? this.graphGuardEngine.apply('hashrate_10m', entry.hashrate_10m, HOME_CFG.graphGuard.thresholds.hashrate10m, livePoolSum)
-        : entry.hashrate_10m);
-      this.dataData1h.push(this.enableHashrateSpikeGuard
-        ? this.graphGuardEngine.apply('hashrate_1h', entry.hashrate_1h, HOME_CFG.graphGuard.thresholds.hashrate1h, livePoolSum)
-        : entry.hashrate_1h);
-      this.dataData1d.push(this.enableHashrateSpikeGuard
-        ? this.graphGuardEngine.apply('hashrate_1d', entry.hashrate_1d, HOME_CFG.graphGuard.thresholds.hashrate1d, livePoolSum)
-        : entry.hashrate_1d);
+
+      this.dataVregTemp.push(vregEnabled ? applyTemp('vregTemp', vregRaw, HOME_CFG.graphGuard.thresholds.vregTemp) : NaN);
+      this.dataAsicTemp.push(asicEnabled ? applyTemp('asicTemp', asicRaw, HOME_CFG.graphGuard.thresholds.asicTemp) : NaN);
+
+      const hr1mOut = hr1mEnabled
+        ? applyHash('hashrate_1m', hr1mCandidate, HOME_CFG.graphGuard.thresholds.hashrate1m)
+        : NaN;
+      this.dataData1m.push(hr1mOut);
+      if (hr1mEnabled && Number.isFinite(hr1mOut)) {
+        this.warmupMachine.notifyHr1mFlow(entry.timestamp);
+      }
+
+      this.dataData10m.push(otherHashEnabled ? applyHash('hashrate_10m', hr10mRaw, HOME_CFG.graphGuard.thresholds.hashrate10m) : NaN);
+      this.dataData1h.push(otherHashEnabled ? applyHash('hashrate_1h', hr1hRaw, HOME_CFG.graphGuard.thresholds.hashrate1h) : NaN);
+      this.dataData1d.push(otherHashEnabled ? applyHash('hashrate_1d', hr1dRaw, HOME_CFG.graphGuard.thresholds.hashrate1d) : NaN);
     }
   }
 
@@ -891,6 +1250,20 @@ private setAxisPadding(cfg: any, persist: boolean = false): void {
 
     try {
       this.chartState = HomeChartState.fromPersisted(persisted);
+
+      // IMPORTANT: persisted history can contain bogus 0/invalid samples (e.g. during restarts)
+      // that must never be plotted. During a normal run, warmup gating prevents these samples
+      // from being pushed, but on a page refresh we restore raw arrays and must sanitize them
+      // again so refreshes never re-introduce spikes to the 0-line.
+      this.sanitizeLoadedHistory();
+
+      // If we already have finite 1m points (from persisted history), treat startup as already started.
+      try {
+        const lastFinite = findLastFinite(this.dataData1m);
+        this.hr1mStarted = Number.isFinite(lastFinite as any);
+      } catch {
+        this.hr1mStarted = false;
+      }
 
       // Keep chartData in sync with the restored arrays.
       if (this.chartData) {
@@ -923,20 +1296,44 @@ private setAxisPadding(cfg: any, persist: boolean = false): void {
     const outAsic: number[] = [];
 
     for (let i = 0; i < len; i++) {
-      out1m.push(this.enableHashrateSpikeGuard
-        ? this.graphGuardEngine.apply('hashrate_1m', this.dataData1m[i], HOME_CFG.graphGuard.thresholds.hashrate1m)
-        : this.dataData1m[i]);
-      outVreg.push(this.graphGuardEngine.apply('vregTemp', this.dataVregTemp[i], HOME_CFG.graphGuard.thresholds.vregTemp));
-      outAsic.push(this.graphGuardEngine.apply('asicTemp', this.dataAsicTemp[i], HOME_CFG.graphGuard.thresholds.asicTemp));
-      out10m.push(this.enableHashrateSpikeGuard
-        ? this.graphGuardEngine.apply('hashrate_10m', this.dataData10m[i], HOME_CFG.graphGuard.thresholds.hashrate10m)
-        : this.dataData10m[i]);
-      out1h.push(this.enableHashrateSpikeGuard
-        ? this.graphGuardEngine.apply('hashrate_1h', this.dataData1h[i], HOME_CFG.graphGuard.thresholds.hashrate1h)
-        : this.dataData1h[i]);
-      out1d.push(this.enableHashrateSpikeGuard
-        ? this.graphGuardEngine.apply('hashrate_1d', this.dataData1d[i], HOME_CFG.graphGuard.thresholds.hashrate1d)
-        : this.dataData1d[i]);
+      const hr1m = this.sanitizeHashrateHs(this.dataData1m[i]);
+      const hr10m = this.sanitizeHashrateHs(this.dataData10m[i]);
+      const hr1h = this.sanitizeHashrateHs(this.dataData1h[i]);
+      const hr1d = this.sanitizeHashrateHs(this.dataData1d[i]);
+      const vreg = this.sanitizeTempC(this.dataVregTemp[i]);
+      const asic = this.sanitizeTempC(this.dataAsicTemp[i]);
+
+      out1m.push(Number.isFinite(hr1m)
+        ? (this.enableHashrateSpikeGuard
+          ? this.graphGuardEngine.apply('hashrate_1m', hr1m, HOME_CFG.graphGuard.thresholds.hashrate1m)
+          : hr1m)
+        : NaN);
+
+      out10m.push(Number.isFinite(hr10m)
+        ? (this.enableHashrateSpikeGuard
+          ? this.graphGuardEngine.apply('hashrate_10m', hr10m, HOME_CFG.graphGuard.thresholds.hashrate10m)
+          : hr10m)
+        : NaN);
+
+      out1h.push(Number.isFinite(hr1h)
+        ? (this.enableHashrateSpikeGuard
+          ? this.graphGuardEngine.apply('hashrate_1h', hr1h, HOME_CFG.graphGuard.thresholds.hashrate1h)
+          : hr1h)
+        : NaN);
+
+      out1d.push(Number.isFinite(hr1d)
+        ? (this.enableHashrateSpikeGuard
+          ? this.graphGuardEngine.apply('hashrate_1d', hr1d, HOME_CFG.graphGuard.thresholds.hashrate1d)
+          : hr1d)
+        : NaN);
+
+      outVreg.push(Number.isFinite(vreg)
+        ? this.graphGuardEngine.apply('vregTemp', vreg, HOME_CFG.graphGuard.thresholds.vregTemp)
+        : NaN);
+
+      outAsic.push(Number.isFinite(asic)
+        ? this.graphGuardEngine.apply('asicTemp', asic, HOME_CFG.graphGuard.thresholds.asicTemp)
+        : NaN);
     }
 
     this.dataData1m = out1m;
@@ -987,7 +1384,7 @@ private updateTempScaleFromLatest(): void {
   const maxLast = Math.max(...vals);
 
   const pad = HOME_CFG.tempScale.latestPadC;
-  const min = Math.floor(minLast - pad);
+  const min = Math.max(0, Math.floor(minLast - pad));
   const max = Math.ceil(maxLast + pad);
 
   if (this.chartOptions?.scales?.y_temp) {

--- a/main/http_server/axe-os/src/app/pages/home/home.component.experimental.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.experimental.ts
@@ -1,5 +1,5 @@
 import { Component, AfterViewChecked, OnInit, OnDestroy, ElementRef, ViewChild } from '@angular/core';
-import { map, Observable, Subscription } from 'rxjs';
+import { map, Observable, Subscription, firstValueFrom } from 'rxjs';
 import { HashSuffixPipe } from '../../pipes/hash-suffix.pipe';
 import { SystemService } from '../../services/system.service';
 import { ISystemInfo } from '../../models/ISystemInfo';
@@ -674,6 +674,19 @@ ngOnInit() {
           if (this.wasLoaded) this.saveChartData();
           this.updateChart();
         } catch {}
+      },
+
+      // Console helper: restart device via backend endpoint.
+      // Note: mirrors the SystemComponent.restart() backend call; OTP is optional depending on device settings.
+      restart: async (totp?: string) => {
+        try {
+          const res = await firstValueFrom(this.systemService.restart('', (totp || '').trim()));
+          return { ok: true, res };
+        } catch (e: any) {
+          // eslint-disable-next-line no-console
+          console.warn('[nerdCharts] restart failed', e);
+          return { ok: false, error: String(e) };
+        }
       },
     });
     this.syncDebugModeFromStorage();

--- a/main/http_server/axe-os/src/app/pages/home/plugins/value-pills.plugin.ts
+++ b/main/http_server/axe-os/src/app/pages/home/plugins/value-pills.plugin.ts
@@ -1,5 +1,6 @@
 import { Chart, Plugin } from 'chart.js';
 import { TimeScale } from 'chart.js/auto';
+import { HOME_CFG } from '../home.cfg';
 
 type ValuePillsSide = 'left' | 'right';
 
@@ -154,7 +155,7 @@ function valuePillsComputePills(chart: any, opts: ValuePillsPluginOptions, measu
       plotGapPx,
       outerPaddingPx,
       bg: (overrides.bg || ds.borderColor || ds.backgroundColor || '#333') as string,
-      fg: (overrides.fg || '#ffffff') as string,
+      fg: (overrides.fg || HOME_CFG.colors.pillsText) as string,
     });
   });
 
@@ -340,7 +341,7 @@ function valuePillsDrawPills(chart: any, opts: ValuePillsPluginOptions, pills: V
 
   if (o.debug) {
     ctx.save();
-    ctx.strokeStyle = '#ff00ff';
+    ctx.strokeStyle = HOME_CFG.colors.pillsDebugStroke;
     ctx.lineWidth = 1;
     ctx.strokeRect(chartArea.left, chartArea.top, chartArea.right - chartArea.left, chartArea.bottom - chartArea.top);
     ctx.restore();


### PR DESCRIPTION
#476 follow up, @shufps Let the dragon fly.

---

- Warmup logic implemented, which is necessary after a restart
- X-axis always displays a fixed one-hour viewport regardless of datasets
- 1-day dataset deactivated
- 10m/1h/1d legend hidden initially until user reactivates it
- restart() hook implemented for console
- Show 15m x-axis ticks without shifting viewport 
- Centralize dataset/theme/plugin colors in HOME_CFG

<img width="1268" height="1044" alt="image" src="https://github.com/user-attachments/assets/595f80c3-e9f5-4010-989d-599049949dfd" />