### PR TITLE
Draft: control nonce space and timeouts for all all chip topologies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ components/components/*
 config.bin
 config.cvs
 managed_components/*
+release/
+esp-miner-*.bin

--- a/components/bm1397/asic.cpp
+++ b/components/bm1397/asic.cpp
@@ -220,6 +220,30 @@ void Asic::setNonceSpace(float frequency, uint16_t asic_count, uint16_t cores) {
     setVrFreqReg(hcn);
 }
 
+double Asic::calculateSearchSpaceMs(float frequency, uint16_t asic_count, uint16_t cores,
+                                     uint16_t small_cores, uint32_t version_count, float percent) {
+    if (asic_count <= 0 || frequency <= 0.0f) return 500.0;
+
+    int cores_up = next_power_of_two(cores);
+    int small_cores_up = next_power_of_two(small_cores);
+    int asic_count_up = next_power_of_two(asic_count);
+
+    if (small_cores_up < cores_up) return 500.0;
+
+    // midstates = parallel version searches per core
+    double midstates = (double)small_cores_up / (double)cores_up;
+    double serial_versions = (double)version_count / midstates;
+    double serial_nonces = NONCE_SPACE / (double)cores_up / (double)asic_count_up;
+    double fullspace_ms = serial_versions * serial_nonces / ((double)frequency * 1000.0);
+
+    if (fullspace_ms <= 0.0) return 500.0;
+
+    ESP_LOGI(TAG, "Search space: %.1f seconds (%.0f%% = %.1f seconds)",
+             fullspace_ms / 1000.0, percent * 100.0, fullspace_ms * percent / 1000.0);
+
+    return percent * fullspace_ms;
+}
+
 // default calculation using address_interval
 uint8_t Asic::chipIndexFromAddr(uint8_t addr) {
     return (m_addressInterval > 0) ? (addr / m_addressInterval) : 0;

--- a/components/bm1397/asic.cpp
+++ b/components/bm1397/asic.cpp
@@ -199,13 +199,6 @@ void Asic::setVrFrequency(uint32_t freq_hz) {
     setVrFreqReg(vrFreqToReg(freq_hz));
 }
 
-static int next_power_of_two(int num) {
-    if (num <= 1) return 1;
-    int power = 1;
-    while (power < num) power <<= 1;
-    return power;
-}
-
 void Asic::setNonceSpace(float frequency, uint16_t asic_count, uint16_t cores) {
     int cores_up = next_power_of_two(cores);
     int asic_count_up = next_power_of_two(asic_count);

--- a/components/bm1397/asic.cpp
+++ b/components/bm1397/asic.cpp
@@ -205,10 +205,12 @@ void Asic::setNonceSpace(float frequency, uint16_t asic_count, uint16_t cores) {
 
     float hcn_space = (float)NONCE_SPACE / cores_up / chips_from_interval;
     double hcn_max = hcn_space * (double)FREQ_MULT / frequency * 0.5;
+    // HW errata: 134 per half clock cycle = 268 overlap between cores
     uint32_t hcn = (uint32_t)hcn_max;
+    if (hcn > 268) hcn -= 268;
 
-    ESP_LOGI(TAG, "Setting nonce space: cores=%d(%d) chips=%d(interval=%d) freq=%.0f HCN=%lu",
-             cores, cores_up, chips_from_interval, m_addressInterval, frequency, (unsigned long)hcn);
+    ESP_LOGI(TAG, "Setting nonce space: cores=%d(%d) chips=%d(interval=%d) freq=%.0f HCN=%lu (max=%lu)",
+             cores, cores_up, chips_from_interval, m_addressInterval, frequency, (unsigned long)hcn, (unsigned long)(uint32_t)hcn_max);
 
     setVrFreqReg(hcn);
 }

--- a/components/bm1397/asic.cpp
+++ b/components/bm1397/asic.cpp
@@ -220,13 +220,13 @@ void Asic::setNonceSpace(float frequency, uint16_t asic_count, uint16_t cores) {
     setVrFreqReg(hcn);
 }
 
-// default calculation
+// default calculation using address_interval
 uint8_t Asic::chipIndexFromAddr(uint8_t addr) {
-    return addr >> 1;
+    return (m_addressInterval > 0) ? (addr / m_addressInterval) : 0;
 }
 
 uint8_t Asic::addrFromChipIndex(uint8_t idx) {
-    return idx << 1;
+    return idx * m_addressInterval;
 }
 
 void Asic::requestChipTemp() {
@@ -411,7 +411,9 @@ bool Asic::processWork(task_result *result)
 
     uint32_t rolled_version = (reverseUint16(asic_result.version) << 13); // shift the 16 bit value left 13
 
-    int asic_nr = nonceToAsicNr(asic_result.nonce);
+    // Extract ASIC number from nonce using address_interval (Bitaxe-style)
+    uint32_t nonce_h = __bswap32(asic_result.nonce);
+    int asic_nr = (m_addressInterval > 0) ? ((uint8_t)((nonce_h >> 17) & 0xff) / m_addressInterval) : 0;
 
     result->job_id = job_id;
     result->asic_nr = asic_nr;

--- a/components/bm1397/asic.cpp
+++ b/components/bm1397/asic.cpp
@@ -199,6 +199,27 @@ void Asic::setVrFrequency(uint32_t freq_hz) {
     setVrFreqReg(vrFreqToReg(freq_hz));
 }
 
+static int next_power_of_two(int num) {
+    if (num <= 1) return 1;
+    int power = 1;
+    while (power < num) power <<= 1;
+    return power;
+}
+
+void Asic::setNonceSpace(float frequency, uint16_t asic_count, uint16_t cores) {
+    int cores_up = next_power_of_two(cores);
+    int asic_count_up = next_power_of_two(asic_count);
+
+    float hcn_space = (float)NONCE_SPACE / cores_up / asic_count_up;
+    double hcn_max = hcn_space * (double)FREQ_MULT / frequency * 0.5;
+    uint32_t hcn = (uint32_t)hcn_max;
+
+    ESP_LOGI(TAG, "Setting nonce space: cores=%d(%d) asics=%d(%d) freq=%.0f HCN=%lu",
+             cores, cores_up, asic_count, asic_count_up, frequency, (unsigned long)hcn);
+
+    setVrFreqReg(hcn);
+}
+
 // default calculation
 uint8_t Asic::chipIndexFromAddr(uint8_t addr) {
     return addr >> 1;

--- a/components/bm1397/asic.cpp
+++ b/components/bm1397/asic.cpp
@@ -201,14 +201,14 @@ void Asic::setVrFrequency(uint32_t freq_hz) {
 
 void Asic::setNonceSpace(float frequency, uint16_t asic_count, uint16_t cores) {
     int cores_up = next_power_of_two(cores);
-    int asic_count_up = next_power_of_two(asic_count);
+    int chips_from_interval = (m_addressInterval > 0) ? (256 / m_addressInterval) : next_power_of_two(asic_count);
 
-    float hcn_space = (float)NONCE_SPACE / cores_up / asic_count_up;
+    float hcn_space = (float)NONCE_SPACE / cores_up / chips_from_interval;
     double hcn_max = hcn_space * (double)FREQ_MULT / frequency * 0.5;
     uint32_t hcn = (uint32_t)hcn_max;
 
-    ESP_LOGI(TAG, "Setting nonce space: cores=%d(%d) asics=%d(%d) freq=%.0f HCN=%lu",
-             cores, cores_up, asic_count, asic_count_up, frequency, (unsigned long)hcn);
+    ESP_LOGI(TAG, "Setting nonce space: cores=%d(%d) chips=%d(interval=%d) freq=%.0f HCN=%lu",
+             cores, cores_up, chips_from_interval, m_addressInterval, frequency, (unsigned long)hcn);
 
     setVrFreqReg(hcn);
 }

--- a/components/bm1397/asic.cpp
+++ b/components/bm1397/asic.cpp
@@ -167,13 +167,7 @@ int Asic::setMaxBaud(void)
     return 1000000;
 }
 
-// set version rolling frequency
-constexpr uint32_t ASIC_IO_CLK_HZ_U32 = 15'000'000u; // 15 MHz
-constexpr uint32_t VR_TICK_DIV_U32    = 5000u;       // VR counter increments every 5000 IO clock cycles
-constexpr uint32_t VR_TICK_HZ_U32     = ASIC_IO_CLK_HZ_U32 / VR_TICK_DIV_U32; // 3000 Hz
-constexpr uint64_t VR_REG_PER_HZ_U64  = 65536ull * VR_TICK_HZ_U32;            // 196,608,000
-
-// Version rolling frequency register @0x10 (MSB -> LSB)
+// Register 0x10 write (MSB -> LSB)
 void Asic::setVrFreqReg(uint32_t value) {
     ESP_LOGI(TAG, "setting 0x10 to %08lx", value);
     send6(CMD_WRITE_ALL, 0x00, 0x10,
@@ -181,22 +175,6 @@ void Asic::setVrFreqReg(uint32_t value) {
           static_cast<uint8_t>((value >> 16) & 0xFF),
           static_cast<uint8_t>((value >>  8) & 0xFF),
           static_cast<uint8_t>((value >>  0) & 0xFF));
-}
-
-// Convert desired VR frequency (Hz, integer) to register value for 0x10
-uint32_t Asic::vrFreqToReg(uint32_t freq_hz) {
-    // reg = round(VR_REG_PER_HZ / freq_hz) using integer division with rounding
-    return static_cast<uint32_t>((VR_REG_PER_HZ_U64 + (freq_hz / 2)) / freq_hz);
-}
-
-// Convert 0x10 register value back to VR frequency (Hz, integer)
-uint32_t Asic::vrRegToFreq(uint32_t reg) {
-    // freq = round(VR_REG_PER_HZ / reg) using integer division with rounding
-    return static_cast<uint32_t>((VR_REG_PER_HZ_U64 + (reg / 2)) / reg);
-}
-
-void Asic::setVrFrequency(uint32_t freq_hz) {
-    setVrFreqReg(vrFreqToReg(freq_hz));
 }
 
 void Asic::setNonceSpace(float frequency, uint16_t asic_count, uint16_t cores) {
@@ -213,30 +191,6 @@ void Asic::setNonceSpace(float frequency, uint16_t asic_count, uint16_t cores) {
              cores, cores_up, chips_from_interval, m_addressInterval, frequency, (unsigned long)hcn, (unsigned long)(uint32_t)hcn_max);
 
     setVrFreqReg(hcn);
-}
-
-double Asic::calculateSearchSpaceMs(float frequency, uint16_t asic_count, uint16_t cores,
-                                     uint16_t small_cores, uint32_t version_count, float percent) {
-    if (asic_count <= 0 || frequency <= 0.0f) return 500.0;
-
-    int cores_up = next_power_of_two(cores);
-    int small_cores_up = next_power_of_two(small_cores);
-    int asic_count_up = next_power_of_two(asic_count);
-
-    if (small_cores_up < cores_up) return 500.0;
-
-    // midstates = parallel version searches per core
-    double midstates = (double)small_cores_up / (double)cores_up;
-    double serial_versions = (double)version_count / midstates;
-    double serial_nonces = NONCE_SPACE / (double)cores_up / (double)asic_count_up;
-    double fullspace_ms = serial_versions * serial_nonces / ((double)frequency * 1000.0);
-
-    if (fullspace_ms <= 0.0) return 500.0;
-
-    ESP_LOGI(TAG, "Search space: %.1f seconds (%.0f%% = %.1f seconds)",
-             fullspace_ms / 1000.0, percent * 100.0, fullspace_ms * percent / 1000.0);
-
-    return percent * fullspace_ms;
 }
 
 // default calculation using address_interval

--- a/components/bm1397/bm1366.cpp
+++ b/components/bm1397/bm1366.cpp
@@ -102,8 +102,8 @@ uint8_t BM1366::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
 
     doFrequencyTransition(frequency);
 
-    // set 0x10
-    setVrFrequency(vrFrequency);
+    // set nonce search space based on frequency and core count
+    setNonceSpace((float)frequency, asic_count, getCoreCount());
 
     send6(CMD_WRITE_ALL, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF);
 

--- a/components/bm1397/bm1366.cpp
+++ b/components/bm1397/bm1366.cpp
@@ -33,11 +33,7 @@ const uint8_t* BM1366::getChipId() {
     return (uint8_t*) chip_id;
 }
 
-uint32_t BM1366::getDefaultVrFrequency() {
-    return vrRegToFreq(0x151c);
-};
-
-uint8_t BM1366::init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty, uint32_t vrFrequency)
+uint8_t BM1366::init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty)
 {
     // reset is done externally to not have board dependencies
 

--- a/components/bm1397/bm1366.cpp
+++ b/components/bm1397/bm1366.cpp
@@ -69,7 +69,7 @@ uint8_t BM1366::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
     sendChainInactive();
 
     // set chip address - distribute evenly across 0-255 range
-    m_addressInterval = (chip_counter > 0) ? (256 / chip_counter) : 2;
+    m_addressInterval = (chip_counter > 0) ? (256 / next_power_of_two(chip_counter)) : 2;
     for (uint8_t i = 0; i < chip_counter; i++) {
         setChipAddress(i * m_addressInterval);
     }

--- a/components/bm1397/bm1366.cpp
+++ b/components/bm1397/bm1366.cpp
@@ -68,9 +68,10 @@ uint8_t BM1366::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
     // chain inactive
     sendChainInactive();
 
-    // set chip address
+    // set chip address - distribute evenly across 0-255 range
+    m_addressInterval = (chip_counter > 0) ? (256 / chip_counter) : 2;
     for (uint8_t i = 0; i < chip_counter; i++) {
-        setChipAddress(i * 2);
+        setChipAddress(i * m_addressInterval);
     }
 
     // Core Register Control
@@ -88,21 +89,22 @@ uint8_t BM1366::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
     send6(CMD_WRITE_ALL, 0x00, 0x58, 0x02, 0x11, 0x11, 0x11);
 
     for (uint8_t i = 0; i < chip_counter; i++) {
+        uint8_t addr = i * m_addressInterval;
         // Reg_A8
-        send6(CMD_WRITE_SINGLE, i * 2, 0xA8, 0x00, 0x07, 0x01, 0xF0);
+        send6(CMD_WRITE_SINGLE, addr, 0xA8, 0x00, 0x07, 0x01, 0xF0);
         // Misc Control
-        send6(CMD_WRITE_SINGLE, i * 2, 0x18, 0xF0, 0x00, 0xC1, 0x00);
+        send6(CMD_WRITE_SINGLE, addr, 0x18, 0xF0, 0x00, 0xC1, 0x00);
         // Core Register Control
-        send6(CMD_WRITE_SINGLE, i * 2, 0x3C, 0x80, 0x00, 0x85, 0x40);
+        send6(CMD_WRITE_SINGLE, addr, 0x3C, 0x80, 0x00, 0x85, 0x40);
         // Core Register Control
-        send6(CMD_WRITE_SINGLE, i * 2, 0x3C, 0x80, 0x00, 0x80, 0x20);
+        send6(CMD_WRITE_SINGLE, addr, 0x3C, 0x80, 0x00, 0x80, 0x20);
         // Core Register Control
-        send6(CMD_WRITE_SINGLE, i * 2, 0x3C, 0x80, 0x00, 0x82, 0xAA);
+        send6(CMD_WRITE_SINGLE, addr, 0x3C, 0x80, 0x00, 0x82, 0xAA);
     }
 
     doFrequencyTransition(frequency);
 
-    // set nonce search space based on frequency and core count
+    // set nonce search space (register 0x10) based on frequency and core count
     setNonceSpace((float)frequency, asic_count, getCoreCount());
 
     send6(CMD_WRITE_ALL, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF);

--- a/components/bm1397/bm1368.cpp
+++ b/components/bm1397/bm1368.cpp
@@ -103,8 +103,8 @@ uint8_t BM1368::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
 
     doFrequencyTransition(frequency);
 
-    // set 0x10
-    setVrFrequency(vrFrequency);
+    // set nonce search space based on frequency and core count
+    setNonceSpace((float)frequency, asic_count, getCoreCount());
 
     send6(CMD_WRITE_ALL, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF);
 

--- a/components/bm1397/bm1368.cpp
+++ b/components/bm1397/bm1368.cpp
@@ -33,12 +33,7 @@ const uint8_t* BM1368::getChipId() {
     return (uint8_t*) chip_id;
 }
 
-uint32_t BM1368::getDefaultVrFrequency() {
-    return vrRegToFreq(0x15a4);
-};
-
-
-uint8_t BM1368::init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty, uint32_t vrFrequency)
+uint8_t BM1368::init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty)
 {
     // reset is done externally to not have board dependencies
 

--- a/components/bm1397/bm1368.cpp
+++ b/components/bm1397/bm1368.cpp
@@ -70,7 +70,7 @@ uint8_t BM1368::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
     sendChainInactive();
 
     // set chip address - distribute evenly across 0-255 range
-    m_addressInterval = (chip_counter > 0) ? (256 / chip_counter) : 2;
+    m_addressInterval = (chip_counter > 0) ? (256 / next_power_of_two(chip_counter)) : 2;
     for (uint8_t i = 0; i < chip_counter; i++) {
         setChipAddress(i * m_addressInterval);
     }

--- a/components/bm1397/bm1368.cpp
+++ b/components/bm1397/bm1368.cpp
@@ -69,9 +69,10 @@ uint8_t BM1368::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
     // chain inactive
     sendChainInactive();
 
-    // set chip address
+    // set chip address - distribute evenly across 0-255 range
+    m_addressInterval = (chip_counter > 0) ? (256 / chip_counter) : 2;
     for (uint8_t i = 0; i < chip_counter; i++) {
-        setChipAddress(i * 2);
+        setChipAddress(i * m_addressInterval);
     }
 
     // Core Register Control
@@ -89,21 +90,22 @@ uint8_t BM1368::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
     send6(CMD_WRITE_ALL, 0x00, 0x58, 0x02, 0x11, 0x11, 0x11);
 
     for (uint8_t i = 0; i < chip_counter; i++) {
+        uint8_t addr = i * m_addressInterval;
         // Reg_A8
-        send6(CMD_WRITE_SINGLE, i * 2, 0xA8, 0x00, 0x07, 0x01, 0xF0);
+        send6(CMD_WRITE_SINGLE, addr, 0xA8, 0x00, 0x07, 0x01, 0xF0);
         // Misc Control
-        send6(CMD_WRITE_SINGLE, i * 2, 0x18, 0xF0, 0x00, 0xC1, 0x00);
+        send6(CMD_WRITE_SINGLE, addr, 0x18, 0xF0, 0x00, 0xC1, 0x00);
         // Core Register Control
-        send6(CMD_WRITE_SINGLE, i * 2, 0x3C, 0x80, 0x00, 0x8B, 0x00);
+        send6(CMD_WRITE_SINGLE, addr, 0x3C, 0x80, 0x00, 0x8B, 0x00);
         // Core Register Control
-        send6(CMD_WRITE_SINGLE, i * 2, 0x3C, 0x80, 0x00, 0x80, 0x18);
+        send6(CMD_WRITE_SINGLE, addr, 0x3C, 0x80, 0x00, 0x80, 0x18);
         // Core Register Control
-        send6(CMD_WRITE_SINGLE, i * 2, 0x3C, 0x80, 0x00, 0x82, 0xAA);
+        send6(CMD_WRITE_SINGLE, addr, 0x3C, 0x80, 0x00, 0x82, 0xAA);
     }
 
     doFrequencyTransition(frequency);
 
-    // set nonce search space based on frequency and core count
+    // set nonce search space (register 0x10) based on frequency and core count
     setNonceSpace((float)frequency, asic_count, getCoreCount());
 
     send6(CMD_WRITE_ALL, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF);

--- a/components/bm1397/bm1370.cpp
+++ b/components/bm1397/bm1370.cpp
@@ -122,8 +122,8 @@ uint8_t BM1370::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
 
     doFrequencyTransition(frequency);
 
-    // set 0x10
-    setVrFrequency(vrFrequency);
+    // set nonce search space based on frequency and core count
+    setNonceSpace((float)frequency, asic_count, getCoreCount());
 
     send6(CMD_WRITE_ALL, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF);
 

--- a/components/bm1397/bm1370.cpp
+++ b/components/bm1397/bm1370.cpp
@@ -36,11 +36,7 @@ const uint8_t* BM1370::getChipId() {
     return (uint8_t*) chip_id;
 }
 
-uint32_t BM1370::getDefaultVrFrequency() {
-    return vrRegToFreq(0x1eb5);
-};
-
-uint8_t BM1370::init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty, uint32_t vrFrequency)
+uint8_t BM1370::init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty)
 {
     // reset is done externally to not have board dependencies
 

--- a/components/bm1397/bm1370.cpp
+++ b/components/bm1397/bm1370.cpp
@@ -73,7 +73,7 @@ uint8_t BM1370::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
     sendChainInactive();
 
     // set chip address - distribute evenly across 0-255 range
-    m_addressInterval = (chip_counter > 0) ? (256 / chip_counter) : 4;
+    m_addressInterval = (chip_counter > 0) ? (256 / next_power_of_two(chip_counter)) : 4;
     for (uint8_t i = 0; i < chip_counter; i++) {
         setChipAddress(i * m_addressInterval);
     }

--- a/components/bm1397/bm1370.cpp
+++ b/components/bm1397/bm1370.cpp
@@ -72,9 +72,10 @@ uint8_t BM1370::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
     // chain inactive
     sendChainInactive();
 
-    // set chip address
+    // set chip address - distribute evenly across 0-255 range
+    m_addressInterval = (chip_counter > 0) ? (256 / chip_counter) : 4;
     for (uint8_t i = 0; i < chip_counter; i++) {
-        setChipAddress(i * 4);
+        setChipAddress(i * m_addressInterval);
     }
 
     // Core Register Control
@@ -96,16 +97,17 @@ uint8_t BM1370::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
     //send6(CMD_WRITE_ALL, 0x00, 0x28, 0x01, 0x30, 0x00, 0x00);
 
     for (uint8_t i = 0; i < chip_counter; i++) {
+        uint8_t addr = i * m_addressInterval;
         // Reg_A8
-        send6(CMD_WRITE_SINGLE, i * 4, 0xA8, 0x00, 0x07, 0x01, 0xF0);
+        send6(CMD_WRITE_SINGLE, addr, 0xA8, 0x00, 0x07, 0x01, 0xF0);
         // Misc Control
-        send6(CMD_WRITE_SINGLE, i * 4, 0x18, 0xF0, 0x00, 0xC1, 0x00);
+        send6(CMD_WRITE_SINGLE, addr, 0x18, 0xF0, 0x00, 0xC1, 0x00);
         // Core Register Control
-        send6(CMD_WRITE_SINGLE, i * 4, 0x3C, 0x80, 0x00, 0x8B, 0x00);
+        send6(CMD_WRITE_SINGLE, addr, 0x3C, 0x80, 0x00, 0x8B, 0x00);
         // Core Register Control
-        send6(CMD_WRITE_SINGLE, i * 4, 0x3C, 0x80, 0x00, 0x80, 0x0C);
+        send6(CMD_WRITE_SINGLE, addr, 0x3C, 0x80, 0x00, 0x80, 0x0C);
         // Core Register Control
-        send6(CMD_WRITE_SINGLE, i * 4, 0x3C, 0x80, 0x00, 0x82, 0xAA);
+        send6(CMD_WRITE_SINGLE, addr, 0x3C, 0x80, 0x00, 0x82, 0xAA);
     }
 
     // ?
@@ -122,7 +124,7 @@ uint8_t BM1370::init(uint64_t frequency, uint16_t asic_count, uint32_t difficult
 
     doFrequencyTransition(frequency);
 
-    // set nonce search space based on frequency and core count
+    // set nonce search space (register 0x10) based on frequency and core count
     setNonceSpace((float)frequency, asic_count, getCoreCount());
 
     send6(CMD_WRITE_ALL, 0x00, 0xA4, 0x90, 0x00, 0xFF, 0xFF);
@@ -143,13 +145,8 @@ uint8_t BM1370::nonceToAsicNr(uint32_t nonce) {
     return (uint8_t) ((nonce & 0x0000fc00) >> 11);
 }
 
-uint8_t BM1370::chipIndexFromAddr(uint8_t addr) {
-    return addr >> 2;
-}
-
-uint8_t BM1370::addrFromChipIndex(uint8_t idx) {
-    return idx << 2;
-}
+// chipIndexFromAddr and addrFromChipIndex now use base class
+// implementation with m_addressInterval (set during init)
 
 uint16_t BM1370::getSmallCoreCount() {
     return BM1370_SMALL_CORE_COUNT;

--- a/components/bm1397/include/asic.h
+++ b/components/bm1397/include/asic.h
@@ -122,6 +122,8 @@ public:
 
     void setVrFrequency(uint32_t freq);
     void setNonceSpace(float frequency, uint16_t asic_count, uint16_t cores);
+    double calculateSearchSpaceMs(float frequency, uint16_t asic_count, uint16_t cores,
+                                   uint16_t small_cores, uint32_t version_count, float percent);
     virtual uint32_t getDefaultVrFrequency() = 0;
     virtual uint16_t getCoreCount() = 0;
 

--- a/components/bm1397/include/asic.h
+++ b/components/bm1397/include/asic.h
@@ -36,6 +36,13 @@
 #define FREQ_MULT 25.0
 #define NONCE_SPACE 4294967296.0 // 2^32
 
+static inline int next_power_of_two(int num) {
+    if (num <= 1) return 1;
+    int power = 1;
+    while (power < num) power <<= 1;
+    return power;
+}
+
 #define CLOCK_ORDER_CONTROL_0 0x80
 #define CLOCK_ORDER_CONTROL_1 0x84
 #define ORDERED_CLOCK_ENABLE 0x20

--- a/components/bm1397/include/asic.h
+++ b/components/bm1397/include/asic.h
@@ -109,10 +109,6 @@ protected:
     virtual uint8_t chipIndexFromAddr(uint8_t addr);
     virtual uint8_t addrFromChipIndex(uint8_t idx);
 
-    // helper functions
-    uint32_t vrFreqToReg(uint32_t freq_hz);
-    uint32_t vrRegToFreq(uint32_t reg);
-
     virtual uint8_t nonceToAsicNr(uint32_t nonce) = 0;
 
 public:
@@ -127,14 +123,10 @@ public:
     virtual void readCounter(uint8_t reg);
     virtual uint16_t getSmallCoreCount() = 0;
 
-    void setVrFrequency(uint32_t freq);
     void setNonceSpace(float frequency, uint16_t asic_count, uint16_t cores);
-    double calculateSearchSpaceMs(float frequency, uint16_t asic_count, uint16_t cores,
-                                   uint16_t small_cores, uint32_t version_count, float percent);
-    virtual uint32_t getDefaultVrFrequency() = 0;
     virtual uint16_t getCoreCount() = 0;
 
-    virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty, uint32_t vrFrequency) = 0;
+    virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty) = 0;
     virtual int setMaxBaud(void);
 };
 

--- a/components/bm1397/include/asic.h
+++ b/components/bm1397/include/asic.h
@@ -80,6 +80,7 @@ protected:
     float m_current_frequency;
     float m_actual_current_frequency;
     uint32_t m_asicDifficulty;
+    uint8_t m_addressInterval = 2; ///< Chip address spacing (set during init)
 
     void send(uint8_t header, uint8_t *data, uint8_t data_len);
     void send2(uint8_t header, uint8_t b0, uint8_t b1);

--- a/components/bm1397/include/asic.h
+++ b/components/bm1397/include/asic.h
@@ -34,6 +34,7 @@
 
 #define SLEEP_TIME 20
 #define FREQ_MULT 25.0
+#define NONCE_SPACE 4294967296.0 // 2^32
 
 #define CLOCK_ORDER_CONTROL_0 0x80
 #define CLOCK_ORDER_CONTROL_1 0x84
@@ -119,7 +120,9 @@ public:
     virtual uint16_t getSmallCoreCount() = 0;
 
     void setVrFrequency(uint32_t freq);
+    void setNonceSpace(float frequency, uint16_t asic_count, uint16_t cores);
     virtual uint32_t getDefaultVrFrequency() = 0;
+    virtual uint16_t getCoreCount() = 0;
 
     virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty, uint32_t vrFrequency) = 0;
     virtual int setMaxBaud(void);

--- a/components/bm1397/include/bm1366.h
+++ b/components/bm1397/include/bm1366.h
@@ -19,5 +19,6 @@ public:
     virtual const char* getName() { return "BM1366"; };
     virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty, uint32_t vrFrequency);
     virtual uint16_t getSmallCoreCount();
+    virtual uint16_t getCoreCount() { return 112; }
 };
 

--- a/components/bm1397/include/bm1366.h
+++ b/components/bm1397/include/bm1366.h
@@ -8,7 +8,6 @@
 class BM1366 : public Asic {
 protected:
     virtual const uint8_t* getChipId();
-    virtual uint32_t getDefaultVrFrequency();
 
     virtual uint8_t jobToAsicId(uint8_t job_id);
     virtual uint8_t asicToJobId(uint8_t asic_id);
@@ -17,7 +16,7 @@ protected:
 public:
     BM1366();
     virtual const char* getName() { return "BM1366"; };
-    virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty, uint32_t vrFrequency);
+    virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty);
     virtual uint16_t getSmallCoreCount();
     virtual uint16_t getCoreCount() { return 112; }
 };

--- a/components/bm1397/include/bm1368.h
+++ b/components/bm1397/include/bm1368.h
@@ -20,5 +20,6 @@ public:
     virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty, uint32_t vrFrequency);
     virtual void requestChipTemp();
     virtual uint16_t getSmallCoreCount();
+    virtual uint16_t getCoreCount() { return 80; }
 };
 

--- a/components/bm1397/include/bm1368.h
+++ b/components/bm1397/include/bm1368.h
@@ -8,7 +8,6 @@
 class BM1368 : public Asic {
 protected:
     virtual const uint8_t* getChipId();
-    virtual uint32_t getDefaultVrFrequency();
 
     virtual uint8_t jobToAsicId(uint8_t job_id);
     virtual uint8_t asicToJobId(uint8_t asic_id);
@@ -17,7 +16,7 @@ protected:
 public:
     BM1368();
     virtual const char* getName() { return "BM1368"; };
-    virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty, uint32_t vrFrequency);
+    virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty);
     virtual void requestChipTemp();
     virtual uint16_t getSmallCoreCount();
     virtual uint16_t getCoreCount() { return 80; }

--- a/components/bm1397/include/bm1370.h
+++ b/components/bm1397/include/bm1370.h
@@ -8,7 +8,6 @@
 class BM1370 : public Asic {
 protected:
     virtual const uint8_t* getChipId();
-    virtual uint32_t getDefaultVrFrequency();
 
     virtual uint8_t jobToAsicId(uint8_t job_id);
     virtual uint8_t asicToJobId(uint8_t asic_id);
@@ -17,7 +16,7 @@ protected:
 public:
     BM1370();
     virtual const char* getName() { return "BM1370"; };
-    virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty, uint32_t vrFrequency);
+    virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty);
     virtual uint16_t getSmallCoreCount();
     virtual uint16_t getCoreCount() { return 128; }
 };

--- a/components/bm1397/include/bm1370.h
+++ b/components/bm1397/include/bm1370.h
@@ -21,5 +21,6 @@ public:
     virtual const char* getName() { return "BM1370"; };
     virtual uint8_t init(uint64_t frequency, uint16_t asic_count, uint32_t difficulty, uint32_t vrFrequency);
     virtual uint16_t getSmallCoreCount();
+    virtual uint16_t getCoreCount() { return 128; }
 };
 

--- a/components/bm1397/include/bm1370.h
+++ b/components/bm1397/include/bm1370.h
@@ -14,8 +14,6 @@ protected:
     virtual uint8_t asicToJobId(uint8_t asic_id);
 
     virtual uint8_t nonceToAsicNr(uint32_t nonce);
-    virtual uint8_t chipIndexFromAddr(uint8_t addr);
-    virtual uint8_t addrFromChipIndex(uint8_t idx);
 public:
     BM1370();
     virtual const char* getName() { return "BM1370"; };

--- a/main/boards/board.cpp
+++ b/main/boards/board.cpp
@@ -12,7 +12,6 @@ const static char* TAG = "board";
 Board::Board() {
     m_absMaxAsicFrequency = 0;
     m_absMaxAsicVoltageMillis = 0;
-    m_vrFrequency = m_defaultVrFrequency = 0;
     m_hasHashCounter = false;
     m_ecoAsicFrequency = 0;
     m_ecoAsicVoltageMillis = 0;
@@ -41,7 +40,6 @@ void Board::loadSettings()
     m_asicJobIntervalMs = Config::getAsicJobInterval(m_asicJobIntervalMs);
     m_fanInvertPolarity = Config::isFanPolarity(m_fanInvertPolarity);
     m_flipScreen = Config::isFlipScreenEnabled(m_flipScreen);
-    m_vrFrequency = Config::getVrFrequency(m_defaultVrFrequency);
 
     for (int ch = 0; ch < 2; ch++) {
         m_pidSettings[ch].targetTemp = Config::getFanPidTargetTemp(ch, m_pidSettings[ch].targetTemp);
@@ -144,15 +142,6 @@ bool Board::setAsicFrequency(float frequency) {
     }
 
     return m_asics->setAsicFrequency(frequency);
-}
-
-// set and get version rolling frequency
-// requires loadSettings to update the variables
-void Board::setVrFrequency(uint32_t freq) {
-    if (!m_asics) {
-        return;
-    }
-    m_asics->setVrFrequency(freq);
 }
 
 bool Board::validateVoltage(float core_voltage) {

--- a/main/boards/board.h
+++ b/main/boards/board.h
@@ -40,8 +40,6 @@ public:
     int m_numTempSensors = 0;
     float *m_chipTemps;
     const char *m_swarmColorName = "blue";
-    uint32_t m_vrFrequency;
-    uint32_t m_defaultVrFrequency;
     bool m_hasHashCounter;
     const char *m_defaultTheme = "cosmic";
 
@@ -124,8 +122,6 @@ public:
     virtual bool setAsicFrequency(float f);
     bool validateFrequency(float frequency);
     bool validateVoltage(float core_voltage);
-
-    void setVrFrequency(uint32_t freq);
 
     // abstract common methos
     virtual bool setVoltage(float core_voltage) = 0;
@@ -241,14 +237,6 @@ public:
     int getEcoAsicFrequency()
     {
         return m_ecoAsicFrequency;
-    }
-
-    uint32_t getDefaultVrFrequency() {
-        return m_defaultVrFrequency;
-    }
-
-    uint32_t getVrFrequency() {
-        return m_vrFrequency;
     }
 
     float getMinPin()

--- a/main/boards/nerdaxe.cpp
+++ b/main/boards/nerdaxe.cpp
@@ -73,7 +73,6 @@ NerdAxe::NerdAxe() : Board() {
 
     m_asics = new BM1366();
     m_hasHashCounter = true;
-    m_vrFrequency = m_defaultVrFrequency = m_asics->getDefaultVrFrequency();
 }
 
 /**
@@ -165,7 +164,7 @@ bool NerdAxe::initAsics()
     vTaskDelay(pdMS_TO_TICKS(250));
 
     SERIAL_clear_buffer();
-    m_chipsDetected = m_asics->init(m_asicFrequency, m_asicCount, m_asicMaxDifficulty, m_vrFrequency);
+    m_chipsDetected = m_asics->init(m_asicFrequency, m_asicCount, m_asicMaxDifficulty);
     if (!m_chipsDetected) {
         ESP_LOGE(TAG, "error initializing asics!");
         return false;

--- a/main/boards/nerdaxegamma.cpp
+++ b/main/boards/nerdaxegamma.cpp
@@ -63,7 +63,6 @@ NerdaxeGamma::NerdaxeGamma() : NerdAxe() {
 
     m_asics = new BM1370();
     m_hasHashCounter = true;
-    m_vrFrequency = m_defaultVrFrequency = m_asics->getDefaultVrFrequency();
 }
 
 
@@ -135,7 +134,7 @@ bool NerdaxeGamma::initAsics() {
     vTaskDelay(pdMS_TO_TICKS(250));
 
     SERIAL_clear_buffer();
-    m_chipsDetected = m_asics->init(m_asicFrequency, m_asicCount, m_asicMaxDifficulty, m_vrFrequency);
+    m_chipsDetected = m_asics->init(m_asicFrequency, m_asicCount, m_asicMaxDifficulty);
     if (!m_chipsDetected) {
         ESP_LOGE(TAG, "error initializing asics!");
         return false;

--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -77,7 +77,7 @@ NerdQaxePlus::NerdQaxePlus() : Board() {
 
     m_asics = new BM1368();
     m_hasHashCounter = true;
-    m_vrFrequency = m_defaultVrFrequency = m_asics->getDefaultVrFrequency();
+
 
     m_tps = new TPS53647();
 }
@@ -170,7 +170,7 @@ bool NerdQaxePlus::initAsics()
     vTaskDelay(pdMS_TO_TICKS(250));
 
     SERIAL_clear_buffer();
-    m_chipsDetected = m_asics->init(m_asicFrequency, m_asicCount, m_asicMaxDifficulty, m_vrFrequency);
+    m_chipsDetected = m_asics->init(m_asicFrequency, m_asicCount, m_asicMaxDifficulty);
     if (!m_chipsDetected) {
         ESP_LOGE(TAG, "error initializing asics!");
         return false;

--- a/main/boards/nerdqaxeplus2.cpp
+++ b/main/boards/nerdqaxeplus2.cpp
@@ -42,7 +42,6 @@ NerdQaxePlus2::NerdQaxePlus2() : NerdQaxePlus() {
 #endif
     m_asics = new BM1370();
     m_hasHashCounter = true;
-    m_vrFrequency = m_defaultVrFrequency = m_asics->getDefaultVrFrequency();
 }
 
 float NerdQaxePlus2::getTemperature(int index) {

--- a/main/boards/nerdqx.cpp
+++ b/main/boards/nerdqx.cpp
@@ -71,7 +71,6 @@ NerdQX::NerdQX() : NerdQaxePlus2() {
 
     m_swarmColorName = "#7300e7";
     m_defaultTheme = "default"; // light theme
-    m_vrFrequency = m_defaultVrFrequency = 35000;
 }
 
 bool NerdQX::initBoard() {

--- a/main/http_server/axe-os/src/app/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/app/models/ISystemInfo.ts
@@ -83,8 +83,6 @@ export interface ISystemInfo {
     lastpingrtt: number,
     recentpingloss: number,
     stratum_keep: number,
-    defaultVrFrequency?: number,
-    vrFrequency: number,
     shutdown: boolean,
 
     stratum: IStratum,

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.html
@@ -248,24 +248,6 @@
                             <small>Mining job switching time in milliseconds.</small>
                         </div>
                     </div>
-                    <div class="form-row" *ngIf="defaultVrFrequency !== undefined">
-                        <label for="vrFrequency" class="form-label">VR-Frequency:</label>
-                        <div class="form-control-wrapper">
-                            <input nbInput id="vrFrequency" formControlName="vrFrequency" type="number" /><br />
-                        </div>
-                    </div>
-                    <div class="form-row" *ngIf="defaultVrFrequency !== undefined">
-                        <div class="form-control-wrapper-no-label">
-                            <small>
-                                Version Rolling
-                                Frequency.<!-- (Default <b>{{ defaultVrFrequency | number:'1.3-3' }} Hz</b>).-->
-                            </small>
-                            <br />
-                            <small>
-                                Calculated wrap-around time: <b>{{ wrapAroundTime | number:'1.2-2' }} s</b>
-                            </small>
-                        </div>
-                    </div>
                 </ng-container>
                 <ng-container *ngIf="supportLevel >= 1">
                     <div class="form-row">

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
@@ -38,7 +38,6 @@ export class EditComponent implements OnInit {
 
   public defaultFrequency: number = 0;
   public defaultCoreVoltage: number = 0;
-  public defaultVrFrequency: number = 0;
   public fanCount: number = 1;
   public fanLabels: string[] = ['Fan 1', 'Fan 2'];
 
@@ -109,8 +108,6 @@ export class EditComponent implements OnInit {
         // Store raw options (can be empty if the endpoint returns nothing)
         this.asicFrequencyValues = asic?.frequencyOptions ?? [];
         this.asicVoltageValues = asic?.voltageOptions ?? [];
-
-        this.defaultVrFrequency = info.defaultVrFrequency ?? undefined;
 
         this.fanCount = info.fans?.length ?? info.fanCount ?? 1;
         this.fanLabels = info.fans?.map((f, i) => f.label || `Fan ${i + 1}`) ?? ['Fan 1', 'Fan 2'];
@@ -221,12 +218,6 @@ export class EditComponent implements OnInit {
             Validators.min(40),
             Validators.max(90),
             Validators.required
-          ]],
-          vrFrequency: [info.vrFrequency, [
-            Validators.min(1000),
-            Validators.max(100000),
-            Validators.pattern(/^\d+$/),   // only ints
-            Validators.required,
           ]],
           otpEnabled: [info.otp],
 
@@ -534,14 +525,6 @@ export class EditComponent implements OnInit {
     this.runSaveWithOptionalOtp();
   }
 
-  get wrapAroundTime(): number {
-    const freq = this.form.get('vrFrequency')?.value;
-    if (!freq || freq <= 0) {
-      return 0;
-    }
-    const wrap = 65536 / freq; // seconds
-    return wrap;
-  }
 
   private runSaveWithOptionalOtp(): void {
     this.otpAuth.ensureOtp$(

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -81,7 +81,6 @@ const defaultInfo: ISystemInfo = {
   recentpingloss: 0.00,
   poolDifficulty: 0,
   stratum_keep: 0,
-  vrFrequency: 25000,
   defaultTheme: "cosmic",
   shutdown: false,
 

--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -15,8 +15,6 @@
 
 static const char *TAG = "http_system";
 
-#define VR_FREQUENCY_ENABLED
-
 uint64_t getDuplicateHWNonces();
 
 /* Simple handler for getting system handler */
