### PR TITLE
increase watchdog timeout from 3600 to 604800

### DIFF
--- a/main/main.cpp
+++ b/main/main.cpp
@@ -40,7 +40,7 @@
 #include "guards.h"
 #include "utils.h"
 
-#define STRATUM_WATCHDOG_TIMEOUT_SECONDS 3600
+#define STRATUM_WATCHDOG_TIMEOUT_SECONDS 604800
 
 System SYSTEM_MODULE;
 

--- a/main/stratum/stratum_manager.cpp
+++ b/main/stratum/stratum_manager.cpp
@@ -125,7 +125,7 @@ void StratumManager::task()
         vTaskDelay(pdMS_TO_TICKS(30000));
 
         // Reset watchdog if there was a submit response within the last hour
-        if (m_lastSubmitResponseTimestamp && ((esp_timer_get_time() - m_lastSubmitResponseTimestamp) / 1000000) < 3600) {
+        if (m_lastSubmitResponseTimestamp && ((esp_timer_get_time() - m_lastSubmitResponseTimestamp) / 1000000) < 604800) {
             esp_task_wdt_reset();
         }
     }


### PR DESCRIPTION
### Problem

When mining solo at high pool difficulty (e.g. 50M), physical miners at low hashrates (1–12 TH/s) can statistically take longer than 1 hour between qualifying share submissions. The current hardcoded 3600s watchdog timeout in `stratum_manager.cpp` causes continuous reboots in this scenario:

- Miner connects, pool sets difficulty to 50M
- Miner hashes for >3600s without finding a share above 50M
- `m_lastSubmitResponseTimestamp` is never updated
- ESP task watchdog fires → `SYSTEM.RESET_TASK_WATCHDOG`
- Repeat indefinitely

**Affected devices:** Any Nerd\*Axe running at low hashrate pointed at a solo pool with high minimum difficulty.

### Fix

Increase the watchdog timeout from `3600` (1 hour) to `604800` (7 days), giving miners sufficient time to find and submit a qualifying share before the watchdog fires.

### Testing

Tested on:
- **NerdQAxe++** (~4.8 TH/s, BM1370) — stable, no watchdog resets
- **NerdOCTAXE-γ** (~12 TH/s, BM1370) — stable, no watchdog resets

Both miners previously rebooted every hour. After this fix they run continuously.

### Notes

A more elegant long-term solution might be to make this timeout configurable via the API (e.g. a `watchdogTimeout` setting in NVS), allowing users to tune it based on their pool difficulty and hashrate. This PR takes the minimal safe approach of raising the ceiling significantly.



Update: The fix required changes in two places:

main/stratum/stratum_manager.cpp — application-level check (initial fix)
main/main.cpp — STRATUM_WATCHDOG_TIMEOUT_SECONDS define that sets the actual ESP hardware watchdog timeout via esp_task_wdt_init(). This was the real culprit causing reboots at exactly 3600s regardless of the application-level check.