### PR TITLE
Add mDNS/DNS-SD discovery for LAN device detection

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -66,6 +66,7 @@ SRCS
     "./stratum/stratum_transport_noise.cpp"
     "./stratum/stratum_task_v2.cpp"
     "./network/connect.cpp"
+    "./network/mdns_service.cpp"
     "./network/network_manager.cpp"
     "./network/w5500.cpp"
     "./tasks/create_jobs_task.cpp"

--- a/main/main.cpp
+++ b/main/main.cpp
@@ -45,6 +45,7 @@
 #include "can_master_task.h"
 #include "guards.h"
 #include "utils.h"
+#include "network/mdns_service.h"
 #include "network/network_manager.h"
 
 #define STRATUM_WATCHDOG_TIMEOUT_SECONDS 3600
@@ -138,6 +139,7 @@ static void setup_network(bool hasEth)
                 ESP_LOGI(TAG, "Network up via WiFi");
                 SYSTEM_MODULE.setWifiStatus("WiFi Connected!");
             }
+            mdns_service_start(hostname, SYSTEM_MODULE.getBoard());
             return;
         }
 

--- a/main/network/mdns_service.cpp
+++ b/main/network/mdns_service.cpp
@@ -1,0 +1,57 @@
+#include "mdns_service.h"
+
+#include <stdio.h>
+#include "esp_app_desc.h"
+#include "esp_log.h"
+#include "mdns.h"
+
+static const char *TAG = "mdns_svc";
+static bool s_started = false;
+
+void mdns_service_start(const char *hostname, Board *board)
+{
+    if (s_started) return;
+
+    esp_err_t err = mdns_init();
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "mdns_init failed: %s", esp_err_to_name(err));
+        return;
+    }
+
+    const char *host = (hostname && hostname[0]) ? hostname : "nerdminer";
+    mdns_hostname_set(host);
+    mdns_instance_name_set(host);
+
+    char board_ver[8];
+    snprintf(board_ver, sizeof(board_ver), "%d", board ? board->getVersion() : 0);
+    char asic_count[8];
+    snprintf(asic_count, sizeof(asic_count), "%d", board ? board->getAsicCount() : 0);
+    const esp_app_desc_t *app = esp_app_get_description();
+
+    mdns_txt_item_t txt[] = {
+        {"board",      board_ver},
+        {"family",     board ? board->getDeviceModel() : "unknown"},
+        {"asic",       board ? board->getAsicModel() : ""},
+        {"asic_count", asic_count},
+        {"fw_version", app ? app->version : ""},
+    };
+
+    err = mdns_service_add(host, "_http", "_tcp", 80, txt, sizeof(txt) / sizeof(txt[0]));
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "mdns_service_add failed: %s", esp_err_to_name(err));
+        return;
+    }
+
+    err = mdns_service_subtype_add_for_host(host, "_http", "_tcp", NULL, "_axeos");
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "subtype add failed: %s", esp_err_to_name(err));
+    }
+
+    ESP_LOGI(TAG, "mDNS up: %s.local (family=%s, asic=%s, count=%s, fw=%s)",
+             host,
+             board ? board->getDeviceModel() : "",
+             board ? board->getAsicModel() : "",
+             asic_count,
+             app ? app->version : "");
+    s_started = true;
+}

--- a/main/network/mdns_service.h
+++ b/main/network/mdns_service.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "boards/board.h"
+
+void mdns_service_start(const char *hostname, Board *board);


### PR DESCRIPTION
Advertise <hostname>.local via mDNS with _http._tcp service and _axeos subtype for AxeOS-compatible discovery. TXT records expose board, family, ASIC model, ASIC count, and firmware version.

Based on PR #609 by @jankrejci, cleaned up for the current codebase.