### PR TITLE
added reset session stats button and endpoint

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/home.component.html
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.html
@@ -205,7 +205,17 @@
           @let usingFallback = info.stratum?.usingFallback;
 
           <nb-card class="h-100 pool-tile-card" [class.pool-tile-card--dual]="isDualPool">
-            <nb-card-body class="no-scroll pool-tile-card__body">
+            <nb-card-body class="no-scroll pool-tile-card__body" style="position: relative;">
+
+              <button
+                nbButton ghost size="tiny" type="button"
+                style="position: absolute; top: 4px; right: 4px; z-index: 1; opacity: 0.5;"
+                [attr.aria-label]="'HOME.RESET_STATS' | translate"
+                [nbTooltip]="'HOME.RESET_STATS' | translate"
+                (click)="openResetStatsDialog(resetStatsDialog)"
+              >
+                <nb-icon icon="refresh-outline"></nb-icon>
+              </button>
 
               <div class="pool-tile-layout pool-tile-layout--mirror" [class.pool-tile-layout--dual]="isDualPool">
 
@@ -660,3 +670,16 @@
     </div>
   </div>
 </div>
+
+<ng-template #resetStatsDialog let-ref="dialogRef">
+  <nb-card accent="warning" style="width: 340px">
+    <nb-card-header>{{ 'HOME.RESET_STATS' | translate }}</nb-card-header>
+    <nb-card-body>
+      <p>{{ 'HOME.RESET_STATS_CONFIRM' | translate }}</p>
+      <div class="d-flex justify-content-between">
+        <button nbButton status="warning" (click)="confirmResetStats(ref)">{{ 'COMMON.RESET' | translate }}</button>
+        <button nbButton status="basic" (click)="ref.close()">{{ 'COMMON.CANCEL' | translate }}</button>
+      </div>
+    </nb-card-body>
+  </nb-card>
+</ng-template>

--- a/main/http_server/axe-os/src/app/pages/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.ts
@@ -50,7 +50,7 @@ import {
   updateChartWithZoomAnimation,
 } from './chart';
 
-import { NbThemeService } from '@nebular/theme';
+import { NbThemeService, NbDialogService, NbToastrService } from '@nebular/theme';
 import { NbTrigger } from '@nebular/theme';
 import { TranslateService } from '@ngx-translate/core';
 import { LocalStorageService } from '../../services/local-storage.service';
