### PR TITLE
Add block header card with coinbase decoder

### DIFF
--- a/components/coinbase_decoder/CMakeLists.txt
+++ b/components/coinbase_decoder/CMakeLists.txt
@@ -1,0 +1,13 @@
+idf_component_register(
+    SRCS
+        "coinbase_decoder.c"
+        "segwit_addr.c"
+        "base58.c"
+
+    INCLUDE_DIRS
+        "include"
+
+    REQUIRES
+        "mbedtls"
+        "bm1397"
+)

--- a/components/coinbase_decoder/base58.c
+++ b/components/coinbase_decoder/base58.c
@@ -1,0 +1,204 @@
+/*
+ * Copyright 2012-2014 Luke Dashjr
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the standard MIT license.  See COPYING for more details.
+ */
+
+#ifndef WIN32
+#include <arpa/inet.h>
+#else
+#include <winsock2.h>
+#endif
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "libbase58.h"
+
+bool (*b58_sha256_impl)(void *, const void *, size_t) = NULL;
+
+static const int8_t b58digits_map[] = {
+	-1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+	-1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+	-1,-1,-1,-1,-1,-1,-1,-1, -1,-1,-1,-1,-1,-1,-1,-1,
+	-1, 0, 1, 2, 3, 4, 5, 6,  7, 8,-1,-1,-1,-1,-1,-1,
+	-1, 9,10,11,12,13,14,15, 16,-1,17,18,19,20,21,-1,
+	22,23,24,25,26,27,28,29, 30,31,32,-1,-1,-1,-1,-1,
+	-1,33,34,35,36,37,38,39, 40,41,42,43,-1,44,45,46,
+	47,48,49,50,51,52,53,54, 55,56,57,-1,-1,-1,-1,-1,
+};
+
+typedef uint64_t b58_maxint_t;
+typedef uint32_t b58_almostmaxint_t;
+#define b58_almostmaxint_bits (sizeof(b58_almostmaxint_t) * 8)
+static const b58_almostmaxint_t b58_almostmaxint_mask = ((((b58_maxint_t)1) << b58_almostmaxint_bits) - 1);
+
+bool b58tobin(void *bin, size_t *binszp, const char *b58, size_t b58sz)
+{
+	size_t binsz = *binszp;
+	const unsigned char *b58u = (void*)b58;
+	unsigned char *binu = bin;
+	size_t outisz = (binsz + sizeof(b58_almostmaxint_t) - 1) / sizeof(b58_almostmaxint_t);
+	b58_almostmaxint_t outi[outisz];
+	b58_maxint_t t;
+	b58_almostmaxint_t c;
+	size_t i, j;
+	uint8_t bytesleft = binsz % sizeof(b58_almostmaxint_t);
+	b58_almostmaxint_t zeromask = bytesleft ? (b58_almostmaxint_mask << (bytesleft * 8)) : 0;
+	unsigned zerocount = 0;
+
+	if (!b58sz)
+		b58sz = strlen(b58);
+
+	for (i = 0; i < outisz; ++i) {
+		outi[i] = 0;
+	}
+
+	// Leading zeros, just count
+	for (i = 0; i < b58sz && b58u[i] == '1'; ++i)
+		++zerocount;
+
+	for ( ; i < b58sz; ++i)
+	{
+		if (b58u[i] & 0x80)
+			// High-bit set on invalid digit
+			return false;
+		if (b58digits_map[b58u[i]] == -1)
+			// Invalid base58 digit
+			return false;
+		c = (unsigned)b58digits_map[b58u[i]];
+		for (j = outisz; j--; )
+		{
+			t = ((b58_maxint_t)outi[j]) * 58 + c;
+			c = t >> b58_almostmaxint_bits;
+			outi[j] = t & b58_almostmaxint_mask;
+		}
+		if (c)
+			// Output number too big (carry to the next int32)
+			return false;
+		if (outi[0] & zeromask)
+			// Output number too big (last int32 filled too far)
+			return false;
+	}
+
+	j = 0;
+	if (bytesleft) {
+		for (i = bytesleft; i > 0; --i) {
+			*(binu++) = (outi[0] >> (8 * (i - 1))) & 0xff;
+		}
+		++j;
+	}
+
+	for (; j < outisz; ++j)
+	{
+		for (i = sizeof(*outi); i > 0; --i) {
+			*(binu++) = (outi[j] >> (8 * (i - 1))) & 0xff;
+		}
+	}
+
+	// Count canonical base58 byte count
+	binu = bin;
+	for (i = 0; i < binsz; ++i)
+	{
+		if (binu[i])
+			break;
+		--*binszp;
+	}
+	*binszp += zerocount;
+
+	return true;
+}
+
+static
+bool my_dblsha256(void *hash, const void *data, size_t datasz)
+{
+	uint8_t buf[0x20];
+	return b58_sha256_impl(buf, data, datasz) && b58_sha256_impl(hash, buf, sizeof(buf));
+}
+
+int b58check(const void *bin, size_t binsz, const char *base58str, size_t b58sz)
+{
+	unsigned char buf[32];
+	const uint8_t *binc = bin;
+	unsigned i;
+	if (binsz < 4)
+		return -4;
+	if (!my_dblsha256(buf, bin, binsz - 4))
+		return -2;
+	if (memcmp(&binc[binsz - 4], buf, 4))
+		return -1;
+
+	// Check number of zeros is correct AFTER verifying checksum
+	for (i = 0; binc[i] == '\0' && base58str[i] == '1'; ++i)
+	{}
+	if (binc[i] == '\0' || base58str[i] == '1')
+		return -3;
+
+	return binc[0];
+}
+
+static const char b58digits_ordered[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
+
+bool b58enc(char *b58, size_t *b58sz, const void *data, size_t binsz)
+{
+	const uint8_t *bin = data;
+	int carry;
+	size_t i, j, high, zcount = 0;
+	size_t size;
+
+	while (zcount < binsz && !bin[zcount])
+		++zcount;
+
+	size = (binsz - zcount) * 138 / 100 + 1;
+	uint8_t buf[size];
+	memset(buf, 0, size);
+
+	for (i = zcount, high = size - 1; i < binsz; ++i, high = j)
+	{
+		for (carry = bin[i], j = size - 1; (j > high) || carry; --j)
+		{
+			carry += 256 * buf[j];
+			buf[j] = carry % 58;
+			carry /= 58;
+			if (!j) {
+				break;
+			}
+		}
+	}
+
+	for (j = 0; j < size && !buf[j]; ++j);
+
+	if (*b58sz <= zcount + size - j)
+	{
+		*b58sz = zcount + size - j + 1;
+		return false;
+	}
+
+	if (zcount)
+		memset(b58, '1', zcount);
+	for (i = zcount; j < size; ++i, ++j)
+		b58[i] = b58digits_ordered[buf[j]];
+	b58[i] = '\0';
+	*b58sz = i + 1;
+
+	return true;
+}
+
+bool b58check_enc(char *b58c, size_t *b58c_sz, uint8_t ver, const void *data, size_t datasz)
+{
+	uint8_t buf[1 + datasz + 0x20];
+	uint8_t *hash = &buf[1 + datasz];
+
+	buf[0] = ver;
+	memcpy(&buf[1], data, datasz);
+	if (!my_dblsha256(hash, buf, datasz + 1))
+	{
+		*b58c_sz = 0;
+		return false;
+	}
+
+	return b58enc(b58c, b58c_sz, buf, 1 + datasz + 4);
+}

--- a/components/coinbase_decoder/coinbase_decoder.c
+++ b/components/coinbase_decoder/coinbase_decoder.c
@@ -1,0 +1,346 @@
+/*
+ * Coinbase transaction decoder for Bitcoin mining firmware.
+ */
+
+#include "coinbase_decoder.h"
+#include "mining_utils.h"
+#include "segwit_addr.h"
+#include "libbase58.h"
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <ctype.h>
+#include "mbedtls/sha256.h"
+
+/* Network difficulty calculation from nBits (same as calculateNetworkDifficulty) */
+static double calc_network_difficulty(uint32_t nbits)
+{
+    uint32_t mantissa = nbits & 0x007fffff;
+    uint8_t exponent = (nbits >> 24) & 0xff;
+
+    if (exponent <= 3) {
+        mantissa >>= 8 * (3 - exponent);
+        if (mantissa == 0) return 0.0;
+        return (double) 0xFFFF / (double) mantissa;
+    }
+
+    if (mantissa == 0) return 0.0;
+    return (double) 0xFFFF / (double) mantissa * (1ULL << (8 * (exponent - 3))) / (1ULL << 16);
+}
+
+/* SHA256 wrapper for libbase58 */
+static bool sha256_for_base58(void *digest, const void *data, size_t datasz)
+{
+    mbedtls_sha256(data, datasz, digest, 0);
+    return true;
+}
+
+static void ensure_base58_init(void)
+{
+    if (b58_sha256_impl == NULL) {
+        b58_sha256_impl = sha256_for_base58;
+    }
+}
+
+/* Decode a Bitcoin varint from binary data */
+static uint64_t decode_varint(const uint8_t *data, int *offset)
+{
+    uint8_t first_byte = data[*offset];
+    (*offset)++;
+
+    if (first_byte < 0xFD) {
+        return first_byte;
+    } else if (first_byte == 0xFD) {
+        uint64_t value = data[*offset] | (data[*offset + 1] << 8);
+        *offset += 2;
+        return value;
+    } else if (first_byte == 0xFE) {
+        uint64_t value = data[*offset] | (data[*offset + 1] << 8) |
+                        (data[*offset + 2] << 16) | (data[*offset + 3] << 24);
+        *offset += 4;
+        return value;
+    } else {
+        uint64_t value = 0;
+        for (int i = 0; i < 8; i++) {
+            value |= ((uint64_t)data[*offset + i]) << (i * 8);
+        }
+        *offset += 8;
+        return value;
+    }
+}
+
+/* Decode Bitcoin address from scriptPubKey */
+static void decode_address(const uint8_t *script, size_t script_len,
+                           char *output, size_t output_len)
+{
+    if (script_len == 0 || output_len < 65) {
+        snprintf(output, output_len, "unknown");
+        return;
+    }
+
+    ensure_base58_init();
+
+    /* P2PKH: OP_DUP OP_HASH160 <20 bytes> OP_EQUALVERIFY OP_CHECKSIG */
+    if (script_len == 25 && script[0] == OP_DUP && script[1] == OP_HASH160 &&
+        script[2] == OP_PUSHDATA_20 && script[23] == OP_EQUALVERIFY && script[24] == OP_CHECKSIG) {
+        size_t b58sz = output_len;
+        if (b58check_enc(output, &b58sz, 0x00, script + 3, 20)) {
+            return;
+        }
+        snprintf(output, output_len, "P2PKH:");
+        bin2hex(script + 3, 20, output + 6, output_len - 6);
+        return;
+    }
+
+    /* P2SH: OP_HASH160 <20 bytes> OP_EQUAL */
+    if (script_len == 23 && script[0] == OP_HASH160 && script[1] == OP_PUSHDATA_20 && script[22] == OP_EQUAL) {
+        size_t b58sz = output_len;
+        if (b58check_enc(output, &b58sz, 0x05, script + 2, 20)) {
+            return;
+        }
+        snprintf(output, output_len, "P2SH:");
+        bin2hex(script + 2, 20, output + 5, output_len - 5);
+        return;
+    }
+
+    /* P2WPKH: OP_0 <20 bytes> */
+    if (script_len == 22 && script[0] == OP_0 && script[1] == OP_PUSHDATA_20) {
+        if (segwit_addr_encode(output, "bc", 0, script + 2, 20)) {
+            return;
+        }
+        snprintf(output, output_len, "P2WPKH:");
+        bin2hex(script + 2, 20, output + 7, output_len - 7);
+        return;
+    }
+
+    /* P2WSH: OP_0 <32 bytes> */
+    if (script_len == 34 && script[0] == OP_0 && script[1] == OP_PUSHDATA_32) {
+        if (segwit_addr_encode(output, "bc", 0, script + 2, 32)) {
+            return;
+        }
+        snprintf(output, output_len, "P2WSH:");
+        bin2hex(script + 2, 32, output + 6, output_len - 6);
+        return;
+    }
+
+    /* P2TR: OP_1 <32 bytes> */
+    if (script_len == 34 && script[0] == OP_1 && script[1] == OP_PUSHDATA_32) {
+        if (segwit_addr_encode(output, "bc", 1, script + 2, 32)) {
+            return;
+        }
+        snprintf(output, output_len, "P2TR:");
+        bin2hex(script + 2, 32, output + 5, output_len - 5);
+        return;
+    }
+
+    /* OP_RETURN: null data output */
+    if (script_len > 0 && script[0] == OP_RETURN) {
+        snprintf(output, output_len, "OP_RETURN: ");
+        size_t offset = 1;
+
+        if (script_len > 1 && script[1] > 0 && script[1] <= 0x4b && (size_t)script[1] + 2 == script_len) {
+            offset = 2;
+        }
+
+        size_t out_idx = strlen(output);
+        for (size_t i = offset; i < script_len && out_idx < output_len - 1; i++) {
+            unsigned char c = script[i];
+            output[out_idx++] = isprint(c) ? c : '.';
+        }
+        output[out_idx] = '\0';
+        return;
+    }
+
+    /* Unknown format */
+    snprintf(output, output_len, "UNKNOWN:");
+    size_t hex_len = script_len < 32 ? script_len : 32;
+    bin2hex(script, hex_len, output + 8, output_len - 8);
+}
+
+esp_err_t coinbase_process(const char *coinbase_1,
+                           const char *coinbase_2,
+                           uint32_t block_version,
+                           uint32_t nbits,
+                           const char *extranonce1,
+                           int extranonce2_len,
+                           const char *user_address,
+                           bool decode_coinbase_tx,
+                           coinbase_result_t *result)
+{
+    if (!coinbase_1 || !coinbase_2 || !extranonce1 || !result) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    /* Initialize result */
+    memset(result, 0, sizeof(coinbase_result_t));
+    result->decode_coinbase_tx = decode_coinbase_tx;
+
+    /* 1. Calculate difficulty */
+    result->network_difficulty = calc_network_difficulty(nbits);
+
+    /* 2. Parse coinbase_1 for block height and scriptsig */
+    int coinbase_1_len = strlen(coinbase_1) / 2;
+    int coinbase_1_offset = 41; /* Skip: version(4) + inputcount(1) + prevhash(32) + vout(4) */
+
+    if (coinbase_1_len < coinbase_1_offset) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    uint8_t scriptsig_len;
+    hex2bin(coinbase_1 + (coinbase_1_offset * 2), &scriptsig_len, 1);
+    coinbase_1_offset++;
+
+    if (coinbase_1_len < coinbase_1_offset) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    uint8_t block_height_len;
+    hex2bin(coinbase_1 + (coinbase_1_offset * 2), &block_height_len, 1);
+    coinbase_1_offset++;
+
+    if (coinbase_1_len < coinbase_1_offset || block_height_len == 0 || block_height_len > 4) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    result->block_height = 0;
+    hex2bin(coinbase_1 + (coinbase_1_offset * 2), (uint8_t *)&result->block_height, block_height_len);
+    coinbase_1_offset += block_height_len;
+
+    /* Detect BIP-110 signaling: version bit 4 set */
+    result->bip110_signaling = decode_coinbase_tx &&
+        result->block_height < BIP110_SIGNAL_EXPIRY_BLOCK &&
+        (block_version & (1U << BIP110_SIGNAL_BIT)) != 0;
+
+    /* Calculate remaining scriptsig length (excluding block height part) */
+    int scriptsig_length = scriptsig_len - 1 - block_height_len;
+    size_t extranonce1_len = strlen(extranonce1) / 2;
+
+    /* Check if scriptsig extends into coinbase_2 (covers extranonces) */
+    if (coinbase_1_len - coinbase_1_offset < scriptsig_length) {
+        scriptsig_length -= (extranonce1_len + extranonce2_len);
+    }
+
+    /* Extract miner tag (scriptsig) */
+    if (scriptsig_length > 0 && scriptsig_length < MAX_SCRIPTSIG_LEN) {
+        int coinbase_1_tag_len = coinbase_1_len - coinbase_1_offset;
+        if (coinbase_1_tag_len > scriptsig_length) {
+            coinbase_1_tag_len = scriptsig_length;
+        }
+
+        hex2bin(coinbase_1 + (coinbase_1_offset * 2), (uint8_t *)result->scriptsig, coinbase_1_tag_len);
+
+        int coinbase_2_tag_len = scriptsig_length - coinbase_1_tag_len;
+        int coinbase_2_len = strlen(coinbase_2) / 2;
+
+        if (coinbase_2_len >= coinbase_2_tag_len && coinbase_2_tag_len > 0) {
+            hex2bin(coinbase_2, (uint8_t *)result->scriptsig + coinbase_1_tag_len, coinbase_2_tag_len);
+        }
+
+        /* Filter non-printable characters */
+        for (int i = 0; i < scriptsig_length; i++) {
+            if (!isprint((unsigned char)result->scriptsig[i])) {
+                result->scriptsig[i] = '.';
+            }
+        }
+        result->scriptsig[scriptsig_length] = '\0';
+    }
+
+    /* 3. Parse coinbase_2 for outputs */
+    int raw_scriptsig_remainder = (scriptsig_len - 1 - block_height_len) - (coinbase_1_len - coinbase_1_offset);
+
+    int coinbase_2_offset = 0;
+    if (raw_scriptsig_remainder > 0) {
+        int remainder_in_coinbase_2 = raw_scriptsig_remainder - (extranonce1_len + extranonce2_len);
+        if (remainder_in_coinbase_2 > 0) {
+            coinbase_2_offset = remainder_in_coinbase_2;
+        }
+    }
+
+    int coinbase_2_len = strlen(coinbase_2) / 2;
+    uint8_t *coinbase_2_bin = malloc(coinbase_2_len);
+    if (!coinbase_2_bin) {
+        return ESP_ERR_NO_MEM;
+    }
+
+    hex2bin(coinbase_2, coinbase_2_bin, coinbase_2_len);
+
+    int offset = coinbase_2_offset;
+
+    /* Read nSequence (4 bytes) for BIP-54 detection */
+    if (offset + 4 > coinbase_2_len) {
+        free(coinbase_2_bin);
+        return ESP_OK; /* partial success: got block height + scriptsig */
+    }
+    uint32_t nSequence = 0;
+    for (int i = 0; i < 4; i++) {
+        nSequence |= ((uint32_t)coinbase_2_bin[offset + i]) << (i * 8);
+    }
+    offset += 4;
+
+    /* Decode output count */
+    if (offset >= coinbase_2_len) {
+        free(coinbase_2_bin);
+        return ESP_OK;
+    }
+
+    uint64_t num_outputs = decode_varint(coinbase_2_bin, &offset);
+    result->output_count = 0;
+
+    /* Parse each output */
+    for (uint64_t i = 0; i < num_outputs && offset < coinbase_2_len; i++) {
+        /* Read value (8 bytes, little-endian) */
+        if (offset + 8 > coinbase_2_len) break;
+
+        uint64_t value_satoshis = 0;
+        for (int j = 0; j < 8; j++) {
+            value_satoshis |= ((uint64_t)coinbase_2_bin[offset + j]) << (j * 8);
+        }
+        offset += 8;
+
+        result->total_value_satoshis += value_satoshis;
+
+        /* Read scriptPubKey length */
+        if (offset >= coinbase_2_len) break;
+        uint64_t script_len = decode_varint(coinbase_2_bin, &offset);
+
+        if (offset + script_len > (size_t)coinbase_2_len) break;
+
+        if (decode_coinbase_tx && i < MAX_COINBASE_TX_OUTPUTS) {
+            if (value_satoshis > 0) {
+                char output_address[MAX_ADDRESS_STRING_LEN];
+                decode_address(coinbase_2_bin + offset, script_len, output_address, MAX_ADDRESS_STRING_LEN);
+
+                bool is_user = user_address && strncmp(user_address, output_address, strlen(output_address)) == 0;
+                if (is_user) result->user_value_satoshis += value_satoshis;
+
+                strncpy(result->outputs[result->output_count].address, output_address, MAX_ADDRESS_STRING_LEN);
+                result->outputs[result->output_count].value_satoshis = value_satoshis;
+                result->outputs[result->output_count].is_user_output = is_user;
+                result->output_count++;
+            } else {
+                decode_address(coinbase_2_bin + offset, script_len,
+                               result->outputs[result->output_count].address, MAX_ADDRESS_STRING_LEN);
+                result->outputs[result->output_count].value_satoshis = 0;
+                result->outputs[result->output_count].is_user_output = false;
+                result->output_count++;
+            }
+        }
+
+        offset += script_len;
+    }
+
+    /* Read nLockTime (4 bytes) for BIP-54 detection */
+    uint32_t nLockTime = 0;
+    if (offset + 4 <= coinbase_2_len) {
+        for (int i = 0; i < 4; i++) {
+            nLockTime |= ((uint32_t)coinbase_2_bin[offset + i]) << (i * 8);
+        }
+    }
+
+    result->bip54_signaling = decode_coinbase_tx &&
+        (nLockTime == result->block_height - 1) && (nSequence != 0xffffffff);
+
+    free(coinbase_2_bin);
+    return ESP_OK;
+}

--- a/components/coinbase_decoder/include/coinbase_decoder.h
+++ b/components/coinbase_decoder/include/coinbase_decoder.h
@@ -1,0 +1,95 @@
+/*
+ * Coinbase transaction decoder for Bitcoin mining firmware.
+ * Extracts block height, scriptsig (miner tag), and transaction outputs
+ * from stratum mining.notify coinbase data.
+ */
+
+#ifndef COINBASE_DECODER_H
+#define COINBASE_DECODER_H
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdbool.h>
+#include "esp_err.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MAX_ADDRESS_STRING_LEN 128
+#define MAX_COINBASE_TX_OUTPUTS 6
+#define MAX_SCRIPTSIG_LEN 256
+
+/* Bitcoin Script Opcodes */
+#define OP_0            0x00
+#define OP_PUSHDATA_20  0x14
+#define OP_PUSHDATA_32  0x20
+#define OP_1            0x51
+#define OP_RETURN       0x6a
+#define OP_DUP          0x76
+#define OP_EQUAL        0x87
+#define OP_EQUALVERIFY  0x88
+#define OP_HASH160      0xa9
+#define OP_CHECKSIG     0xac
+
+/* BIP-110 signaling: version bit 4 */
+#define BIP110_SIGNAL_BIT 4
+#define BIP110_SIGNAL_EXPIRY_BLOCK 965664
+
+/**
+ * A single decoded coinbase transaction output.
+ */
+typedef struct {
+    uint64_t value_satoshis;
+    char address[MAX_ADDRESS_STRING_LEN];
+    bool is_user_output;
+} coinbase_output_t;
+
+/**
+ * Result of processing a mining notification's coinbase data.
+ */
+typedef struct {
+    double network_difficulty;
+    uint32_t block_height;
+    char scriptsig[MAX_SCRIPTSIG_LEN];
+    coinbase_output_t outputs[MAX_COINBASE_TX_OUTPUTS];
+    int output_count;
+    uint64_t total_value_satoshis;
+    uint64_t user_value_satoshis;
+    bool decode_coinbase_tx;
+    bool bip54_signaling;
+    bool bip110_signaling;
+} coinbase_result_t;
+
+/**
+ * Process coinbase data from a mining.notify notification.
+ *
+ * This is a self-contained C function that takes the raw coinbase fields
+ * from stratum, without depending on the C++ stratum_api.h header.
+ *
+ * @param coinbase_1        Hex string of coinbase part 1 (before extranonces)
+ * @param coinbase_2        Hex string of coinbase part 2 (after extranonces)
+ * @param block_version     Block version from mining.notify
+ * @param nbits             nBits/target from mining.notify
+ * @param extranonce1       Hex string of extranonce1
+ * @param extranonce2_len   Length of extranonce2 in bytes
+ * @param user_address      User's payout address (for output matching), may be NULL
+ * @param decode_coinbase_tx Enable full coinbase TX decoding (addresses, values)
+ * @param result            Output: decoded result
+ * @return ESP_OK on success
+ */
+esp_err_t coinbase_process(const char *coinbase_1,
+                           const char *coinbase_2,
+                           uint32_t block_version,
+                           uint32_t nbits,
+                           const char *extranonce1,
+                           int extranonce2_len,
+                           const char *user_address,
+                           bool decode_coinbase_tx,
+                           coinbase_result_t *result);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* COINBASE_DECODER_H */

--- a/components/coinbase_decoder/include/libbase58.h
+++ b/components/coinbase_decoder/include/libbase58.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2012-2014 Luke Dashjr
+ *
+ * This program is free software; you can redistribute it and/or modify it
+ * under the terms of the standard MIT license.  See COPYING for more details.
+ */
+
+#ifndef LIBBASE58_H
+#define LIBBASE58_H
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern bool (*b58_sha256_impl)(void *, const void *, size_t);
+
+extern bool b58tobin(void *bin, size_t *binsz, const char *b58, size_t b58sz);
+extern int b58check(const void *bin, size_t binsz, const char *b58, size_t b58sz);
+
+extern bool b58enc(char *b58, size_t *b58sz, const void *bin, size_t binsz);
+extern bool b58check_enc(char *b58c, size_t *b58c_sz, uint8_t ver, const void *data, size_t datasz);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/components/coinbase_decoder/include/segwit_addr.h
+++ b/components/coinbase_decoder/include/segwit_addr.h
@@ -1,0 +1,98 @@
+/* Copyright (c) 2017, 2021 Pieter Wuille
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#ifndef _SEGWIT_ADDR_H_
+#define _SEGWIT_ADDR_H_ 1
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/** Supported encodings. */
+typedef enum {
+    BECH32_ENCODING_NONE,
+    BECH32_ENCODING_BECH32,
+    BECH32_ENCODING_BECH32M
+} bech32_encoding;
+
+/** Encode a SegWit address
+ *
+ *  Out: output:   Pointer to a buffer of size 73 + strlen(hrp) that will be
+ *                 updated to contain the null-terminated address.
+ *  In:  hrp:      Pointer to the null-terminated human readable part to use
+ *                 (chain/network specific).
+ *       ver:      Version of the witness program (between 0 and 16 inclusive).
+ *       prog:     Data bytes for the witness program (between 2 and 40 bytes).
+ *       prog_len: Number of data bytes in prog.
+ *  Returns 1 if successful.
+ */
+int segwit_addr_encode(
+    char *output,
+    const char *hrp,
+    int ver,
+    const uint8_t *prog,
+    size_t prog_len
+);
+
+/** Decode a SegWit address
+ *
+ *  Out: ver:      Pointer to an int that will be updated to contain the witness
+ *                 program version (between 0 and 16 inclusive).
+ *       prog:     Pointer to a buffer of size 40 that will be updated to
+ *                 contain the witness program bytes.
+ *       prog_len: Pointer to a size_t that will be updated to contain the length
+ *                 of bytes in prog.
+ *       hrp:      Pointer to the null-terminated human readable part that is
+ *                 expected (chain/network specific).
+ *       addr:     Pointer to the null-terminated address.
+ *  Returns 1 if successful.
+ */
+int segwit_addr_decode(
+    int* ver,
+    uint8_t* prog,
+    size_t* prog_len,
+    const char* hrp,
+    const char* addr
+);
+
+int bech32_encode(
+    char *output,
+    const char *hrp,
+    const uint8_t *data,
+    size_t data_len,
+    bech32_encoding enc
+);
+
+bech32_encoding bech32_decode(
+    char *hrp,
+    uint8_t *data,
+    size_t *data_len,
+    const char *input
+);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/components/coinbase_decoder/segwit_addr.c
+++ b/components/coinbase_decoder/segwit_addr.c
@@ -1,0 +1,209 @@
+/* Copyright (c) 2017, 2021 Pieter Wuille
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+#include <assert.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "segwit_addr.h"
+
+static uint32_t bech32_polymod_step(uint32_t pre) {
+    uint8_t b = pre >> 25;
+    return ((pre & 0x1FFFFFF) << 5) ^
+        (-((b >> 0) & 1) & 0x3b6a57b2UL) ^
+        (-((b >> 1) & 1) & 0x26508e6dUL) ^
+        (-((b >> 2) & 1) & 0x1ea119faUL) ^
+        (-((b >> 3) & 1) & 0x3d4233ddUL) ^
+        (-((b >> 4) & 1) & 0x2a1462b3UL);
+}
+
+static uint32_t bech32_final_constant(bech32_encoding enc) {
+    if (enc == BECH32_ENCODING_BECH32) return 1;
+    if (enc == BECH32_ENCODING_BECH32M) return 0x2bc830a3;
+    assert(0);
+}
+
+static const char* charset = "qpzry9x8gf2tvdw0s3jn54khce6mua7l";
+
+static const int8_t charset_rev[128] = {
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1,
+    15, -1, 10, 17, 21, 20, 26, 30,  7,  5, -1, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+     1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1,
+    -1, 29, -1, 24, 13, 25,  9,  8, 23, -1, 18, 22, 31, 27, 19, -1,
+     1,  0,  3, 16, 11, 28, 12, 14,  6,  4,  2, -1, -1, -1, -1, -1
+};
+
+int bech32_encode(char *output, const char *hrp, const uint8_t *data, size_t data_len, bech32_encoding enc) {
+    uint32_t chk = 1;
+    size_t i = 0;
+    while (hrp[i] != 0) {
+        int ch = hrp[i];
+        if (ch < 33 || ch > 126) {
+            return 0;
+        }
+
+        if (ch >= 'A' && ch <= 'Z') return 0;
+        chk = bech32_polymod_step(chk) ^ (ch >> 5);
+        ++i;
+    }
+    if (i + 7 + data_len > 90) return 0;
+    chk = bech32_polymod_step(chk);
+    while (*hrp != 0) {
+        chk = bech32_polymod_step(chk) ^ (*hrp & 0x1f);
+        *(output++) = *(hrp++);
+    }
+    *(output++) = '1';
+    for (i = 0; i < data_len; ++i) {
+        if (*data >> 5) return 0;
+        chk = bech32_polymod_step(chk) ^ (*data);
+        *(output++) = charset[*(data++)];
+    }
+    for (i = 0; i < 6; ++i) {
+        chk = bech32_polymod_step(chk);
+    }
+    chk ^= bech32_final_constant(enc);
+    for (i = 0; i < 6; ++i) {
+        *(output++) = charset[(chk >> ((5 - i) * 5)) & 0x1f];
+    }
+    *output = 0;
+    return 1;
+}
+
+bech32_encoding bech32_decode(char* hrp, uint8_t *data, size_t *data_len, const char *input) {
+    uint32_t chk = 1;
+    size_t i;
+    size_t input_len = strlen(input);
+    size_t hrp_len;
+    int have_lower = 0, have_upper = 0;
+    if (input_len < 8 || input_len > 90) {
+        return BECH32_ENCODING_NONE;
+    }
+    *data_len = 0;
+    while (*data_len < input_len && input[(input_len - 1) - *data_len] != '1') {
+        ++(*data_len);
+    }
+    hrp_len = input_len - (1 + *data_len);
+    if (1 + *data_len >= input_len || *data_len < 6) {
+        return BECH32_ENCODING_NONE;
+    }
+    *(data_len) -= 6;
+    for (i = 0; i < hrp_len; ++i) {
+        int ch = input[i];
+        if (ch < 33 || ch > 126) {
+            return BECH32_ENCODING_NONE;
+        }
+        if (ch >= 'a' && ch <= 'z') {
+            have_lower = 1;
+        } else if (ch >= 'A' && ch <= 'Z') {
+            have_upper = 1;
+            ch = (ch - 'A') + 'a';
+        }
+        hrp[i] = ch;
+        chk = bech32_polymod_step(chk) ^ (ch >> 5);
+    }
+    hrp[i] = 0;
+    chk = bech32_polymod_step(chk);
+    for (i = 0; i < hrp_len; ++i) {
+        chk = bech32_polymod_step(chk) ^ (input[i] & 0x1f);
+    }
+    ++i;
+    while (i < input_len) {
+        int v = (input[i] & 0x80) ? -1 : charset_rev[(int)input[i]];
+        if (input[i] >= 'a' && input[i] <= 'z') have_lower = 1;
+        if (input[i] >= 'A' && input[i] <= 'Z') have_upper = 1;
+        if (v == -1) {
+            return BECH32_ENCODING_NONE;
+        }
+        chk = bech32_polymod_step(chk) ^ v;
+        if (i + 6 < input_len) {
+            data[i - (1 + hrp_len)] = v;
+        }
+        ++i;
+    }
+    if (have_lower && have_upper) {
+        return BECH32_ENCODING_NONE;
+    }
+    if (chk == bech32_final_constant(BECH32_ENCODING_BECH32)) {
+        return BECH32_ENCODING_BECH32;
+    } else if (chk == bech32_final_constant(BECH32_ENCODING_BECH32M)) {
+        return BECH32_ENCODING_BECH32M;
+    } else {
+        return BECH32_ENCODING_NONE;
+    }
+}
+
+static int convert_bits(uint8_t* out, size_t* outlen, int outbits, const uint8_t* in, size_t inlen, int inbits, int pad) {
+    uint32_t val = 0;
+    int bits = 0;
+    uint32_t maxv = (((uint32_t)1) << outbits) - 1;
+    while (inlen--) {
+        val = (val << inbits) | *(in++);
+        bits += inbits;
+        while (bits >= outbits) {
+            bits -= outbits;
+            out[(*outlen)++] = (val >> bits) & maxv;
+        }
+    }
+    if (pad) {
+        if (bits) {
+            out[(*outlen)++] = (val << (outbits - bits)) & maxv;
+        }
+    } else if (((val << (outbits - bits)) & maxv) || bits >= inbits) {
+        return 0;
+    }
+    return 1;
+}
+
+int segwit_addr_encode(char *output, const char *hrp, int witver, const uint8_t *witprog, size_t witprog_len) {
+    uint8_t data[65];
+    size_t datalen = 0;
+    bech32_encoding enc = BECH32_ENCODING_BECH32;
+    if (witver > 16) return 0;
+    if (witver == 0 && witprog_len != 20 && witprog_len != 32) return 0;
+    if (witprog_len < 2 || witprog_len > 40) return 0;
+    if (witver > 0) enc = BECH32_ENCODING_BECH32M;
+    data[0] = witver;
+    convert_bits(data + 1, &datalen, 5, witprog, witprog_len, 8, 1);
+    ++datalen;
+    return bech32_encode(output, hrp, data, datalen, enc);
+}
+
+int segwit_addr_decode(int* witver, uint8_t* witdata, size_t* witdata_len, const char* hrp, const char* addr) {
+    uint8_t data[84];
+    char hrp_actual[84];
+    size_t data_len;
+    bech32_encoding enc = bech32_decode(hrp_actual, data, &data_len, addr);
+    if (enc == BECH32_ENCODING_NONE) return 0;
+    if (data_len == 0 || data_len > 65) return 0;
+    if (strncmp(hrp, hrp_actual, 84) != 0) return 0;
+    if (data[0] > 16) return 0;
+    if (data[0] == 0 && enc != BECH32_ENCODING_BECH32) return 0;
+    if (data[0] > 0 && enc != BECH32_ENCODING_BECH32M) return 0;
+    *witdata_len = 0;
+    if (!convert_bits(witdata, witdata_len, 8, data + 1, data_len - 1, 5, 0)) return 0;
+    if (*witdata_len < 2 || *witdata_len > 40) return 0;
+    if (data[0] == 0 && *witdata_len != 20 && *witdata_len != 32) return 0;
+    *witver = data[0];
+    return 1;
+}

--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -124,6 +124,7 @@ REQUIRES
     "esp-tls"
     "stratum_v2"
     "libsecp256k1"
+    "coinbase_decoder"
 
 )
 

--- a/main/http_server/axe-os/src/app/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/app/models/ISystemInfo.ts
@@ -109,6 +109,15 @@ export interface ISystemInfo {
     history: IHistory
 
     otp: boolean,
+
+    networkDifficulty?: number,
+
+    // Block header / coinbase data (only present when blockHeight > 0)
+    blockHeight?: number,
+    scriptsig?: string,
+    coinbaseOutputs?: { value: number, address: string }[],
+    coinbaseValueTotalSatoshis?: number,
+    coinbaseValueUserSatoshis?: number,
 }
 
 // fields swam is using

--- a/main/http_server/axe-os/src/app/models/ISystemInfo.ts
+++ b/main/http_server/axe-os/src/app/models/ISystemInfo.ts
@@ -112,8 +112,14 @@ export interface ISystemInfo {
 
     networkDifficulty?: number,
 
-    // Block header / coinbase data (only present when blockHeight > 0)
-    blockHeight?: number,
+    // Block header / coinbase data (array, one per pool with data)
+    blockHeaders?: IBlockHeader[],
+}
+
+export interface IBlockHeader {
+    pool: number,
+    blockHeight: number,
+    networkDifficulty: number,
     scriptsig?: string,
     coinbaseOutputs?: { value: number, address: string }[],
     coinbaseValueTotalSatoshis?: number,

--- a/main/http_server/axe-os/src/app/pages/home/home.component.html
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.html
@@ -508,6 +508,7 @@
               </div>
             </div>
           </div>
+
         </div>
 
         <div class="col-12 col-xl-6 mt-3 mt-xl-0">
@@ -663,6 +664,60 @@
                 ></div>
                 <span class="nerdos-logo-tooltip">01001110 01100101 01110010 01100100 00101010 01001111 01010011</span>
               </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Block Header (own row, half width, only when block data available) -->
+      <div class="row mt-3" *ngIf="info.blockHeight && info.blockHeight > 0">
+        <div class="col-12 col-xl-6">
+          <div class="plain-section">
+            <div class="block-header-box">
+              <div class="block-header-title">{{ 'HOME.BLOCK_HEADER' | translate }}</div>
+
+              <div class="block-header-row">
+                <span class="block-header-label">{{ 'HOME.BLOCK_HEIGHT' | translate }}</span>
+                <span class="block-header-value">{{ info.blockHeight | number: '1.0-0' }}</span>
+              </div>
+
+              <div class="block-header-row">
+                <span class="block-header-label">{{ 'HOME.BLOCK_DIFFICULTY' | translate }}</span>
+                <span class="block-header-value" [title]="(info.networkDifficulty | number: '1.0-0')">{{ formatDifficulty(info.networkDifficulty) }}</span>
+              </div>
+
+              <div class="block-header-row" *ngIf="info.scriptsig">
+                <span class="block-header-label">{{ 'HOME.BLOCK_SCRIPTSIG' | translate }}</span>
+                <span class="block-header-value block-header-mono">{{ info.scriptsig }}</span>
+              </div>
+
+              <ng-container *ngIf="info.coinbaseOutputs && info.coinbaseOutputs.length > 0">
+                <div class="block-header-row">
+                  <span class="block-header-label">{{ 'HOME.BLOCK_VALUE' | translate }}</span>
+                  <span class="block-header-value">{{ formatSats(info.coinbaseValueTotalSatoshis) }}</span>
+                </div>
+
+                <div class="block-header-row" *ngIf="getPayoutPercentage(info) as pct">
+                  <ng-container *ngIf="pct >= 95">
+                    <span class="block-header-label">{{ 'HOME.BLOCK_FEE' | translate }}</span>
+                    <span class="block-header-value" [style.color]="pct >= 100 ? '#4caf50' : 'inherit'">{{ 100 - pct | number: '1.0-1' }}%</span>
+                  </ng-container>
+                  <ng-container *ngIf="pct > 0 && pct < 95">
+                    <span class="block-header-label">{{ 'HOME.BLOCK_SHARE' | translate }}</span>
+                    <span class="block-header-value" style="color: #f44336">{{ pct | number: '1.0-1' }}%</span>
+                  </ng-container>
+                </div>
+
+                <div class="block-header-row block-header-row--outputs">
+                  <span class="block-header-label">{{ 'HOME.BLOCK_OUTPUTS' | translate }}</span>
+                  <div class="block-header-outputs">
+                    <div *ngFor="let out of info.coinbaseOutputs" class="block-header-output">
+                      <span class="block-header-mono block-header-addr" [title]="out.address">{{ truncateAddress(out.address) }}</span>
+                      <span class="block-header-sats" *ngIf="out.value > 0">{{ formatSats(out.value) }}</span>
+                    </div>
+                  </div>
+                </div>
+              </ng-container>
             </div>
           </div>
         </div>

--- a/main/http_server/axe-os/src/app/pages/home/home.component.html
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.html
@@ -669,35 +669,39 @@
         </div>
       </div>
 
-      <!-- Block Header (own row, half width, only when block data available) -->
-      <div class="row mt-3" *ngIf="info.blockHeight && info.blockHeight > 0">
-        <div class="col-12 col-xl-6">
+      <!-- Block Header cards (one per pool with data, half width each) -->
+      <div class="row mt-3" *ngIf="info.blockHeaders && info.blockHeaders.length > 0">
+        <div *ngFor="let bh of info.blockHeaders; trackBy: trackByPool" class="col-12 col-xl-6"
+             [class.mt-3]="info.blockHeaders.length > 1" [class.mt-xl-0]="info.blockHeaders.length > 1">
           <div class="plain-section">
             <div class="block-header-box">
-              <div class="block-header-title">{{ 'HOME.BLOCK_HEADER' | translate }}</div>
+              <div class="block-header-title">
+                {{ 'HOME.BLOCK_HEADER' | translate }}
+                <span *ngIf="isDualPool" class="block-header-pool-tag">Pool {{ bh.pool + 1 }}</span>
+              </div>
 
               <div class="block-header-row">
                 <span class="block-header-label">{{ 'HOME.BLOCK_HEIGHT' | translate }}</span>
-                <span class="block-header-value">{{ info.blockHeight | number: '1.0-0' }}</span>
+                <span class="block-header-value">{{ bh.blockHeight | number: '1.0-0' }}</span>
               </div>
 
               <div class="block-header-row">
                 <span class="block-header-label">{{ 'HOME.BLOCK_DIFFICULTY' | translate }}</span>
-                <span class="block-header-value" [title]="(info.networkDifficulty | number: '1.0-0')">{{ formatDifficulty(info.networkDifficulty) }}</span>
+                <span class="block-header-value" [title]="(bh.networkDifficulty | number: '1.0-0')">{{ formatDifficulty(bh.networkDifficulty) }}</span>
               </div>
 
-              <div class="block-header-row" *ngIf="info.scriptsig">
+              <div class="block-header-row" *ngIf="bh.scriptsig">
                 <span class="block-header-label">{{ 'HOME.BLOCK_SCRIPTSIG' | translate }}</span>
-                <span class="block-header-value block-header-mono">{{ info.scriptsig }}</span>
+                <span class="block-header-value block-header-mono">{{ bh.scriptsig }}</span>
               </div>
 
-              <ng-container *ngIf="info.coinbaseOutputs && info.coinbaseOutputs.length > 0">
+              <ng-container *ngIf="bh.coinbaseOutputs && bh.coinbaseOutputs.length > 0">
                 <div class="block-header-row">
                   <span class="block-header-label">{{ 'HOME.BLOCK_VALUE' | translate }}</span>
-                  <span class="block-header-value">{{ formatSats(info.coinbaseValueTotalSatoshis) }}</span>
+                  <span class="block-header-value">{{ formatSats(bh.coinbaseValueTotalSatoshis) }}</span>
                 </div>
 
-                <div class="block-header-row" *ngIf="getPayoutPercentage(info) as pct">
+                <div class="block-header-row" *ngIf="getBlockHeaderFee(bh) as pct">
                   <ng-container *ngIf="pct >= 95">
                     <span class="block-header-label">{{ 'HOME.BLOCK_FEE' | translate }}</span>
                     <span class="block-header-value" [style.color]="pct >= 100 ? '#4caf50' : 'inherit'">{{ 100 - pct | number: '1.0-1' }}%</span>
@@ -711,7 +715,7 @@
                 <div class="block-header-row block-header-row--outputs">
                   <span class="block-header-label">{{ 'HOME.BLOCK_OUTPUTS' | translate }}</span>
                   <div class="block-header-outputs">
-                    <div *ngFor="let out of info.coinbaseOutputs" class="block-header-output">
+                    <div *ngFor="let out of bh.coinbaseOutputs" class="block-header-output">
                       <span class="block-header-mono block-header-addr" [title]="out.address">{{ truncateAddress(out.address) }}</span>
                       <span class="block-header-sats" *ngIf="out.value > 0">{{ formatSats(out.value) }}</span>
                     </div>

--- a/main/http_server/axe-os/src/app/pages/home/home.component.scss
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.scss
@@ -2180,6 +2180,16 @@ nb-card-header{
   letter-spacing: 0.04em;
   color: var(--bar-label-color, inherit);
   margin-bottom: 8px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.block-header-pool-tag{
+  font-size: 0.7rem;
+  font-weight: 500;
+  opacity: 0.6;
+  text-transform: none;
 }
 
 .block-header-row{

--- a/main/http_server/axe-os/src/app/pages/home/home.component.scss
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.scss
@@ -1453,6 +1453,11 @@ nb-card-header{
   background: var(--fill-color, var(--bar-track, rgba(128, 128, 128, 0.25)));
 }
 
+/* Heat column: pass full height so the box matches the power box height. */
+.heat-usage--plain{
+  height: 100%;
+}
+
 /* Heat boxed container (same look as other sections) */
 .heat-usage-box{
   width: 100%;
@@ -2157,4 +2162,93 @@ nb-card-header{
   font-weight: 500;
   color: var(--unit-in-fill-color, var(--unit-color));
   line-height: 1.1;
+}
+
+/* ── Block Header card ──────────────────────────────────────────── */
+.block-header-box{
+  width: 100%;
+  background: var(--tile-surface);
+  border: none;
+  border-radius: 0;
+  padding: 12px;
+}
+
+.block-header-title{
+  font-size: 0.85rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--bar-label-color, inherit);
+  margin-bottom: 8px;
+}
+
+.block-header-row{
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  padding: 3px 0;
+  gap: 8px;
+}
+
+.block-header-row--outputs{
+  align-items: flex-start;
+}
+
+.block-header-label{
+  font-size: 0.8rem;
+  color: var(--unit-color, rgba(128, 128, 128, 0.8));
+  flex-shrink: 0;
+  min-width: 70px;
+}
+
+.block-header-value{
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--bar-value-color, inherit);
+  text-align: right;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.block-header-mono{
+  font-family: 'Courier New', Courier, monospace;
+  font-size: 0.78rem;
+}
+
+.block-header-outputs{
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+  min-width: 0;
+}
+
+.block-header-output{
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.block-header-addr{
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+  min-width: 0;
+  text-align: left;
+}
+
+.block-header-sats{
+  font-size: 0.8rem;
+  color: var(--bar-value-color, inherit);
+  flex-shrink: 0;
+  white-space: nowrap;
+}
+
+/* Light theme: match the translucent white of other boxes */
+:host-context(.nb-theme-default) .block-header-box,
+:host-context(.nb-theme-corporate) .block-header-box,
+:host-context(.nb-theme-light) .block-header-box{
+  background: rgba(255, 255, 255, 0.5);
 }

--- a/main/http_server/axe-os/src/app/pages/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.ts
@@ -1900,4 +1900,36 @@ private setAxisPadding(cfg: any, persist: boolean = false): void {
 private importHistoricalDataChunked(history: any): void {
     this.historyDrainer.ingest(history);
   }
+
+  /* ── Block Header helpers ── */
+
+  getPayoutPercentage(info: ISystemInfo): number {
+    if (info.coinbaseValueTotalSatoshis) {
+      return (info.coinbaseValueUserSatoshis ?? 0) / info.coinbaseValueTotalSatoshis * 100;
+    }
+    return -1;
+  }
+
+  formatDifficulty(diff: number | undefined): string {
+    if (!diff) return '-';
+    const suffixes = ['', 'K', 'M', 'G', 'T', 'P', 'E'];
+    let idx = 0;
+    let v = diff;
+    while (v >= 1000 && idx < suffixes.length - 1) {
+      v /= 1000;
+      idx++;
+    }
+    return v.toFixed(idx === 0 ? 0 : 2) + suffixes[idx];
+  }
+
+  formatSats(sats: number | undefined): string {
+    if (!sats) return '-';
+    return (sats / 100_000_000).toFixed(8) + ' BTC';
+  }
+
+  truncateAddress(addr: string): string {
+    if (!addr) return '';
+    if (addr.length <= 20) return addr;
+    return addr.substring(0, 10) + '...' + addr.substring(addr.length - 8);
+  }
 }

--- a/main/http_server/axe-os/src/app/pages/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.ts
@@ -16,7 +16,7 @@ import { map,
   firstValueFrom } from 'rxjs';
 import { HashSuffixPipe } from '../../pipes/hash-suffix.pipe';
 import { SystemService } from '../../services/system.service';
-import { ISystemInfo } from '../../models/ISystemInfo';
+import { ISystemInfo, IBlockHeader } from '../../models/ISystemInfo';
 import { Chart } from 'chart.js';  // Import Chart.js
 import { registerHomeChartPlugins } from './plugins';
 import { HOME_CFG,
@@ -1903,9 +1903,13 @@ private importHistoricalDataChunked(history: any): void {
 
   /* ── Block Header helpers ── */
 
-  getPayoutPercentage(info: ISystemInfo): number {
-    if (info.coinbaseValueTotalSatoshis) {
-      return (info.coinbaseValueUserSatoshis ?? 0) / info.coinbaseValueTotalSatoshis * 100;
+  trackByPool(_index: number, bh: IBlockHeader): number {
+    return bh.pool;
+  }
+
+  getBlockHeaderFee(bh: IBlockHeader): number {
+    if (bh.coinbaseValueTotalSatoshis) {
+      return (bh.coinbaseValueUserSatoshis ?? 0) / bh.coinbaseValueTotalSatoshis * 100;
     }
     return -1;
   }

--- a/main/http_server/axe-os/src/assets/i18n/de.json
+++ b/main/http_server/axe-os/src/assets/i18n/de.json
@@ -73,7 +73,15 @@
     "RESET_STATS": "Sitzungsstatistiken zurücksetzen",
     "RESET_STATS_CONFIRM": "Alle Sitzungsstatistiken zurücksetzen (Shares, beste Diff, Fehler)?",
     "RESET_STATS_SUCCESS": "Sitzungsstatistiken zurückgesetzt.",
-    "RESET_STATS_FAILED": "Zurücksetzen fehlgeschlagen."
+    "RESET_STATS_FAILED": "Zurücksetzen fehlgeschlagen.",
+    "BLOCK_HEADER": "Block Header",
+    "BLOCK_HEIGHT": "Höhe",
+    "BLOCK_DIFFICULTY": "Schwierigkeit",
+    "BLOCK_SCRIPTSIG": "Scriptsig",
+    "BLOCK_VALUE": "Wert",
+    "BLOCK_OUTPUTS": "Ausgaben",
+    "BLOCK_FEE": "Gebühr",
+    "BLOCK_SHARE": "Anteil"
   },
   "PERFORMANCE": {
     "TITLE": "Leistung",

--- a/main/http_server/axe-os/src/assets/i18n/en.json
+++ b/main/http_server/axe-os/src/assets/i18n/en.json
@@ -75,7 +75,15 @@
     "RESET_STATS": "Reset Session Stats",
     "RESET_STATS_CONFIRM": "Reset all session stats (shares, best diff, errors)?",
     "RESET_STATS_SUCCESS": "Session stats reset.",
-    "RESET_STATS_FAILED": "Failed to reset session stats."
+    "RESET_STATS_FAILED": "Failed to reset session stats.",
+    "BLOCK_HEADER": "Block Header",
+    "BLOCK_HEIGHT": "Height",
+    "BLOCK_DIFFICULTY": "Difficulty",
+    "BLOCK_SCRIPTSIG": "Scriptsig",
+    "BLOCK_VALUE": "Value",
+    "BLOCK_OUTPUTS": "Outputs",
+    "BLOCK_FEE": "Fee",
+    "BLOCK_SHARE": "Share"
   },
   "PERFORMANCE": {
     "TITLE": "Performance",

--- a/main/http_server/axe-os/src/assets/i18n/es.json
+++ b/main/http_server/axe-os/src/assets/i18n/es.json
@@ -73,7 +73,15 @@
     "RESET_STATS": "Restablecer estadísticas de sesión",
     "RESET_STATS_CONFIRM": "¿Restablecer todas las estadísticas de sesión (shares, mejor diff, errores)?",
     "RESET_STATS_SUCCESS": "Estadísticas de sesión restablecidas.",
-    "RESET_STATS_FAILED": "Error al restablecer las estadísticas."
+    "RESET_STATS_FAILED": "Error al restablecer las estadísticas.",
+    "BLOCK_HEADER": "Cabecera de Bloque",
+    "BLOCK_HEIGHT": "Altura",
+    "BLOCK_DIFFICULTY": "Dificultad",
+    "BLOCK_SCRIPTSIG": "Scriptsig",
+    "BLOCK_VALUE": "Valor",
+    "BLOCK_OUTPUTS": "Salidas",
+    "BLOCK_FEE": "Comisión",
+    "BLOCK_SHARE": "Participación"
   },
   "PERFORMANCE": {
     "TITLE": "Rendimiento",

--- a/main/http_server/axe-os/src/assets/i18n/fr.json
+++ b/main/http_server/axe-os/src/assets/i18n/fr.json
@@ -74,7 +74,15 @@
     "RESET_STATS": "Réinitialiser les stats de session",
     "RESET_STATS_CONFIRM": "Réinitialiser toutes les stats de session (shares, meilleure diff, erreurs) ?",
     "RESET_STATS_SUCCESS": "Stats de session réinitialisées.",
-    "RESET_STATS_FAILED": "Échec de la réinitialisation."
+    "RESET_STATS_FAILED": "Échec de la réinitialisation.",
+    "BLOCK_HEADER": "En-tête de Bloc",
+    "BLOCK_HEIGHT": "Hauteur",
+    "BLOCK_DIFFICULTY": "Difficulté",
+    "BLOCK_SCRIPTSIG": "Scriptsig",
+    "BLOCK_VALUE": "Valeur",
+    "BLOCK_OUTPUTS": "Sorties",
+    "BLOCK_FEE": "Frais",
+    "BLOCK_SHARE": "Part"
   },
   "PERFORMANCE": {
     "TITLE": "Performance",

--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -148,21 +148,27 @@ esp_err_t GET_system_info(httpd_req_t *req)
 
     STRATUM_MANAGER->getManagerInfoJson(stratum_obj);
 
-    // Block header / coinbase data
+    // Block header / coinbase data (one entry per pool)
     {
-        const coinbase_result_t &cb = STRATUM_MANAGER->getCoinbaseResult();
-        if (cb.block_height > 0) {
-            doc["blockHeight"]  = cb.block_height;
-            doc["scriptsig"]    = cb.scriptsig;
+        JsonArray blockHeaders = doc["blockHeaders"].to<JsonArray>();
+        for (int p = 0; p < 2; p++) {
+            const coinbase_result_t &cb = STRATUM_MANAGER->getCoinbaseResult(p);
+            if (cb.block_height > 0) {
+                JsonObject bh = blockHeaders.add<JsonObject>();
+                bh["pool"]       = p;
+                bh["blockHeight"] = cb.block_height;
+                bh["networkDifficulty"] = cb.network_difficulty;
+                bh["scriptsig"]  = cb.scriptsig;
 
-            JsonArray outputs = doc["coinbaseOutputs"].to<JsonArray>();
-            for (int i = 0; i < cb.output_count; i++) {
-                JsonObject out = outputs.add<JsonObject>();
-                out["value"]   = cb.outputs[i].value_satoshis;
-                out["address"] = cb.outputs[i].address;
+                JsonArray outputs = bh["coinbaseOutputs"].to<JsonArray>();
+                for (int i = 0; i < cb.output_count; i++) {
+                    JsonObject out = outputs.add<JsonObject>();
+                    out["value"]   = cb.outputs[i].value_satoshis;
+                    out["address"] = cb.outputs[i].address;
+                }
+                bh["coinbaseValueTotalSatoshis"] = cb.total_value_satoshis;
+                bh["coinbaseValueUserSatoshis"]  = cb.user_value_satoshis;
             }
-            doc["coinbaseValueTotalSatoshis"] = cb.total_value_satoshis;
-            doc["coinbaseValueUserSatoshis"]  = cb.user_value_satoshis;
         }
     }
 

--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -148,6 +148,24 @@ esp_err_t GET_system_info(httpd_req_t *req)
 
     STRATUM_MANAGER->getManagerInfoJson(stratum_obj);
 
+    // Block header / coinbase data
+    {
+        const coinbase_result_t &cb = STRATUM_MANAGER->getCoinbaseResult();
+        if (cb.block_height > 0) {
+            doc["blockHeight"]  = cb.block_height;
+            doc["scriptsig"]    = cb.scriptsig;
+
+            JsonArray outputs = doc["coinbaseOutputs"].to<JsonArray>();
+            for (int i = 0; i < cb.output_count; i++) {
+                JsonObject out = outputs.add<JsonObject>();
+                out["value"]   = cb.outputs[i].value_satoshis;
+                out["address"] = cb.outputs[i].address;
+            }
+            doc["coinbaseValueTotalSatoshis"] = cb.total_value_satoshis;
+            doc["coinbaseValueUserSatoshis"]  = cb.user_value_satoshis;
+        }
+    }
+
     // asic temps
     {
         JsonArray arr = doc["asicTemps"].to<JsonArray>();

--- a/main/stratum/stratum_manager.cpp
+++ b/main/stratum/stratum_manager.cpp
@@ -419,7 +419,7 @@ void StratumManager::processCoinbase(int pool, const mining_notify *notify)
     );
 
     if (err == ESP_OK) {
-        m_coinbaseResult = result;
+        m_coinbaseResult[pool & 1] = result;
     }
 }
 

--- a/main/stratum/stratum_manager.cpp
+++ b/main/stratum/stratum_manager.cpp
@@ -173,6 +173,7 @@ void StratumManager::dispatch(int pool, JsonDocument &doc)
     switch (m_stratum_api_v1_message.method) {
     case MINING_NOTIFY: {
         setNetworkDifficulty(pool, m_stratum_api_v1_message.mining_notification->target);
+        processCoinbase(pool, m_stratum_api_v1_message.mining_notification);
         create_job_mining_notify(pool, m_stratum_api_v1_message.mining_notification,
                                  m_stratum_api_v1_message.should_abandon_work || selected->m_firstJob);
 
@@ -203,6 +204,7 @@ void StratumManager::dispatch(int pool, JsonDocument &doc)
         // the new extranonce gets active with the next mining.notify
         ESP_LOGI(tag, "Set next enonce %s enonce2-len: %d", m_stratum_api_v1_message.extranonce_str,
                  m_stratum_api_v1_message.extranonce_2_len);
+        storeExtranonce(pool, m_stratum_api_v1_message.extranonce_str, m_stratum_api_v1_message.extranonce_2_len);
         set_next_enonce(pool, m_stratum_api_v1_message.extranonce_str, m_stratum_api_v1_message.extranonce_2_len);
         break;
     }
@@ -210,6 +212,7 @@ void StratumManager::dispatch(int pool, JsonDocument &doc)
     case STRATUM_RESULT_SUBSCRIBE: {
         ESP_LOGI(tag, "Set enonce %s enonce2-len: %d", m_stratum_api_v1_message.extranonce_str,
                  m_stratum_api_v1_message.extranonce_2_len);
+        storeExtranonce(pool, m_stratum_api_v1_message.extranonce_str, m_stratum_api_v1_message.extranonce_2_len);
         create_job_set_enonce(pool, m_stratum_api_v1_message.extranonce_str, m_stratum_api_v1_message.extranonce_2_len);
         break;
     }
@@ -385,6 +388,39 @@ void StratumManager::checkForBestDiff(int pool, double diff, uint32_t nbits)
     // send alert that a new best difficulty was found
     double networkDiff = calculateNetworkDifficulty(nbits);
     discordAlerter.sendBestDifficultyAlert(diff, networkDiff);
+}
+
+void StratumManager::storeExtranonce(int pool, const char *extranonce, int extranonce2_len)
+{
+    if (pool < 0 || pool > 1) return;
+    free(m_extranonce1[pool]);
+    m_extranonce1[pool] = extranonce ? strdup(extranonce) : nullptr;
+    m_extranonce2_len[pool] = extranonce2_len;
+}
+
+void StratumManager::processCoinbase(int pool, const mining_notify *notify)
+{
+    if (!notify || !notify->coinbase_1 || !notify->coinbase_2) return;
+    if (pool < 0 || pool > 1 || !m_extranonce1[pool]) return;
+
+    const char *user = m_stratumConfig[pool] ? m_stratumConfig[pool]->getUser() : nullptr;
+
+    coinbase_result_t result{};
+    esp_err_t err = coinbase_process(
+        notify->coinbase_1,
+        notify->coinbase_2,
+        notify->version,
+        notify->target,
+        m_extranonce1[pool],
+        m_extranonce2_len[pool],
+        user,
+        true, /* decode_coinbase_tx */
+        &result
+    );
+
+    if (err == ESP_OK) {
+        m_coinbaseResult = result;
+    }
 }
 
 void StratumManager::getManagerInfoJson(JsonObject &obj)

--- a/main/stratum/stratum_manager.h
+++ b/main/stratum/stratum_manager.h
@@ -7,6 +7,7 @@
 
 #include "ArduinoJson.h"
 
+#include "coinbase_decoder.h"
 #include "stratum_task.h"
 #include "../tasks/ping_task.h"
 
@@ -57,6 +58,14 @@ class StratumManager {
     char m_bestSessionDiffString[DIFF_STRING_SIZE]{}; // String representation of the best session difficulty
 
     bool m_initialized = false;
+
+    // Coinbase decoder: extranonce state per pool + decoded result
+    char *m_extranonce1[2]{};
+    int m_extranonce2_len[2]{};
+    coinbase_result_t m_coinbaseResult{};
+
+    void processCoinbase(int pool, const mining_notify *notify);
+    void storeExtranonce(int pool, const char *extranonce, int extranonce2_len);
 
     PoolMode getPoolMode() const
     {
@@ -173,6 +182,16 @@ class StratumManager {
 
     virtual uint32_t getPoolDifficulty() = 0;
     virtual double getNetworkDifficulty() { return 0; }
+
+    const coinbase_result_t &getCoinbaseResult() {
+        PThreadGuard lock(m_mutex);
+        return m_coinbaseResult;
+    }
+
+    void setCoinbaseResult(const coinbase_result_t &result) {
+        PThreadGuard lock(m_mutex);
+        m_coinbaseResult = result;
+    }
 
     virtual int getCompatPingPoolIndex() = 0;
 

--- a/main/stratum/stratum_manager.h
+++ b/main/stratum/stratum_manager.h
@@ -62,7 +62,7 @@ class StratumManager {
     // Coinbase decoder: extranonce state per pool + decoded result
     char *m_extranonce1[2]{};
     int m_extranonce2_len[2]{};
-    coinbase_result_t m_coinbaseResult{};
+    coinbase_result_t m_coinbaseResult[2]{};
 
     void processCoinbase(int pool, const mining_notify *notify);
     void storeExtranonce(int pool, const char *extranonce, int extranonce2_len);
@@ -183,14 +183,14 @@ class StratumManager {
     virtual uint32_t getPoolDifficulty() = 0;
     virtual double getNetworkDifficulty() { return 0; }
 
-    const coinbase_result_t &getCoinbaseResult() {
+    const coinbase_result_t &getCoinbaseResult(int pool) {
         PThreadGuard lock(m_mutex);
-        return m_coinbaseResult;
+        return m_coinbaseResult[pool & 1];
     }
 
-    void setCoinbaseResult(const coinbase_result_t &result) {
+    void setCoinbaseResult(int pool, const coinbase_result_t &result) {
         PThreadGuard lock(m_mutex);
-        m_coinbaseResult = result;
+        m_coinbaseResult[pool & 1] = result;
     }
 
     virtual int getCompatPingPoolIndex() = 0;

--- a/main/tasks/create_jobs_sv2.cpp
+++ b/main/tasks/create_jobs_sv2.cpp
@@ -5,6 +5,7 @@
 #include "macros.h"
 #include "coinbase_decoder.h"
 #include "mining_utils.h"
+#include "nvs_config.h"
 
 #include "esp_log.h"
 
@@ -34,13 +35,18 @@ static void processSV2ExtendedCoinbase(int pool, const sv2_ext_job_t *job,
     bin2hex(job->coinbase_suffix, job->coinbase_suffix_len, suffix_hex, job->coinbase_suffix_len * 2 + 1);
     bin2hex(extranonce_prefix, extranonce_prefix_len, enonce_hex, extranonce_prefix_len * 2 + 1);
 
+    // Get user address for payout matching (fee calculation)
+    char *user = Config::getStratumUser();
+
     coinbase_result_t result{};
     esp_err_t err = coinbase_process(
         prefix_hex, suffix_hex,
         job->version, job->nbits,
         enonce_hex, extranonce_size,
-        nullptr, true, &result
+        user, true, &result
     );
+
+    safe_free(user);
 
     if (err == ESP_OK) {
         STRATUM_MANAGER->setCoinbaseResult(result);

--- a/main/tasks/create_jobs_sv2.cpp
+++ b/main/tasks/create_jobs_sv2.cpp
@@ -3,10 +3,53 @@
 #include "mining_info_v2.h"
 #include "global_state.h"
 #include "macros.h"
+#include "coinbase_decoder.h"
+#include "mining_utils.h"
 
 #include "esp_log.h"
 
 static const char *TAG = "create_jobs_sv2";
+
+/**
+ * Process SV2 Extended Channel coinbase for block header display.
+ * Converts binary coinbase_prefix/suffix to hex and runs coinbase_process().
+ */
+static void processSV2ExtendedCoinbase(int pool, const sv2_ext_job_t *job,
+                                        const uint8_t *extranonce_prefix, uint8_t extranonce_prefix_len,
+                                        uint8_t extranonce_size)
+{
+    if (!job->coinbase_prefix || !job->coinbase_suffix || job->coinbase_prefix_len == 0) return;
+    if (!STRATUM_MANAGER) return;
+
+    // Convert binary prefix/suffix to hex strings for coinbase_process()
+    char *prefix_hex = (char *)malloc(job->coinbase_prefix_len * 2 + 1);
+    char *suffix_hex = (char *)malloc(job->coinbase_suffix_len * 2 + 1);
+    char *enonce_hex = (char *)malloc(extranonce_prefix_len * 2 + 1);
+    if (!prefix_hex || !suffix_hex || !enonce_hex) {
+        free(prefix_hex); free(suffix_hex); free(enonce_hex);
+        return;
+    }
+
+    bin2hex(job->coinbase_prefix, job->coinbase_prefix_len, prefix_hex, job->coinbase_prefix_len * 2 + 1);
+    bin2hex(job->coinbase_suffix, job->coinbase_suffix_len, suffix_hex, job->coinbase_suffix_len * 2 + 1);
+    bin2hex(extranonce_prefix, extranonce_prefix_len, enonce_hex, extranonce_prefix_len * 2 + 1);
+
+    coinbase_result_t result{};
+    esp_err_t err = coinbase_process(
+        prefix_hex, suffix_hex,
+        job->version, job->nbits,
+        enonce_hex, extranonce_size,
+        nullptr, true, &result
+    );
+
+    if (err == ESP_OK) {
+        STRATUM_MANAGER->setCoinbaseResult(result);
+    }
+
+    free(prefix_hex);
+    free(suffix_hex);
+    free(enonce_hex);
+}
 
 // Thread-safe holders for V2 mining info (one per pool)
 // These are allocated on first use and reused across jobs.
@@ -58,6 +101,9 @@ void create_job_sv2_extended(int pool, const sv2_ext_job_t *job,
 
     s_v2_extended[pool]->updateJob(job, extranonce_prefix, extranonce_prefix_len,
                                     extranonce_size, version_mask, difficulty);
+
+    // Decode coinbase for block header display
+    processSV2ExtendedCoinbase(pool, job, extranonce_prefix, extranonce_prefix_len, extranonce_size);
 
     // Clear old jobs on clean flag
     if (clean) {

--- a/main/tasks/create_jobs_sv2.cpp
+++ b/main/tasks/create_jobs_sv2.cpp
@@ -36,7 +36,7 @@ static void processSV2ExtendedCoinbase(int pool, const sv2_ext_job_t *job,
     bin2hex(extranonce_prefix, extranonce_prefix_len, enonce_hex, extranonce_prefix_len * 2 + 1);
 
     // Get user address for payout matching (fee calculation)
-    char *user = Config::getStratumUser();
+    char *user = (pool == 0) ? Config::getStratumUser() : Config::getStratumFallbackUser();
 
     coinbase_result_t result{};
     esp_err_t err = coinbase_process(
@@ -49,7 +49,7 @@ static void processSV2ExtendedCoinbase(int pool, const sv2_ext_job_t *job,
     safe_free(user);
 
     if (err == ESP_OK) {
-        STRATUM_MANAGER->setCoinbaseResult(result);
+        STRATUM_MANAGER->setCoinbaseResult(pool, result);
     }
 
     free(prefix_hex);


### PR DESCRIPTION
## Summary

- Adds a **Block Header card** to the dashboard showing block height, network difficulty, scriptsig (miner tag), coinbase value, pool fee percentage, and payout outputs
- New `components/coinbase_decoder/` ESP-IDF component that decodes coinbase transactions with bech32 and base58 address encoding (P2PKH, P2SH, P2WPKH, P2WSH, P2TR)
- Works for both **SV1** (via `mining.notify` in stratum manager dispatch) and **SV2 Extended Channel** (via `NewExtendedMiningJob` in create_jobs_sv2)
- Hidden for future SV2 Standard Channel deployments (no coinbase data available)
- Half-width card below the power/heat section, matching existing theme styling
- Translations: EN, DE, ES, FR

<img width="2708" height="1220" alt="grafik" src="https://github.com/user-attachments/assets/225f665e-0f03-44a9-a927-010f1b6e8f06" />
