### PR TITLE
polish fan2 control

### DIFF
--- a/main/fan_controller.cpp
+++ b/main/fan_controller.cpp
@@ -102,19 +102,19 @@ void FanController::update(float chipTempMax, float vrTemp)
             m_pid[ch]->Compute();
         }
 
-        // LINKED: mirror channel-0 output (ch0 must be processed first)
-        if (m_config[ch].mode == Mode::LINKED && ch > 0) {
-            m_fanPerc[ch] = m_fanPerc[0];
-            m_board->setFanSpeedCh(ch, static_cast<float>(m_fanPerc[ch]) / 100.0f);
-            m_overheated[ch] = false;
-            continue;
-        }
-
-        // Overheat: drive fan to 100% and flag it
+        // Overheat: drive fan to 100% and flag it (checked even in LINKED mode for shutdown purposes)
         if (m_config[ch].overheatTemp && tempInput[ch] > m_config[ch].overheatTemp) {
             m_overheated[ch] = true;
             m_fanPerc[ch]    = 100;
             m_board->setFanSpeedCh(ch, 1.0f);
+            continue;
+        }
+        m_overheated[ch] = false;
+
+        // LINKED: mirror channel-0 output (ch0 must be processed first)
+        if (m_config[ch].mode == Mode::LINKED && ch > 0) {
+            m_fanPerc[ch] = m_fanPerc[0];
+            m_board->setFanSpeedCh(ch, static_cast<float>(m_fanPerc[ch]) / 100.0f);
             continue;
         }
         m_overheated[ch] = false;
@@ -153,4 +153,10 @@ bool FanController::isOverheated(int ch) const
 {
     if (ch < 0 || ch >= m_numChannels) return false;
     return m_overheated[ch];
+}
+
+uint16_t FanController::getOverheatTemp(int ch) const
+{
+    if (ch < 0 || ch >= m_numChannels) return 0;
+    return m_config[ch].overheatTemp;
 }

--- a/main/fan_controller.h
+++ b/main/fan_controller.h
@@ -66,6 +66,9 @@ public:
      */
     bool isOverheated(int ch) const;
 
+    /** Configured overheat threshold in °C for the given channel (0 = disabled). */
+    uint16_t getOverheatTemp(int ch) const;
+
 private:
     Board* m_board        = nullptr;
     int    m_numChannels  = 0;

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.html
@@ -284,8 +284,8 @@
             <nb-card-header>{{ 'FAN.TITLE' | translate }}</nb-card-header>
             <nb-tabset>
 
-                <!-- ── Fan 1 ─────────────────────────────────────────── -->
-                <nb-tab tabTitle="Fan 1">
+                <!-- ── Fan 1 (ASICs) ──────────────────────────────────── -->
+                <nb-tab tabTitle="ASICs">
                     <nb-card-body>
 
                         <!-- Connector hint Fan 1 (only when 2-fan board and unlinked) -->
@@ -365,8 +365,8 @@
                     </nb-card-body>
                 </nb-tab>
 
-                <!-- ── Fan 2 (nur bei 2-Lüfter-Boards) ───────────────── -->
-                <nb-tab tabTitle="Fan 2" *ngIf="fanCount > 1">
+                <!-- ── Fan 2 (VReg, nur bei 2-Lüfter-Boards) ─────────── -->
+                <nb-tab tabTitle="VReg" *ngIf="fanCount > 1">
                     <nb-card-body>
 
                         <!-- Linked-Checkbox -->
@@ -442,14 +442,15 @@
                                 </div>
                             </div>
 
-                            <div class="form-row-separator">
-                                <label for="fan1OverheatTemp" class="form-label">{{ 'SETTINGS.SHUTDOWN_TEMP' | translate }}:</label>
-                                <div class="form-control-wrapper">
-                                    <input nbInput id="fan1OverheatTemp" formControlName="fan1OverheatTemp" type="number" />
-                                </div>
-                            </div>
-
                         </ng-container>