@@ -505,7 +505,9 @@ export class HomeComponent implements AfterViewChecked, OnInit, OnDestroy {
     private hostEl: ElementRef<HTMLElement>,
     private renderer: Renderer2,
     private cdr: ChangeDetectorRef,
-    private ngZone: NgZone
+    private ngZone: NgZone,
+    private dialogService: NbDialogService,
+    private toastrService: NbToastrService
   ) {
     // Local persistence wrapper for chart state/settings
     this.chartStorage = new HomeChartStorage({
@@ -1877,6 +1879,24 @@ private setAxisPadding(cfg: any, persist: boolean = false): void {
 
   return (rejected / total) * 100;
 }
+  public openResetStatsDialog(template: any): void {
+    this.dialogService.open(template);
+  }
+
+  public confirmResetStats(ref: any): void {
+    ref.close();
+    this.systemService.resetStats().subscribe({
+      next: () => this.toastrService.success(
+        this.translateService.instant('HOME.RESET_STATS_SUCCESS'),
+        this.translateService.instant('COMMON.SUCCESS')
+      ),
+      error: () => this.toastrService.danger(
+        this.translateService.instant('HOME.RESET_STATS_FAILED'),
+        this.translateService.instant('COMMON.ERROR')
+      )
+    });
+  }
+
 private importHistoricalDataChunked(history: any): void {
     this.historyDrainer.ingest(history);
   }

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -216,6 +216,10 @@ export class SystemService {
     });
   }
 
+  public resetStats(uri: string = '') {
+    return this.httpClient.post(`${uri}/api/system/reset-stats`, null, { responseType: 'text' });
+  }
+
   public shutdown(uri: string = '', totp?: string) {
     let headers = new HttpHeaders();
     if (totp) headers = headers.set('X-TOTP', totp);

--- a/main/http_server/axe-os/src/assets/i18n/de.json
+++ b/main/http_server/axe-os/src/assets/i18n/de.json
@@ -69,7 +69,11 @@
     "SHARE_TOO_SMALL": "Anteil für diesen Pool zu klein!",
     "HIDE_CHART": "ausblenden",
     "SHOW_CHART": "einblenden",
-    "STRATUM_NOT_CONNECTED": "Stratum für diesen Pool nicht verbunden."
+    "STRATUM_NOT_CONNECTED": "Stratum für diesen Pool nicht verbunden.",
+    "RESET_STATS": "Sitzungsstatistiken zurücksetzen",
+    "RESET_STATS_CONFIRM": "Alle Sitzungsstatistiken zurücksetzen (Shares, beste Diff, Fehler)?",
+    "RESET_STATS_SUCCESS": "Sitzungsstatistiken zurückgesetzt.",
+    "RESET_STATS_FAILED": "Zurücksetzen fehlgeschlagen."
   },
   "PERFORMANCE": {
     "TITLE": "Leistung",

--- a/main/http_server/axe-os/src/assets/i18n/en.json
+++ b/main/http_server/axe-os/src/assets/i18n/en.json
@@ -71,7 +71,11 @@
     "SHARE_TOO_SMALL": "Share for this pool too small!",
     "HIDE_CHART": "Hide",
     "SHOW_CHART": "Show",
-    "STRATUM_NOT_CONNECTED": "Stratum not connected for this pool."
+    "STRATUM_NOT_CONNECTED": "Stratum not connected for this pool.",
+    "RESET_STATS": "Reset Session Stats",
+    "RESET_STATS_CONFIRM": "Reset all session stats (shares, best diff, errors)?",
+    "RESET_STATS_SUCCESS": "Session stats reset.",
+    "RESET_STATS_FAILED": "Failed to reset session stats."
   },
   "PERFORMANCE": {
     "TITLE": "Performance",

--- a/main/http_server/axe-os/src/assets/i18n/es.json
+++ b/main/http_server/axe-os/src/assets/i18n/es.json
@@ -69,7 +69,11 @@
     "SHARE_TOO_SMALL": "Porcentaje para este pool demasiado bajo!",
     "HIDE_CHART": "ocultar",
     "SHOW_CHART": "mostrar",
-    "STRATUM_NOT_CONNECTED": "Stratum no conectado para este pool."
+    "STRATUM_NOT_CONNECTED": "Stratum no conectado para este pool.",
+    "RESET_STATS": "Restablecer estadísticas de sesión",
+    "RESET_STATS_CONFIRM": "¿Restablecer todas las estadísticas de sesión (shares, mejor diff, errores)?",
+    "RESET_STATS_SUCCESS": "Estadísticas de sesión restablecidas.",
+    "RESET_STATS_FAILED": "Error al restablecer las estadísticas."
   },
   "PERFORMANCE": {
     "TITLE": "Rendimiento",

--- a/main/http_server/axe-os/src/assets/i18n/fr.json
+++ b/main/http_server/axe-os/src/assets/i18n/fr.json
@@ -70,7 +70,11 @@
     "SHARE_TOO_SMALL": "Pourcentage pour ce pool trop faible!",
     "HIDE_CHART": "masquer",
     "SHOW_CHART": "afficher",
-    "STRATUM_NOT_CONNECTED": "Stratum non connecté pour ce pool."
+    "STRATUM_NOT_CONNECTED": "Stratum non connecté pour ce pool.",
+    "RESET_STATS": "Réinitialiser les stats de session",
+    "RESET_STATS_CONFIRM": "Réinitialiser toutes les stats de session (shares, meilleure diff, erreurs) ?",
+    "RESET_STATS_SUCCESS": "Stats de session réinitialisées.",
+    "RESET_STATS_FAILED": "Échec de la réinitialisation."
   },
   "PERFORMANCE": {
     "TITLE": "Performance",

--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -462,3 +462,18 @@ esp_err_t GET_system_asic(httpd_req_t *req)
     doc.clear();
     return ret;
 }
+
+esp_err_t POST_reset_stats(httpd_req_t *req)
+{
+    ConGuard g(http_server, req);
+
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+
+    STRATUM_MANAGER->resetSessionStats();
+
+    ESP_LOGI(TAG, "Session stats reset by user");
+    httpd_resp_set_status(req, "204 No Content");
+    return httpd_resp_send(req, NULL, 0);
+}

--- a/main/http_server/handler_system.h
+++ b/main/http_server/handler_system.h
@@ -4,3 +4,4 @@ esp_err_t GET_system_info(httpd_req_t *req);
 esp_err_t PATCH_update_settings(httpd_req_t *req);
 
 esp_err_t GET_system_asic(httpd_req_t *req);
+esp_err_t POST_reset_stats(httpd_req_t *req);

--- a/main/http_server/http_server.cpp
+++ b/main/http_server/http_server.cpp
@@ -144,7 +144,7 @@ esp_err_t start_rest_server(void * pvParameters)
 
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.uri_match_fn = httpd_uri_match_wildcard;
-    config.max_uri_handlers = 30;
+    config.max_uri_handlers = 35;
     config.lru_purge_enable = true;
     config.max_open_sockets = 10;
     config.stack_size = 12288;
@@ -207,6 +207,10 @@ esp_err_t start_rest_server(void * pvParameters)
         .user_ctx = NULL
     };
     httpd_register_uri_handler(http_server, &system_restart_options_uri);
