### PR TITLE
fix(dashboard): show °C instead of H/s for temperature tooltip in classic dashboard

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.ts
@@ -224,7 +224,12 @@ export class HomeComponent implements AfterViewChecked, OnInit, OnDestroy {
                 ? date.toLocaleString('en-US', { hour: 'numeric', minute: '2-digit', hour12: true, month: 'short', day: 'numeric' })
                 : date.toLocaleString('en-US', { hour: '2-digit', minute: '2-digit', hour12: false, month: 'short', day: 'numeric' });
             },
-            label: (x: any) => `${x.dataset.label}: ${HashSuffixPipe.transform(x.raw)}`
+            label: (x: any) => {
+              if (x?.dataset?.yAxisID === 'y_temp') {
+                return `${x.dataset.label}: ${Number(x.raw).toFixed(2)} °C`;
+              }
+              return `${x.dataset.label}: ${HashSuffixPipe.transform(x.raw)}`;
+            }
           }
         },
       },


### PR DESCRIPTION
This PR:
- Fixes the chart tooltip in classic dashboard showing "H/s" suffix for temperature datasets (ASIC Temp, VR Temp) instead of "°C"