### PR TITLE
Protect sensitive system actions with OTP

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/home.component.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.component.ts
@@ -13,9 +13,13 @@ import {
 import { map,
   Observable,
   Subscription,
-  firstValueFrom } from 'rxjs';
+  firstValueFrom,
+  switchMap,
+  catchError,
+  of } from 'rxjs';
 import { HashSuffixPipe } from '../../pipes/hash-suffix.pipe';
 import { SystemService } from '../../services/system.service';
+import { OtpAuthService, EnsureOtpResult } from '../../services/otp-auth.service';
 import { IDashboardV2, IDashboardV2BlockHeader, IDashboardV2Pool } from '../../models/IDashboardV2';
 import { Chart } from 'chart.js';  // Import Chart.js
 import { registerHomeChartPlugins } from './plugins';
@@ -622,7 +626,8 @@ export class HomeComponent implements AfterViewChecked, OnInit, OnDestroy {
     private cdr: ChangeDetectorRef,
     private ngZone: NgZone,
     private dialogService: NbDialogService,
-    private toastrService: NbToastrService
+    private toastrService: NbToastrService,
+    private otpAuth: OtpAuthService
   ) {
     // Local persistence wrapper for chart state/settings
     this.chartStorage = new HomeChartStorage({
@@ -1979,16 +1984,29 @@ private setAxisPadding(cfg: any, persist: boolean = false): void {
 
   public confirmResetStats(ref: any): void {
     ref.close();
-    this.systemService.resetStats().subscribe({
-      next: () => this.toastrService.success(
-        this.translateService.instant('HOME.RESET_STATS_SUCCESS'),
-        this.translateService.instant('COMMON.SUCCESS')
-      ),
-      error: () => this.toastrService.danger(
-        this.translateService.instant('HOME.RESET_STATS_FAILED'),
-        this.translateService.instant('COMMON.ERROR')
+    this.otpAuth.ensureOtp$(
+      '',
+      this.translateService.instant('SECURITY.OTP_TITLE'),
+      this.translateService.instant('SECURITY.OTP_HINT')
+    )
+      .pipe(
+        switchMap(({ totp }: EnsureOtpResult) => this.systemService.resetStats('', totp)),
+        catchError(() => {
+          this.toastrService.danger(
+            this.translateService.instant('HOME.RESET_STATS_FAILED'),
+            this.translateService.instant('COMMON.ERROR')
+          );
+          return of(null);
+        })
       )
-    });
+      .subscribe((res) => {
+        if (res !== null) {
+          this.toastrService.success(
+            this.translateService.instant('HOME.RESET_STATS_SUCCESS'),
+            this.translateService.instant('COMMON.SUCCESS')
+          );
+        }
+      });
   }
 
 private importHistoricalDataChunked(history: any): void {

--- a/main/http_server/axe-os/src/app/services/system.service.spec.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.spec.ts
@@ -1,16 +1,38 @@
 import { TestBed } from '@angular/core/testing';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { provideHttpClient } from '@angular/common/http';
 
 import { SystemService } from './system.service';
 
 describe('SystemService', () => {
   let service: SystemService;
+  let httpMock: HttpTestingController;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    });
     service = TestBed.inject(SystemService);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  it('sends X-TOTP when resetting stats with a one-shot code', () => {
+    service.resetStats('', '123456').subscribe();
+
+    const req = httpMock.expectOne('/api/system/reset-stats');
+    expect(req.request.method).toBe('POST');
+    expect(req.request.headers.get('X-TOTP')).toBe('123456');
+    req.flush('', { status: 204, statusText: 'No Content' });
   });
 });

--- a/main/http_server/axe-os/src/app/services/system.service.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.ts
@@ -262,8 +262,11 @@ export class SystemService {
     });
   }
 
-  public resetStats(uri: string = '') {
-    return this.httpClient.post(`${uri}/api/system/reset-stats`, null, { responseType: 'text' });
+  public resetStats(uri: string = '', totp?: string) {
+    let headers = new HttpHeaders();
+    if (totp) headers = headers.set('X-TOTP', totp);
+
+    return this.httpClient.post(`${uri}/api/system/reset-stats`, null, { headers, responseType: 'text' });
   }
 
   public shutdown(uri: string = '', totp?: string) {

--- a/main/http_server/handler_alert.cpp
+++ b/main/http_server/handler_alert.cpp
@@ -113,6 +113,10 @@ esp_err_t POST_test_alert(httpd_req_t *req)
     // close connection when out of scope
     ConGuard g(http_server, req);
 
+    if (is_network_allowed(req) != ESP_OK) {
+        return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
+    }
+
     if (set_cors_headers(req) != ESP_OK) {
         httpd_resp_send_500(req);
         return ESP_FAIL;

--- a/main/http_server/handler_restart.cpp
+++ b/main/http_server/handler_restart.cpp
@@ -17,12 +17,11 @@ esp_err_t POST_restart(httpd_req_t *req)
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
-/*
     // disable OTP when in recovery mode
     if (!enter_recovery && validateOTP(req) != ESP_OK) {
         return ESP_FAIL;
     }
-*/
+
     ESP_LOGI(TAG, "Restarting System because of API Request");
 
     // Send HTTP response before restarting

--- a/main/http_server/handler_shutdown.cpp
+++ b/main/http_server/handler_shutdown.cpp
@@ -18,11 +18,10 @@ esp_err_t POST_shutdown(httpd_req_t *req)
     if (is_network_allowed(req) != ESP_OK) {
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
-/*
     if (validateOTP(req) != ESP_OK) {
         return ESP_FAIL;
     }
-*/
+
     ESP_LOGI(TAG, "Shutting down System because of API Request");
 
     // Send HTTP response before shutting down

--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -485,6 +485,10 @@ esp_err_t POST_reset_stats(httpd_req_t *req)
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Unauthorized");
     }
 
+    if (validateOTP(req) != ESP_OK) {
+        return ESP_FAIL;
+    }
+
     STRATUM_MANAGER->resetSessionStats();
 
     ESP_LOGI(TAG, "Session stats reset by user");

--- a/test/static_http_security_test.py
+++ b/test/static_http_security_test.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def strip_comments(source: str) -> str:
+    source = re.sub(r"/\*.*?\*/", "", source, flags=re.S)
+    source = re.sub(r"//.*", "", source)
+    return source
+
+
+def function_body(path: str, name: str) -> str:
+    text = (ROOT / path).read_text()
+    match = re.search(rf"esp_err_t\s+{re.escape(name)}\s*\([^)]*\)\s*{{", text)
+    assert match, f"{name} not found in {path}"
+
+    start = text.find("{", match.start())
+    depth = 0
+    for idx in range(start, len(text)):
+        if text[idx] == "{":
+            depth += 1
+        elif text[idx] == "}":
+            depth -= 1
+            if depth == 0:
+                return strip_comments(text[start : idx + 1])
+    raise AssertionError(f"{name} body not closed in {path}")
+
+
+def assert_has_call(path: str, function: str, call: str) -> None:
+    body = function_body(path, function)
+    assert call in body, f"{function} in {path} must call {call}"
+
+
+def test_system_power_actions_require_otp_in_backend() -> None:
+    assert_has_call("main/http_server/handler_restart.cpp", "POST_restart", "validateOTP(req")
+    assert_has_call("main/http_server/handler_shutdown.cpp", "POST_shutdown", "validateOTP(req")
+
+
+def test_alert_test_uses_same_network_allow_list_as_alert_update() -> None:
+    assert_has_call("main/http_server/handler_alert.cpp", "POST_test_alert", "is_network_allowed(req)")
+
+
+def test_reset_stats_requires_otp_because_it_mutates_runtime_state() -> None:
+    assert_has_call("main/http_server/handler_system.cpp", "POST_reset_stats", "validateOTP(req")


### PR DESCRIPTION
## Summary
- restore backend OTP enforcement for restart and shutdown endpoints
- require the network allow-list before triggering alert test emails
- require OTP for reset-stats and pass one-shot TOTP from the home UI
- add static HTTP security regression checks plus a SystemService header test

## Why
Several mutating endpoints were reachable after only the network allow-list check. Restart/shutdown had the OTP checks commented out, alert-test skipped the allow-list, and reset-stats mutated runtime state without OTP. This makes the backend policy inconsistent with other sensitive actions.

## Verification
- docker run --rm -v "/tmp/ESP-Miner-NerdQAxePlus-auth-hardening":/repo:ro -w /repo python:3.12-alpine sh -lc 'python -m pip install --quiet pytest && pytest -q test/static_http_security_test.py' => 3 passed
- docker run --rm -v axe-os:/src:ro node:22-bookworm-slim ... tsc -p tsconfig.spec.targeted.json --noEmit => pass for system.service.spec.ts
- docker run --rm -v axe-os:/src:ro node:22-bookworm-slim ... npm run build -- --progress=false => pass
- docker run --rm -v repo:/src:ro esp-idf-builder ... BOARD=NERDQAXEPLUS2 idf.py build => pass, generated esp-miner.bin

Note: the full existing tsconfig.spec build still reports unrelated pre-existing failures in date-ago.pipe.spec.ts and web-socket.service.spec.ts.