### PR TITLE
Avoid duplicate temp tick values

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/chart/home.axis-scale.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.axis-scale.ts
@@ -206,33 +206,20 @@ export function computeAxisBounds(input: AxisScaleInputs): ComputedAxisBounds {
 
   // Temperature axis
   if (tm.mn !== undefined && tm.mx !== undefined) {
-    // Temps cannot be negative; clamp min to 0 to avoid whitespace artifacts.
-    const targetMin = Math.max(0, tm.mn - 2);
-    const targetMax = tm.mx + 3;
+    // We intentionally keep temperature bounds *strict* so the pills match the
+    // intended padding: bottom <= -2°C and top <= +3°C relative to data.
+    //
+    // Previously we aligned to a "nice" tick step (e.g. 5°C) via floor/ceil.
+    // That can push the max well beyond +3°C (e.g. 61°C -> 65°C), which makes
+    // the top padding look wrong.
+    const targetMin = Math.max(0, tm.mn - 1);
+    const targetMax = tm.mx + 2;
 
     const maxTicks = Math.max(2, Math.round(Number(input.maxTicks || 7)));
-    const rangeC = Math.max(0, targetMax - targetMin);
-    const desired = rangeC / Math.max(1, maxTicks - 1);
-
-    const niceStepsC = [0.5, 1, 2, 5, 10];
-    let stepC = niceStepsC[niceStepsC.length - 1];
-    for (const s of niceStepsC) {
-      if (s >= desired) {
-        stepC = s;
-        break;
-      }
-    }
-    if (stepC < input.tempMinStepC) stepC = input.tempMinStepC;
-
-    let minAligned = Math.floor(targetMin / stepC) * stepC;
-    const maxAligned = Math.ceil(targetMax / stepC) * stepC;
-
-    minAligned = Math.max(0, minAligned);
 
     out.y_temp = {
-      min: minAligned,
-      max: maxAligned,
-      stepSize: stepC,
+      min: targetMin,
+      max: targetMax,
       maxTicksLimit: maxTicks,
     };
   }

--- a/main/http_server/axe-os/src/app/pages/home/chart/home.chart.factory.ts
+++ b/main/http_server/axe-os/src/app/pages/home/chart/home.chart.factory.ts
@@ -63,7 +63,7 @@ export function createHomeChartConfig(deps: HomeChartFactoryDeps): HomeChartConf
           },
           label: (x: any) => {
             if (x?.dataset?.yAxisID === 'y_temp') {
-              return `${x.dataset.label}: ${Number(x.raw).toFixed(1)} °C`;
+              return `${x.dataset.label}: ${Number(x.raw).toFixed(2)} °C`;
             }
             return `${x.dataset.label}: ${deps.formatHashrate(x.raw)}`;
           },
@@ -141,10 +141,37 @@ export function createHomeChartConfig(deps: HomeChartFactoryDeps): HomeChartConf
       },
       y_temp: {
         position: 'right',
+        // Force the right temperature axis to show only whole-degree tick labels (50, 51, 52...),
+        // while allowing the underlying data and pills to remain fractional.
+        afterBuildTicks: (scale: any) => {
+          const maxTicks = Math.max(2, Math.round(Number(deps.maxTicksLimit || 7)));
+          const min = Number(scale?.min);
+          const max = Number(scale?.max);
+          if (!Number.isFinite(min) || !Number.isFinite(max)) return;
+
+          const minI = Math.ceil(min);
+          const maxI = Math.floor(max);
+          if (maxI < minI) return;
+
+          const values: number[] = [];
+          for (let v = minI; v <= maxI; v += 1) values.push(v);
+
+          // If there are too many whole-degree ticks, downsample but keep the end tick.
+          if (values.length > maxTicks) {
+            const step = Math.ceil((values.length - 1) / (maxTicks - 1));
+            const reduced: number[] = [];
+            for (let i = 0; i < values.length; i += step) reduced.push(values[i]);
+            if (reduced[reduced.length - 1] !== values[values.length - 1]) reduced.push(values[values.length - 1]);
+            scale.ticks = reduced.map((v) => ({ value: v }));
+            return;
+          }
+
+          scale.ticks = values.map((v) => ({ value: v }));
+        },
         ticks: {
           // color set by theme helper
           maxTicksLimit: deps.maxTicksLimit,
-          callback: (value: number) => `${Math.round(Number(value))} °C`,
+          callback: (value: number) => `${Number(value)} °C`,
         },
         grid: {
           color: HOME_CFG.colors.chartGridColor,


### PR DESCRIPTION
## Problem:

After adjusting the temperature axis limits, Chart.js sometimes generated tick values with decimal places (e.g., 59.6 / 60.0 / 60.4). However, since the temperature axis on the right side of the UI was formatted to whole degrees, several different tick values could appear as identical labels (e.g., “60 °C” twice). This was confusing and made the scale difficult to read.

## Goal:
The temperature scale on the right should display only whole degree values (50, 51, 52 ...), while the data/curves and pills can remain precise (even with decimal places).

- In addition, two decimal places are displayed in the graph tooltip when the mouse hovers over it.
- The adjustment also allows for much finer temperature increments to be displayed on the temperature axis.

<img width="1815" height="733" alt="image" src="https://github.com/user-attachments/assets/bf51103c-f1a6-4578-a3d3-90d25ed742ab" />
