### PR TITLE
fix: require auth for CAN slave actions

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -514,19 +514,19 @@ Update node configuration (slaves only, `id >= 1`). Requires OTP.
 
 #### `POST /api/v2/can/nodes/{id}/restart`
 
-Restart a node (slaves only, `id >= 1`).
+Restart a node (slaves only, `id >= 1`). Requires OTP.
 
 **Response**: `{"ok": true}`
 
 #### `POST /api/v2/can/nodes/{id}/shutdown`
 
-Shutdown a node (slaves only, `id >= 1`). Stops mining until restarted.
+Shutdown a node (slaves only, `id >= 1`). Stops mining until restarted. Requires OTP.
 
 **Response**: `{"ok": true}`
 
 #### `POST /api/v2/can/nodes/{id}/identify`
 
-Trigger identification sequence on a node (slaves only, `id >= 1`).
+Trigger identification sequence on a node (slaves only, `id >= 1`). Requires OTP.
 
 **Response**: `{"ok": true}`
 

--- a/main/http_server/axe-os/src/app/pages/can-swarm/can-swarm.component.ts
+++ b/main/http_server/axe-os/src/app/pages/can-swarm/can-swarm.component.ts
@@ -211,24 +211,27 @@ export class CanSwarmComponent implements OnInit, OnDestroy {
     });
   }
 
-  restartSlave(id: number): void {
-    if (!confirm(`Restart slave ${id}?`)) return;
-    this.http.post(`/api/v2/can/nodes/${id}/restart`, null).pipe(
+  private postSlaveAction(id: number, action: 'restart' | 'shutdown' | 'identify', hint: string): void {
+    this.otpAuth.ensureOtp$('', 'OTP Required', hint).pipe(
+      switchMap(({ totp }: EnsureOtpResult) =>
+        this.http.post(`/api/v2/can/nodes/${id}/${action}`, null, { headers: this.headers(totp) })
+      ),
       catchError(() => of(null))
     ).subscribe();
+  }
+
+  restartSlave(id: number): void {
+    if (!confirm(`Restart slave ${id}?`)) return;
+    this.postSlaveAction(id, 'restart', 'Enter your OTP to restart slave');
   }
 
   shutdownSlave(id: number): void {
     if (!confirm(`Shutdown slave ${id}? It will stop mining until restarted.`)) return;
-    this.http.post(`/api/v2/can/nodes/${id}/shutdown`, null).pipe(
-      catchError(() => of(null))
-    ).subscribe();
+    this.postSlaveAction(id, 'shutdown', 'Enter your OTP to shut down slave');
   }
 
   identifySlave(id: number): void {
-    this.http.post(`/api/v2/can/nodes/${id}/identify`, null).pipe(
-      catchError(() => of(null))
-    ).subscribe();
+    this.postSlaveAction(id, 'identify', 'Enter your OTP to identify slave');
   }
 
   deleteSlave(id: number): void {

--- a/main/http_server/handler_can_swarm.cpp
+++ b/main/http_server/handler_can_swarm.cpp
@@ -186,8 +186,16 @@ esp_err_t PATCH_can_slave(httpd_req_t *req)
 {
     ConGuard g(http_server, req);
 
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+
     if (set_cors_headers(req) != ESP_OK) {
         httpd_resp_send_500(req);
+        return ESP_FAIL;
+    }
+
+    if (validateOTP(req) != ESP_OK) {
         return ESP_FAIL;
     }
 
@@ -213,10 +221,6 @@ esp_err_t PATCH_can_slave(httpd_req_t *req)
     JsonDocument doc;
     if (deserializeJson(doc, body) != DeserializationError::Ok) {
         return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "invalid json");
-    }
-
-    if (validateOTP(req) != ESP_OK) {
-        return ESP_FAIL;
     }
 
     // field names matching info endpoint PATCH
@@ -275,6 +279,9 @@ esp_err_t POST_can_slave_action(httpd_req_t *req)
     if (is_network_allowed(req) != ESP_OK)
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     if (set_cors_headers(req) != ESP_OK) { httpd_resp_send_500(req); return ESP_FAIL; }
+    if (validateOTP(req) != ESP_OK) {
+        return ESP_FAIL;
+    }
 
     uint8_t slave_id;
     if (parse_slave_id(req, &slave_id) != ESP_OK)
@@ -302,6 +309,10 @@ esp_err_t POST_can_slave_action(httpd_req_t *req)
 esp_err_t DELETE_can_slave(httpd_req_t *req)
 {
     ConGuard g(http_server, req);
+
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
 
     if (set_cors_headers(req) != ESP_OK) {
         httpd_resp_send_500(req);


### PR DESCRIPTION
## Summary
- Require OTP/session validation for CAN slave restart/shutdown/identify actions.
- Add the same network allow-list check to CAN slave PATCH and DELETE handlers that peer API handlers already use.
- Update the web UI and API docs so CAN slave actions send OTP headers when OTP is enabled.

## Why
The CAN slave action endpoint could restart, shut down, or identify slave nodes after only the network allow-list check. This bypassed the OTP/session protection used by other mutating device-management endpoints. PATCH and DELETE also had OTP checks but missed the network allow-list check, making the CAN mutating handlers inconsistent.

## Test plan
- `git diff --check`
- Static check confirmed PATCH/POST/DELETE CAN slave handlers contain both `is_network_allowed(req)` and `validateOTP(req)`.
- `npm ci`
- `npm run build`

Note: I could not run a full ESP-IDF firmware build because `idf.py` is not installed in this environment.
