### PR TITLE
Scope OTP session headers to same origin

### DIFF
--- a/main/http_server/axe-os/src/app/services/otp-session.interceptor.spec.ts
+++ b/main/http_server/axe-os/src/app/services/otp-session.interceptor.spec.ts
@@ -1,0 +1,53 @@
+import { TestBed } from '@angular/core/testing';
+import { HTTP_INTERCEPTORS, HttpClient, provideHttpClient, withInterceptorsFromDi } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+
+import { OtpAuthService } from './otp-auth.service';
+import { OtpSessionInterceptor } from './otp-session.interceptor';
+
+describe('OtpSessionInterceptor', () => {
+  let http: HttpClient;
+  let httpMock: HttpTestingController;
+  const otpAuth = jasmine.createSpyObj<OtpAuthService>('OtpAuthService', [
+    'getToken',
+    'getExp',
+    'clearSession',
+  ]);
+
+  beforeEach(() => {
+    otpAuth.getToken.and.returnValue('session-token');
+    otpAuth.getExp.and.returnValue(String(Date.now() + 60_000));
+
+    TestBed.configureTestingModule({
+      providers: [
+        provideHttpClient(withInterceptorsFromDi()),
+        provideHttpClientTesting(),
+        { provide: OtpAuthService, useValue: otpAuth },
+        { provide: HTTP_INTERCEPTORS, useClass: OtpSessionInterceptor, multi: true },
+      ],
+    });
+
+    http = TestBed.inject(HttpClient);
+    httpMock = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    httpMock.verify();
+  });
+
+  it('attaches the OTP session header to relative API requests', () => {
+    http.get('/api/system/info').subscribe();
+
+    const req = httpMock.expectOne('/api/system/info');
+    expect(req.request.headers.get('X-OTP-Session')).toBe('session-token');
+    req.flush({});
+  });
+
+  it('does not leak the OTP session header to external origins', () => {
+    http.get('https://api.github.com/repos/shufps/ESP-Miner-NerdQAxePlus/releases/latest').subscribe();
+
+    const req = httpMock.expectOne('https://api.github.com/repos/shufps/ESP-Miner-NerdQAxePlus/releases/latest');
+    expect(req.request.headers.has('X-OTP-Session')).toBeFalse();
+    req.flush({});
+  });
+});

--- a/main/http_server/axe-os/src/app/services/otp-session.interceptor.ts
+++ b/main/http_server/axe-os/src/app/services/otp-session.interceptor.ts
@@ -12,6 +12,15 @@ import { OtpAuthService } from '../services/otp-auth.service';
 export class OtpSessionInterceptor implements HttpInterceptor {
   constructor(private otpAuth: OtpAuthService) { }
 
+  private shouldAttachOtpSession(url: string): boolean {
+    try {
+      const requestUrl = new URL(url, window.location.origin);
+      return requestUrl.origin === window.location.origin;
+    } catch {
+      return false;
+    }
+  }
+
   intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
     let authReq = req;
 
@@ -21,8 +30,8 @@ export class OtpSessionInterceptor implements HttpInterceptor {
       const expRaw = this.otpAuth.getExp();
       const exp = Number.parseInt(expRaw, 10) || 0;
 
-      // Only attach header if token exists and is not expired
-      if (token && Date.now() < exp) {
+      // Only attach header if token exists, is not expired, and the request targets this UI origin.
+      if (token && Date.now() < exp && this.shouldAttachOtpSession(req.url)) {
         authReq = req.clone({ setHeaders: { 'X-OTP-Session': token } });
       }
     } catch {

--- a/main/http_server/http_cors.cpp
+++ b/main/http_server/http_cors.cpp
@@ -166,7 +166,7 @@ esp_err_t set_cors_headers(httpd_req_t *req)
 {
     return (httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*") == ESP_OK &&
             httpd_resp_set_hdr(req, "Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS") == ESP_OK &&
-            httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type") == ESP_OK)
+            httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type, Authorization, X-TOTP, X-OTP-Session") == ESP_OK)
                ? ESP_OK
                : ESP_FAIL;
 }

--- a/test/static_cors_otp_test.py
+++ b/test/static_cors_otp_test.py
@@ -1,0 +1,36 @@
+from pathlib import Path
+import re
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_cors_allows_frontend_auth_headers() -> None:
+    cors = (ROOT / "main/http_server/http_cors.cpp").read_text()
+    match = re.search(
+        r'Access-Control-Allow-Headers"\s*,\s*"([^"]+)"',
+        cors,
+    )
+    assert match, "Access-Control-Allow-Headers not found"
+    allowed = {part.strip().lower() for part in match.group(1).split(',')}
+
+    assert "content-type" in allowed
+    assert "authorization" in allowed
+    assert "x-totp" in allowed
+    assert "x-otp-session" in allowed
+
+
+def test_otp_session_interceptor_only_attaches_to_same_origin_requests() -> None:
+    interceptor = (
+        ROOT
+        / "main/http_server/axe-os/src/app/services/otp-session.interceptor.ts"
+    ).read_text()
+
+    assert "shouldAttachOtpSession" in interceptor
+    assert "window.location.origin" in interceptor
+    assert "new URL" in interceptor
+    assert "X-OTP-Session" in interceptor
+
+    # The header clone must be guarded by the same-origin predicate, not just by token expiry.
+    predicate_pos = interceptor.find("shouldAttachOtpSession")
+    header_pos = interceptor.find("X-OTP-Session")
+    assert predicate_pos != -1 and header_pos != -1 and predicate_pos < header_pos


### PR DESCRIPTION
## Summary
- allow frontend auth headers in CORS preflight responses: Authorization, X-TOTP, and X-OTP-Session
- stop the OTP session interceptor from attaching X-OTP-Session to external origins
- add regression tests for CORS headers and interceptor header scoping

## Why
The frontend can send X-TOTP/X-OTP-Session/Authorization, but the server only allowed Content-Type in CORS preflight responses. At the same time, the OTP session interceptor attached X-OTP-Session to every request, including third-party URLs such as GitHub release checks. That can leak local OTP session tokens and force unnecessary preflights.

## Verification
- docker run --rm -v "/tmp/ESP-Miner-NerdQAxePlus-cors-hardening":/repo:ro -w /repo python:3.12-alpine sh -lc 'python -m pip install --quiet pytest && pytest -q test/static_cors_otp_test.py' => 2 passed
- docker run --rm -v axe-os:/src:ro node:22-bookworm-slim ... tsc -p tsconfig.spec.targeted.json --noEmit => pass for otp-session.interceptor.spec.ts
- docker run --rm -v axe-os:/src:ro node:22-bookworm-slim ... npm run build -- --progress=false => pass
- docker run --rm -v repo:/src:ro esp-idf-builder ... BOARD=NERDQAXEPLUS2 idf.py build => pass, generated esp-miner.bin