### PR TITLE
Show payout share instead of honesty in basic verify mode

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.ts
@@ -2058,6 +2058,25 @@ private importHistoricalDataChunked(history: any): void {
     const bh = (this._info?.blockHeaders as IBlockHeader[] | undefined)?.find((h: IBlockHeader) => h.pool === poolIdx);
     if (!bh) return '';
 
+    const lines: string[] = [];
+
+    if (mode === 1) {
+      // Basic mode: only address check. Show payout share as % and BTC.
+      const total = bh.coinbaseValueTotalSatoshis ?? 0;
+      const user  = bh.coinbaseValueUserSatoshis ?? 0;
+      if (total > 0) {
+        const pct = (user / total) * 100;
+        lines.push(`Payout: ${pct.toFixed(2)}% (${this.formatSats(user)})`);
+      } else {
+        lines.push('Payout: n/a (no coinbase data yet)');
+      }
+      if (!bh.verificationOk) {
+        lines.push('Your address was not found in the last coinbase.');
+      }
+      return lines.join('\n');
+    }
+
+    // Advanced mode (fee check etc.): keep honesty-style summary
     const checks = bh.verificationCheckCount ?? 0;
     const fails = bh.verificationFailCount ?? 0;
     const honesty = this.getPoolHonestyPct(bh);
@@ -2065,9 +2084,8 @@ private importHistoricalDataChunked(history: any): void {
     const fee = this.getBlockHeaderFee(bh);
     const feeStr = fee >= 0 ? fee.toFixed(2) + '%' : 'unknown';
 
-    const lines: string[] = [];
     lines.push(`Honesty: ${honestyStr} (${checks - fails}/${checks} checks passed)`);
-    if (mode >= 2) lines.push(`Current pool fee: ${feeStr}`);
+    lines.push(`Current pool fee: ${feeStr}`);
     if (!bh.verificationOk) {
       lines.push(bh.coinbaseValueUserSatoshis === 0
         ? 'Your address was not found in the last coinbase.'


### PR DESCRIPTION
Follow-up to #572.

In basic coinbase verification mode (address check only), the honesty percentage doesn't add much - it's essentially just "is your address in the last coinbase, yes/no". The number users actually care about is their share of the coinbase output.

This changes the basic-mode tooltip to show the payout share both as percentage and in BTC, e.g.:

```
Payout: 99.85% (3.12345678 BTC)
```

If the address isn't in the coinbase, an additional line warns about it (same as before). Advanced mode (with fee check) keeps the existing honesty + pool fee breakdown.

Color logic stays as-is: green while the user's address is found in the coinbase outputs, red when it disappears.

Our Pool in PPLNS Mode:

<img width="1256" height="288" alt="grafik" src="https://github.com/user-attachments/assets/b794f9ca-e72e-491e-a6da-f951d28b9e9e" />

Solo Mode

<img width="1256" height="289" alt="grafik" src="https://github.com/user-attachments/assets/3fad13c4-2009-4669-b685-679cb14f3b25" />