@@ -220,10 +218,6 @@ esp_err_t GET_system_info(httpd_req_t *req)
     doc["invertfanpolarity"]  = board->isInvertFanPolarityEnabled() ? 1 : 0;
     doc["autofanspeed"]       = Config::getTempControlMode();
     doc["stratum_keep"]       = Config::isStratumKeepaliveEnabled() ? 1 : 0;
-#ifdef VR_FREQUENCY_ENABLED
-    doc["vrFrequency"]        = board->getVrFrequency();
-    doc["defaultVrFrequency"] = board->getDefaultVrFrequency();
-#endif
     doc["otp"]                = Config::isOTPEnabled(); // flag if otp is enabled
 
     // system screen
@@ -352,12 +346,6 @@ esp_err_t PATCH_update_settings(httpd_req_t *req)
     if (doc["pidD"].is<float>()) {
         Config::setPidD((uint16_t) (doc["pidD"].as<float>() * 100.0f));
     }
-#ifdef VR_FREQUENCY_ENABLED
-    if (doc["vrFrequency"].is<uint32_t>()) {
-        Config::setVrFrequency(doc["vrFrequency"].as<uint32_t>());
-    }
-#endif
-
     // Per-channel fan settings: fans[0] maps to ch0 NVS keys, fans[1] to ch1 NVS keys
     if (doc["fans"].is<JsonArray>()) {
         JsonArray fans = doc["fans"].as<JsonArray>();

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -68,8 +68,6 @@
 
 #define NVS_CONFIG_SWARM "swarmconfig"
 
-#define NVS_CONFIG_VR_FREQUENCY "vr_frequency"
-
 // device global stats
 #define NVS_TOTAL_FOUND_BLOCKS "totalblocks"
 #define NVS_CONFIG_BEST_DIFF "bestdiff"
@@ -245,8 +243,6 @@ namespace Config {
     inline void setBestDiff(uint64_t value) { nvs_config_set_u64(NVS_CONFIG_BEST_DIFF, value); }
     inline void setStratumDifficulty(uint32_t value) { nvs_config_set_u64(NVS_CONFIG_STRATUM_DIFFICULTY, value); }
     inline void setTotalFoundBlocks(uint32_t value) { nvs_config_set_u64(NVS_TOTAL_FOUND_BLOCKS, value); }
-    inline void setVrFrequency(uint32_t value) { nvs_config_set_u64(NVS_CONFIG_VR_FREQUENCY, value); }
-
     // ---- Boolean Getters (Stored as uint16_t but used as bool) ----
     inline bool isInvertScreenEnabled() { return nvs_config_get_u16(NVS_CONFIG_INVERT_SCREEN, 0) != 0; } // todo unused?
     inline bool isSelfTestEnabled() { return nvs_config_get_u16(NVS_CONFIG_SELF_TEST, 0) != 0; }
@@ -289,8 +285,6 @@ namespace Config {
     inline uint16_t getPidP(uint16_t d) { return nvs_config_get_u16(NVS_CONFIG_PID_P, d); }
     inline uint16_t getPidI(uint16_t d) { return nvs_config_get_u16(NVS_CONFIG_PID_I, d); }
     inline uint16_t getPidD(uint16_t d) { return nvs_config_get_u16(NVS_CONFIG_PID_D, d); }
-    inline uint32_t getVrFrequency(uint32_t d) { return (uint32_t) nvs_config_get_u64(NVS_CONFIG_VR_FREQUENCY, d); }
-
     // OTP Replay-Protection state (last_step + 3-bit mask)
     inline void getOTPReplayState(int64_t& base_step, uint8_t& mask) {
         base_step = (int64_t) nvs_config_get_u64(NVS_CONFIG_OTP_LAST_STEP, 0ULL);

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -89,6 +89,11 @@ void PowerManagementTask::checkAsicFrequencyChanged()
         if (!m_board->setAsicFrequency((float) asic_frequency)) {
             ESP_LOGE(TAG, "pll setting not found for %uMHz", asic_frequency);
         }
+        // recalculate nonce space for new frequency (register 0x10)
+        Asic *asics = m_board->getAsics();
+        if (asics) {
+            asics->setNonceSpace((float)asic_frequency, m_board->getAsicCount(), asics->getCoreCount());
+        }
         last_asic_frequency = asic_frequency;
     }
 }
@@ -97,12 +102,15 @@ void PowerManagementTask::checkVrFrequencyChanged()
 {
     static uint32_t lastVrFrequency = 0;
 
-    uint32_t vrFrequency = m_board->getVrFrequency();
-    if (vrFrequency != lastVrFrequency) {
-        m_board->setVrFrequency(vrFrequency);
-        ESP_LOGI(TAG, "setting version rolling frequency to %luHz", vrFrequency);
-        lastVrFrequency = vrFrequency;
-    }
+    // TODO: temporarily disabled for SV2 Standard Channel nonce space testing.
+    // setVrFrequency overwrites register 0x10 with VR frequency value,
+    // which conflicts with the HCN (hash counting number) set during init.
+    // uint32_t vrFrequency = m_board->getVrFrequency();
+    // if (vrFrequency != lastVrFrequency) {
+    //     m_board->setVrFrequency(vrFrequency);
+    //     ESP_LOGI(TAG, "setting version rolling frequency to %luHz", vrFrequency);
+    //     lastVrFrequency = vrFrequency;
+    // }
 }
 
 void PowerManagementTask::logChipTemps()

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -98,21 +98,6 @@ void PowerManagementTask::checkAsicFrequencyChanged()
     }
 }
 
