### PR TITLE
fix: handle SV2 batch share acknowledgment per spec

### DIFF
--- a/components/stratum_v2/include/sv2_protocol.h
+++ b/components/stratum_v2/include/sv2_protocol.h
@@ -164,7 +164,8 @@ int sv2_parse_set_target(const uint8_t *payload, uint32_t len,
                          uint32_t *channel_id, uint8_t max_target[32]);
 
 int sv2_parse_submit_shares_success(const uint8_t *payload, uint32_t len,
-                                    uint32_t *channel_id);
+                                    uint32_t *channel_id,
+                                    uint32_t *new_submits_accepted_count);
 
 int sv2_parse_submit_shares_error(const uint8_t *payload, uint32_t len,
                                   uint32_t *channel_id, uint32_t *seq_num,

--- a/components/stratum_v2/sv2_protocol.c
+++ b/components/stratum_v2/sv2_protocol.c
@@ -336,11 +336,13 @@ int sv2_parse_set_target(const uint8_t *payload, uint32_t len,
 }
 
 int sv2_parse_submit_shares_success(const uint8_t *payload, uint32_t len,
-                                    uint32_t *channel_id)
+                                    uint32_t *channel_id,
+                                    uint32_t *new_submits_accepted_count)
 {
     // channel_id(4) + last_seq(4) + accepted_count(4) + shares_sum(8) = 20 bytes
     if (len < 20) return -1;
     *channel_id = read_u32_le(payload);
+    *new_submits_accepted_count = read_u32_le(payload + 8);
     return 0;
 }
 

--- a/main/stratum/stratum_task_v2.cpp
+++ b/main/stratum/stratum_task_v2.cpp
@@ -550,14 +550,21 @@ void StratumTaskV2::handleSetTarget(const uint8_t *payload, uint32_t len)
 void StratumTaskV2::handleSubmitSharesSuccess(const uint8_t *payload, uint32_t len)
 {
     uint32_t channel_id;
-    if (sv2_parse_submit_shares_success(payload, len, &channel_id) == 0) {
+    uint32_t accepted_count = 0;
+    if (sv2_parse_submit_shares_success(payload, len, &channel_id, &accepted_count) == 0) {
         if (m_lastSubmitTimeUs > 0) {
             float response_time_ms = (float)(esp_timer_get_time() - m_lastSubmitTimeUs) / 1000.0f;
-            ESP_LOGI(m_tag, "Share accepted (%.1f ms)", response_time_ms);
+            ESP_LOGI(m_tag, "Shares accepted: %lu (%.1f ms)", (unsigned long)accepted_count, response_time_ms);
         } else {
-            ESP_LOGI(m_tag, "Share accepted");
+            ESP_LOGI(m_tag, "Shares accepted: %lu", (unsigned long)accepted_count);
         }
-        m_manager->acceptedShare(m_index);
+        if (accepted_count > 1000) {
+            ESP_LOGW(m_tag, "Suspicious accepted_count %lu, capping to 1000", (unsigned long)accepted_count);
+            accepted_count = 1000;
+        }
+        for (uint32_t i = 0; i < accepted_count; i++) {
+            m_manager->acceptedShare(m_index);
+        }
         m_manager->m_lastSubmitResponseTimestamp = esp_timer_get_time();
     }
 }


### PR DESCRIPTION
## Summary

- Parse `new_submits_accepted_count` from `SubmitShares.Success` (U32 at offset 8) and increment accepted shares by that value instead of hardcoded +1
- SV2 spec allows pools to batch-acknowledge multiple shares in a single response
- Pools that acknowledge per-share (count=1) are unaffected

Previously the accepted share counter undercounted on pools that batch (e.g. SRI reference pool acknowledges in batches of 10).

Ref: https://github.com/stratum-mining/sv2-spec/blob/main/05-Mining-Protocol.md#5313-submitsharessuccess-server---client

## Test plan

- Tested with SRI reference pool (batch acknowledgment) and custom SV2 pool (per-share acknowledgment)
- Share counters now match submitted shares on both pool types