### PR TITLE
fix: use X-TOTP for alert test OTP

### DIFF
--- a/main/http_server/axe-os/src/app/services/system.service.spec.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.spec.ts
@@ -1,16 +1,39 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 
 import { SystemService } from './system.service';
 
 describe('SystemService', () => {
   let service: SystemService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
     service = TestBed.inject(SystemService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('sendAlertTest sends one-shot OTP using the backend accepted X-TOTP header', () => {
+    service.sendAlertTest('', '123456').subscribe();
+
+    const req = httpMock.expectOne('/api/v2/alert/test');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('X-TOTP')).toBe('123456');
+    expect(req.request.headers.has('X-OTP-Code')).toBeFalse();
+    req.flush('ok');
   });
 });

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -364,7 +364,7 @@ export class SystemService {
   }
 
   public sendAlertTest(uri: string = '', totp?: string): Observable<any> {
-    const headers = totp ? new HttpHeaders({ 'X-OTP-Code': totp }) : undefined;
+    const headers = totp ? new HttpHeaders({ 'X-TOTP': totp }) : undefined;
     return this.httpClient.post(`${uri}/api/v2/alert/test`, {}, {
       responseType: 'text',
       headers,


### PR DESCRIPTION
## Summary
- Send alert test one-shot OTPs with the backend-supported `X-TOTP` header instead of `X-OTP-Code`.
- Add a focused SystemService spec to lock the outgoing header contract.

## Why
The backend OTP validator accepts `X-TOTP` and `X-OTP-Session`. The alert test UI used `X-OTP-Code`, so one-shot OTP alert tests failed with authentication enabled unless a session token was available.

## Test plan
- `git diff --check`
- Docker isolated focused Angular test: copied repo into container, narrowed spec tsconfig inside the container copy only, then ran `CHROME_BIN=/usr/bin/chromium ./node_modules/.bin/ng test --watch=false --browsers=ChromeHeadlessNoSandbox --karma-config=karma.docker.conf.js --include='src/app/services/system.service.spec.ts'` -> `TOTAL: 2 SUCCESS`
- Docker isolated production UI build: `npm run build` -> success

Note: the repository's unmodified full Angular test compilation currently has unrelated legacy spec errors in `date-ago.pipe.spec.ts` and `web-socket.service.spec.ts`; the Docker focused test isolates this changed service spec without modifying those files.