-void PowerManagementTask::checkVrFrequencyChanged()
-{
-    static uint32_t lastVrFrequency = 0;
-
-    // TODO: temporarily disabled for SV2 Standard Channel nonce space testing.
-    // setVrFrequency overwrites register 0x10 with VR frequency value,
-    // which conflicts with the HCN (hash counting number) set during init.
-    // uint32_t vrFrequency = m_board->getVrFrequency();
-    // if (vrFrequency != lastVrFrequency) {
-    //     m_board->setVrFrequency(vrFrequency);
-    //     ESP_LOGI(TAG, "setting version rolling frequency to %luHz", vrFrequency);
-    //     lastVrFrequency = vrFrequency;
-    // }
-}
-
 void PowerManagementTask::logChipTemps()
 {
     size_t offset = 0;
@@ -228,8 +213,6 @@ void PowerManagementTask::applyAsicSettings()
     // check if asic frequency changed
     checkAsicFrequencyChanged();
 
-    // check if version rolling frequency changed
-    checkVrFrequencyChanged();
 }
 
 void PowerManagementTask::requestChipTemps()

--- a/main/tasks/power_management_task.h
+++ b/main/tasks/power_management_task.h
@@ -38,7 +38,6 @@ class PowerManagementTask {
 
     void checkCoreVoltageChanged();
     void checkAsicFrequencyChanged();
-    void checkVrFrequencyChanged();
     void readAndPublishPowerTelemetry();
     void applyAsicSettings();
     void task();


### PR DESCRIPTION
## Summary

Port of [Bitaxe ESP-Miner PR 420](https://github.com/bitaxeorg/ESP-Miner/pull/420) - dynamic Hash Counting Number (HCN) calculation for BM1366/BM1368/BM1370 ASICs.

Required for SV2 Standard Channel support where no extranonce is available and the ASIC must search the full nonce space.

## Changes

- Added `setNonceSpace(frequency, asic_count, cores)` to Asic base class
- Added `getCoreCount()` to each ASIC subclass (BM1366=112, BM1368=80, BM1370=128)
- Replaced `setVrFrequency(vrFrequency)` with `setNonceSpace()` in each `init()`
- Formula: `HCN = (2^32 / next_pow2(cores) / next_pow2(asics)) * FREQ_MULT / freq * 0.5`

## Open question: Register 0x10 conflict

NerdQAxePlus uses register 0x10 for **Version Rolling Frequency** (`vrFreqToReg`), while ESP-Miner uses it for **Hash Counting Number**. These produce very different values:

| Purpose | NerdQAxe++ (4x BM1370 @ 615MHz) | Register value |
|---------|----------------------------------|----------------|
| VR Frequency (25kHz) | `VR_REG_PER_HZ / 25000` | ~7,864 |
| HCN (PR #420) | `(2^32/128/4) * 25/615 * 0.5` | ~170,993 |

**Need review**: Can register 0x10 serve both purposes? Does the HCN calculation implicitly set the correct VR timing? Or do we need both writes?

cc @shufps @mutatrum @adammwest for review of the register 0x10 semantics.

## Test plan

- [x] V1 mining still works with new HCN values
- [x] Version rolling still functions correctly
- [x] SV2 Standard Channel can search full nonce space