### PR TITLE
fix: honor OTP session TTL header

### DIFF
--- a/main/http_server/handler_otp.cpp
+++ b/main/http_server/handler_otp.cpp
@@ -3,6 +3,8 @@
 #include "esp_ota_ops.h"
 #include "esp_timer.h"
 
+#include <cstdlib>
+
 #include "ArduinoJson.h"
 
 #include "global_state.h"
@@ -158,6 +160,10 @@ static uint32_t clamp_ttl_ms(uint64_t v, uint32_t min_ms, uint32_t max_ms) {
     return (uint32_t)v;
 }
 
+static constexpr uint32_t OTP_SESSION_MIN_TTL_MS = 60 * 1000;
+static constexpr uint32_t OTP_SESSION_DEFAULT_TTL_MS = 24 * 60 * 60 * 1000;
+static constexpr uint32_t OTP_SESSION_MAX_TTL_MS = 24 * 60 * 60 * 1000;
+
 esp_err_t POST_create_otp_session(httpd_req_t *req)
 {
     // close connection when out of scope
@@ -188,19 +194,33 @@ esp_err_t POST_create_otp_session(httpd_req_t *req)
         return httpd_resp_send_err(req, HTTPD_401_UNAUTHORIZED, "Invalid TOTP");
     }
 
-    // create session token - default 24h
-    uint32_t ttlSeconds = 24 * 3600;
+    // create session token - default 24h, optionally shortened by the client
+    uint32_t ttlMs = OTP_SESSION_DEFAULT_TTL_MS;
+    char ttlHeader[16] = {0};
+    if (read_header_str(req, "X-OTP-Session-TTL", ttlHeader, sizeof(ttlHeader))) {
+        char *end = nullptr;
+        uint64_t requestedTtlMs = strtoull(ttlHeader, &end, 10);
+        if (end != ttlHeader && *end == '\0') {
+            ttlMs = clamp_ttl_ms(requestedTtlMs, OTP_SESSION_MIN_TTL_MS, OTP_SESSION_MAX_TTL_MS);
+        } else {
+            ESP_LOGW(TAG, "invalid X-OTP-Session-TTL header: %s", ttlHeader);
+        }
+    }
+
+    uint32_t ttlSeconds = ttlMs / 1000;
+    ttlMs = ttlSeconds * 1000;
+
     std::string token = otp.mintSessionToken(ttlSeconds);
     if (token.empty()) {
         ESP_LOGE("http_otp", "createSessionToken failed");
         return httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Session error");
     }
-    uint64_t expires_ms = now_ms() + (uint64_t) ttlSeconds * 1000ull;
+    uint64_t expires_ms = now_ms() + (uint64_t) ttlMs;
 
     PSRAMAllocator allocator;
     JsonDocument doc(&allocator);
     doc["token"]     = token;
-    doc["ttlMs"]     = ttlSeconds * 1000;
+    doc["ttlMs"]     = ttlMs;
     doc["expiresAt"] = (double)expires_ms;
 
     std::string out;

--- a/main/http_server/http_cors.cpp
+++ b/main/http_server/http_cors.cpp
@@ -166,7 +166,7 @@ esp_err_t set_cors_headers(httpd_req_t *req)
 {
     return (httpd_resp_set_hdr(req, "Access-Control-Allow-Origin", "*") == ESP_OK &&
             httpd_resp_set_hdr(req, "Access-Control-Allow-Methods", "GET, POST, PUT, PATCH, DELETE, OPTIONS") == ESP_OK &&
-            httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type") == ESP_OK)
+            httpd_resp_set_hdr(req, "Access-Control-Allow-Headers", "Content-Type, Authorization, X-TOTP, X-OTP-Session, X-OTP-Session-TTL") == ESP_OK)
                ? ESP_OK
                : ESP_FAIL;
 }

--- a/test/static_otp_session_ttl_test.py
+++ b/test/static_otp_session_ttl_test.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import re
+import unittest
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO / relative_path).read_text()
+
+
+def _function_body(source: str, function_name: str) -> str:
+    start = source.index(f"esp_err_t {function_name}")
+    brace_start = source.index("{", start)
+    depth = 0
+    for index in range(brace_start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_start:index + 1]
+    raise AssertionError(f"Could not find body for {function_name}")
+
+
+class OtpSessionTtlContractTest(unittest.TestCase):
+    def test_backend_honors_requested_otp_session_ttl_header(self):
+        source = _read("main/http_server/handler_otp.cpp")
+        body = _function_body(source, "POST_create_otp_session")
+
+        self.assertIn("X-OTP-Session-TTL", body)
+        self.assertIn("clamp_ttl_ms", body)
+        self.assertRegex(body, r"ttlSeconds\s*=\s*ttlMs\s*/\s*1000")
+        self.assertIn("otp.mintSessionToken(ttlSeconds)", body)
+        self.assertRegex(body, r'doc\["ttlMs"\]\s*=\s*ttlMs\s*;')
+
+    def test_cors_preflight_allows_otp_session_ttl_header(self):
+        source = _read("main/http_server/http_cors.cpp")
+        self.assertIn("X-OTP-Session-TTL", source)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Honor the frontend-provided `X-OTP-Session-TTL` header when minting OTP session tokens.
- Clamp requested TTLs to a safe 1 minute..24 hour range and return the effective `ttlMs`/`expiresAt`.
- Allow `X-OTP-Session-TTL` in CORS preflight headers.
- Add a static regression test for the backend/CORS contract.

## Why
The Angular client already sends `X-OTP-Session-TTL`, but the backend always minted 24-hour OTP session tokens. Browser clients also could not preflight the TTL header because CORS only allowed `Content-Type` on `develop`.

## Test plan
- `python3 test/static_otp_session_ttl_test.py` -> OK
- `git diff --check` -> OK
- Docker ESP-IDF build: `BOARD=NERDQAXEPLUS2 idf.py set-target esp32s3 && idf.py build` -> OK, generated `build/esp-miner.bin`