+
+                        <div class="form-row-separator">
+                            <label for="fan1OverheatTemp" class="form-label">{{ 'SETTINGS.SHUTDOWN_TEMP' | translate }}:</label>
+                            <div class="form-control-wrapper">
+                                <input nbInput id="fan1OverheatTemp" formControlName="fan1OverheatTemp" type="number" />
+                            </div>
+                        </div>
+
                     </nb-card-body>
                 </nb-tab>
 

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
@@ -232,7 +232,7 @@ export class EditComponent implements OnInit {
 
           fan1Mode: [fan1cfg?.mode ?? 3, [Validators.required]],
           fan1ManualSpeed: [fan1cfg?.manualSpeed ?? 100, [Validators.min(0), Validators.max(100), Validators.required]],
-          fan1OverheatTemp: [fan1cfg?.overheatTemp ?? 80, [Validators.min(40), Validators.max(90), Validators.required]],
+          fan1OverheatTemp: [fan1cfg?.overheatTemp ?? 70, [Validators.min(40), Validators.max(90), Validators.required]],
           fan1PidTargetTemp: [fan1cfg?.pid?.targetTemp ?? 65, [Validators.min(30), Validators.max(80), Validators.required]],
           fan1PidP: [fan1cfg?.pid?.p ?? 6, [Validators.min(0), Validators.max(100), Validators.required]],
           fan1PidI: [fan1cfg?.pid?.i ?? 0.1, [Validators.min(0), Validators.max(10), Validators.required]],
@@ -292,9 +292,8 @@ export class EditComponent implements OnInit {
     const disable = (ctrl: string) => this.form.controls[ctrl]?.disable({ emitEvent: false });
 
     if (mode === 3) {
-      // LINKED — disable fan1-controls
+      // LINKED — disable fan1-controls (overheatTemp stays enabled for shutdown protection)
       disable('fan1ManualSpeed');
-      disable('fan1OverheatTemp');
       disable('fan1PidTargetTemp');
       disable('fan1PidP');
       disable('fan1PidI');

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -187,7 +187,7 @@ namespace Config {
     }
     inline uint16_t getFanOverheatTemp(int ch) {
         return ch == 0 ? nvs_config_get_u16(NVS_CONFIG_OVERHEAT_TEMP, CONFIG_OVERHEAT_TEMP)
-                       : nvs_config_get_u16(NVS_CONFIG_FAN1_OVERHEAT, 80);
+                       : nvs_config_get_u16(NVS_CONFIG_FAN1_OVERHEAT, CONFIG_OVERHEAT_TEMP);
     }
     inline uint16_t getFanPidTargetTemp(int ch, uint16_t d) {
         return ch == 0 ? nvs_config_get_u16(NVS_CONFIG_PID_TARGET_TEMP, d)

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -20,7 +20,7 @@
 
 static const char *TAG = "power_management";
 
-//#define MEASURE_LOOP_TIME
+// #define MEASURE_LOOP_TIME
 
 PowerManagementTask::PowerManagementTask()
 {
@@ -105,7 +105,6 @@ void PowerManagementTask::checkVrFrequencyChanged()
     }
 }
 
-
 void PowerManagementTask::logChipTemps()
 {
     size_t offset = 0;
@@ -184,8 +183,8 @@ void PowerManagementTask::readAndPublishPowerTelemetry()
     m_vrTemp = m_board->getVRTemp();
     m_vrTempInt = m_board->getVRTempInt();
 
-    ESP_LOGI(TAG, "vin: %.2f, iin: %.2f, pin: %.2f, vout: %.2f, iout: %.2f, pout: %.2f, vr-temp: %.2f, vr-temp-int: %.2f", vin, iin, pin, vout, iout,
-             pout, m_vrTemp, m_vrTempInt);
+    ESP_LOGI(TAG, "vin: %.2f, iin: %.2f, pin: %.2f, vout: %.2f, iout: %.2f, pout: %.2f, vr-temp: %.2f, vr-temp-int: %.2f", vin, iin,
+             pin, vout, iout, pout, m_vrTemp, m_vrTempInt);
 
     influx_task_set_pwr(vin, iin, pin, vout, iout, pout);
 
@@ -225,7 +224,8 @@ void PowerManagementTask::applyAsicSettings()
     checkVrFrequencyChanged();
 }
 
-void PowerManagementTask::requestChipTemps() {
+void PowerManagementTask::requestChipTemps()
+{
     // temperature measurements don't work before ASICs
     // are initialized
     if (!m_board->isInitialized()) {
@@ -257,21 +257,6 @@ void PowerManagementTask::task()
 
         uint64_t start = esp_timer_get_time();
         lock();
-/*
-        // don't suspend power management task in shutdown
-        if (m_shutdown) {
-            unlock();
-            ESP_LOGW(TAG, "suspended");
-            vTaskSuspend(NULL);
-        }
-*/
-        uint16_t asic_overheat_temp = Config::getOverheatTemp();
-
-        // overwrite previously allowed 0 value to disable
-        // over-temp shutdown
-        if (!asic_overheat_temp) {
-            asic_overheat_temp = 70;
-        }
 
         applyAsicSettings();
 
@@ -281,7 +266,6 @@ void PowerManagementTask::task()
         logChipTemps();
 
         readAndPublishPowerTelemetry();
-
 
         // collect temperatures
         // get the max of all asic measuring temp sensors
@@ -313,27 +297,24 @@ void PowerManagementTask::task()
 
         influx_task_set_temperature(m_chipTempMax, m_vrTemp);
 
-        float vr_maxTemp = asic_overheat_temp;
-        if (m_board->getVrMaxTemp()) {
-            vr_maxTemp = m_board->getVrMaxTemp();
-        }
+        // Run fan controller (reads RPM, drives fans, updates overheat flags)
+        m_fanController.update(m_chipTempMax, m_vrTemp);
 
-        if (asic_overheat_temp && (m_chipTempMax > asic_overheat_temp || m_vrTemp > vr_maxTemp)) {
-            uint32_t status = ((uint32_t) m_chipTempMax << 24) | ((uint32_t) asic_overheat_temp << 16) |
-                              ((uint32_t) m_vrTemp << 8) | ((uint32_t) vr_maxTemp << 8);
+        // Shutdown if any fan channel reports overheat
+        if (m_fanController.isOverheated(0) || m_fanController.isOverheated(1)) {
+            uint32_t status = ((uint32_t) m_chipTempMax << 24) | ((uint32_t) m_fanController.getOverheatTemp(0) << 16) |
+                              ((uint32_t) m_vrTemp << 8) | ((uint32_t) m_fanController.getOverheatTemp(1));
 
             // over temperature
             SYSTEM_MODULE.setBoardError(Board::Error::TEMP_FAULT, status);
 
             // disables the buck
             m_board->setVoltage(0.0);
-            ESP_LOGE(TAG, "System overheated - Shutting down asic voltage");
+            ESP_LOGE(TAG, "System overheated (chip=%.1f°C/thresh=%d°C vr=%.2f°C/thresh=%d°C) - Shutting down asic voltage",
+                     m_chipTempMax, m_fanController.getOverheatTemp(0), m_vrTemp, m_fanController.getOverheatTemp(1));
         }
-
-        // Run fan controller (reads RPM, drives fans, updates overheat flags)
-        m_fanController.update(m_chipTempMax, m_vrTemp);
-        influx_set_fan(m_fanController.getSpeedPerc(0), (float) m_fanController.getRPM(0),
-                       m_fanController.getSpeedPerc(1), (float) m_fanController.getRPM(1));
+        influx_set_fan(m_fanController.getSpeedPerc(0), (float) m_fanController.getRPM(0), m_fanController.getSpeedPerc(1),
+                       (float) m_fanController.getRPM(1));
         unlock();
 #ifdef MEASURE_LOOP_TIME
         // checks if loop takes too much time


### PR DESCRIPTION
- always enable fan2 shutdown temp in the settings
- renamed tab names from fan 1 and fan 2 to ASICs and VREG
- fixed shutdown logic
- default fan2 shutdown temp is the same as fan1 for backwards compatibility