### PR TITLE
Fix VReg overheat handling after dual fan channel split

### DIFF
--- a/main/nvs_config.cpp
+++ b/main/nvs_config.cpp
@@ -137,6 +137,17 @@ void nvs_config_set_u64(const char *key, const uint64_t value)
     nvs_close(handle);
 }
 
+bool nvs_config_has_u16(const char *key)
+{
+    nvs_handle handle;
+    if (nvs_open(NVS_CONFIG_NAMESPACE, NVS_READONLY, &handle) != ESP_OK)
+        return false;
+    uint16_t dummy;
+    bool exists = (nvs_get_u16(handle, key, &dummy) == ESP_OK);
+    nvs_close(handle);
+    return exists;
+}
+
 void migrate_config()
 {
     // overwrite previously allowed 0 value to disable
@@ -153,6 +164,13 @@ void migrate_config()
         ESP_LOGW(TAG, "Disabled AFC (deprecated), Enabled manual 100%%.");
         setTempControlMode(0);
         setFanSpeed(100);
+    }
+
+    // migrate VReg overheat temp: if not yet set, inherit ASIC overheat temp
+    if (!nvs_config_has_u16(NVS_CONFIG_FAN1_OVERHEAT)) {
+        uint16_t asic_temp = getOverheatTemp();
+        ESP_LOGI(TAG, "Migrating VReg overheat temp from ASIC value: %u°C", asic_temp);
+        setFanOverheatTemp(1, asic_temp);
     }
 }
 

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -115,6 +115,7 @@ namespace Config {
     void nvs_config_set_string(const char* key, const char* value);
     uint16_t nvs_config_get_u16(const char* key, uint16_t default_value);
     void nvs_config_set_u16(const char* key, uint16_t value);
+    bool nvs_config_has_u16(const char* key);
     uint64_t nvs_config_get_u64(const char* key, uint64_t default_value);
     void nvs_config_set_u64(const char* key, uint64_t value);
 

--- a/main/tasks/power_management_task.cpp
+++ b/main/tasks/power_management_task.cpp
@@ -306,8 +306,10 @@ void PowerManagementTask::task()
             uint32_t status = ((uint32_t) m_chipTempMax << 24) | ((uint32_t) m_fanController.getOverheatTemp(0) << 16) |
                               ((uint32_t) m_vrTemp << 8) | ((uint32_t) m_fanController.getOverheatTemp(1));
 
-            // over temperature
-            SYSTEM_MODULE.setBoardError(Board::Error::TEMP_FAULT, status);
+            // over temperature — ASIC takes priority over VReg-only
+            Board::Error overheatErr = Board::Error::VREG_TEMP_FAULT;
+            if (m_fanController.isOverheated(0)) overheatErr = Board::Error::TEMP_FAULT;
+            SYSTEM_MODULE.setBoardError(overheatErr, status);
 
             // disables the buck
             m_board->setVoltage(0.0);


### PR DESCRIPTION
- Migrate VReg shutdown temp on first boot after update: inherits the
  ASIC overheat temp from NVS instead of falling back to the 70°C default
- Show "VREG OVERHEATED" error instead of "MINER OVERHEATED" when only
  the VReg fan channel triggers the shutdown threshold
- Add nvs_config_has_u16() helper to check key existence without a default