+
+    httpd_uri_t system_reset_stats_uri = {
+        .uri = "/api/system/reset-stats", .method = HTTP_POST, .handler = POST_reset_stats, .user_ctx = rest_context};
+    httpd_register_uri_handler(http_server, &system_reset_stats_uri);
 
     httpd_uri_t system_shutdown_uri = {
         .uri = "/api/system/shutdown", .method = HTTP_POST, .handler = POST_shutdown, .user_ctx = rest_context};

--- a/main/stratum/stratum_manager.h
+++ b/main/stratum/stratum_manager.h
@@ -92,6 +92,10 @@ class StratumManager {
     virtual int getPoolMode() = 0;
 
   public:
+    virtual void resetSessionStats() {
+        PThreadGuard lock(m_mutex);
+        m_foundBlocks = 0;
+    }
     StratumManager(PoolMode mode);
     static void taskWrapper(void *pvParameters); ///< Wrapper function for task execution
 

--- a/main/stratum/stratum_manager_dual_pool.h
+++ b/main/stratum/stratum_manager_dual_pool.h
@@ -97,6 +97,18 @@ class StratumManagerDualPool : public StratumManager {
         return (m_balance >= 50) ? m_networkDifficulty[0] : m_networkDifficulty[1];
     }
 
+    virtual void resetSessionStats() override {
+        PThreadGuard lock(m_mutex);
+        m_foundBlocks = 0;
+        for (int i = 0; i < 2; i++) {
+            m_accepted[i] = 0;
+            m_rejected[i] = 0;
+            m_bestSessionDiff[i] = 0;
+            suffixString(0, m_bestSessionDiffString, DIFF_STRING_SIZE, 0);
+            if (m_stratumTasks[i]) m_stratumTasks[i]->m_poolErrors = 0;
+        }
+    }
+
     virtual uint64_t getBestSessionDiff() {
         return std::max(m_bestSessionDiff[0], m_bestSessionDiff[1]);
     }

--- a/main/stratum/stratum_manager_fallback.h
+++ b/main/stratum/stratum_manager_fallback.h
@@ -80,6 +80,18 @@ class StratumManagerFallback : public StratumManager {
         return m_networkDifficulty;
     }
 
+    virtual void resetSessionStats() override {
+        PThreadGuard lock(m_mutex);
+        m_foundBlocks = 0;
+        m_accepted = 0;
+        m_rejected = 0;
+        m_bestSessionDiff = 0;
+        suffixString(0, m_bestSessionDiffString, DIFF_STRING_SIZE, 0);
+        for (int i = 0; i < 2; i++) {
+            if (m_stratumTasks[i]) m_stratumTasks[i]->m_poolErrors = 0;
+        }
+    }
+
     virtual int getPoolErrors() {
         return m_stratumTasks[0]->m_poolErrors + m_stratumTasks[1]->m_poolErrors;
     }


### PR DESCRIPTION
Adds a Reset Session Stats button to the top-right corner of the pool tile card on the dashboard. Clicking it opens a confirmation dialog, then calls the new POST `/api/system/reset-stats` endpoint which resets all session statistics (shares accepted/rejected, best session difficulty, pool errors, found blocks) without requiring a reboot. All-time stats (best difficulty, total found blocks) are not affected.


<img width="324" height="203" alt="image" src="https://github.com/user-attachments/assets/c4a9e473-9f30-431d-8b96-4a417228bb2a" />
