### PR TITLE
fix: handle OTA errors without aborting

### DIFF
--- a/main/http_server/handler_ota.cpp
+++ b/main/http_server/handler_ota.cpp
@@ -46,12 +46,21 @@ esp_err_t POST_WWW_update(httpd_req_t *req)
         // lock the power management module
         LockGuard g(POWER_MANAGEMENT_MODULE);
         ESP_LOGI(TAG, "erasing www partition ...");
-        ESP_ERROR_CHECK(esp_partition_erase_range(www_partition, 0, www_partition->size));
+        esp_err_t erase_err = esp_partition_erase_range(www_partition, 0, www_partition->size);
+        if (erase_err != ESP_OK) {
+            ESP_LOGE(TAG, "www partition erase failed: %s", esp_err_to_name(erase_err));
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Erase Error");
+            return ESP_FAIL;
+        }
         ESP_LOGI(TAG, "erasing done");
     }
 
     // don't put it on the stack
     char *buf = (char*) malloc(2048);
+    if (!buf) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Out of memory");
+        return ESP_FAIL;
+    }
     uint32_t offset = 0;
 
     while (remaining > 0) {
@@ -121,10 +130,25 @@ esp_err_t POST_OTA_update(httpd_req_t *req)
     POWER_MANAGEMENT_MODULE.shutdown();
 
     const esp_partition_t *ota_partition = esp_ota_get_next_update_partition(NULL);
-    ESP_ERROR_CHECK(esp_ota_begin(ota_partition, OTA_SIZE_UNKNOWN, &ota_handle));
+    if (ota_partition == NULL) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "OTA partition not found");
+        return ESP_FAIL;
+    }
+
+    esp_err_t ota_err = esp_ota_begin(ota_partition, OTA_SIZE_UNKNOWN, &ota_handle);
+    if (ota_err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_ota_begin failed: %s", esp_err_to_name(ota_err));
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "OTA Begin Error");
+        return ESP_FAIL;
+    }
 
     // don't put it on the stack
     char *buf = (char*) malloc(2048);
+    if (!buf) {
+        esp_ota_abort(ota_handle);
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Out of memory");
+        return ESP_FAIL;
+    }
     uint32_t offset = 0;
 
     while (remaining > 0) {
@@ -136,6 +160,7 @@ esp_err_t POST_OTA_update(httpd_req_t *req)
 
             // Serious Error: Abort OTA
         } else if (recv_len <= 0) {
+            esp_ota_abort(ota_handle);
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Protocol Error");
             free(buf);
             return ESP_FAIL;
@@ -163,8 +188,17 @@ esp_err_t POST_OTA_update(httpd_req_t *req)
     free(buf);
 
     // Validate and switch to new OTA image and reboot
-    if (esp_ota_end(ota_handle) != ESP_OK || esp_ota_set_boot_partition(ota_partition) != ESP_OK) {
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Validation / Activation Error");
+    ota_err = esp_ota_end(ota_handle);
+    if (ota_err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_ota_end failed: %s", esp_err_to_name(ota_err));
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Validation Error");
+        return ESP_FAIL;
+    }
+
+    ota_err = esp_ota_set_boot_partition(ota_partition);
+    if (ota_err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_ota_set_boot_partition failed: %s", esp_err_to_name(ota_err));
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Activation Error");
         return ESP_FAIL;
     }
 

--- a/main/http_server/handler_ota_factory.cpp
+++ b/main/http_server/handler_ota_factory.cpp
@@ -186,7 +186,11 @@ esp_err_t FactoryOTAUpdate::do_www_update(uint8_t *data)
 
     // Erase the entire www partition before writing
     ESP_LOGI(TAG, "erasing www partition ...");
-    ESP_ERROR_CHECK(esp_partition_erase_range(www_partition, 0, www_partition->size));
+    esp_err_t err = esp_partition_erase_range(www_partition, 0, www_partition->size);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "www partition erase failed: %s", esp_err_to_name(err));
+        return err;
+    }
     ESP_LOGI(TAG, "erasing done");
 
     for (uint32_t offset = 0; offset < to_write; offset += CHUNK_SIZE) {
@@ -219,10 +223,19 @@ esp_err_t FactoryOTAUpdate::do_firmware_update(esp_http_client_handle_t client)
 
     esp_ota_handle_t ota_handle;
     const esp_partition_t *ota_partition = esp_ota_get_next_update_partition(NULL);
-    ESP_ERROR_CHECK(esp_ota_begin(ota_partition, OTA_SIZE_UNKNOWN, &ota_handle));
+    if (ota_partition == NULL) {
+        ESP_LOGE(TAG, "OTA partition not found");
+        return ESP_ERR_NOT_FOUND;
+    }
+
+    esp_err_t err = esp_ota_begin(ota_partition, OTA_SIZE_UNKNOWN, &ota_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_ota_begin failed: %s", esp_err_to_name(err));
+        return err;
+    }
 
     for (uint32_t offset = 0; offset < FW_LEN_BYTES; offset += CHUNK_SIZE) {
-        esp_err_t err = http_read_chunk(client, buf);
+        err = http_read_chunk(client, buf);
         if (err != ESP_OK) {
             // ensure abort on any read error
             esp_ota_abort(ota_handle);
@@ -234,16 +247,26 @@ esp_err_t FactoryOTAUpdate::do_firmware_update(esp_http_client_handle_t client)
             ESP_LOGI(TAG, "flashing to %08lx", offset);
         }
 
-        if (esp_ota_write(ota_handle, (const void *) buf, CHUNK_SIZE) != ESP_OK) {
+        err = esp_ota_write(ota_handle, (const void *) buf, CHUNK_SIZE);
+        if (err != ESP_OK) {
+            ESP_LOGE(TAG, "esp_ota_write failed: %s", esp_err_to_name(err));
             esp_ota_abort(ota_handle);
-            return ESP_FAIL;
+            return err;
         }
         addFwBytes(CHUNK_SIZE);
     }
 
     // Validate and switch to new OTA image and reboot later
-    if (esp_ota_end(ota_handle) != ESP_OK || esp_ota_set_boot_partition(ota_partition) != ESP_OK) {
-        return ESP_FAIL;
+    err = esp_ota_end(ota_handle);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_ota_end failed: %s", esp_err_to_name(err));
+        return err;
+    }
+
+    err = esp_ota_set_boot_partition(ota_partition);
+    if (err != ESP_OK) {
+        ESP_LOGE(TAG, "esp_ota_set_boot_partition failed: %s", esp_err_to_name(err));
+        return err;
     }
 
     return ESP_OK;

--- a/test/static_ota_error_handling_test.py
+++ b/test/static_ota_error_handling_test.py
@@ -1,0 +1,60 @@
+from pathlib import Path
+import re
+import unittest
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO / relative_path).read_text()
+
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    brace_start = source.index("{", start)
+    depth = 0
+    for index in range(brace_start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_start:index + 1]
+    raise AssertionError(f"Could not find body for {signature}")
+
+
+class OtaErrorHandlingContractTest(unittest.TestCase):
+    def test_direct_ota_handlers_return_errors_instead_of_aborting(self):
+        source = _read("main/http_server/handler_ota.cpp")
+        self.assertIsNone(re.search(r"\bESP_ERROR_CHECK\s*\(", source))
+
+        www_body = _function_body(source, "esp_err_t POST_WWW_update")
+        self.assertIn("esp_partition_erase_range", www_body)
+        self.assertRegex(www_body, r"esp_err_t\s+erase_err\s*=\s*esp_partition_erase_range")
+        self.assertIn("if (!buf)", www_body)
+
+        fw_body = _function_body(source, "esp_err_t POST_OTA_update")
+        self.assertIn("if (ota_partition == NULL)", fw_body)
+        self.assertRegex(fw_body, r"esp_err_t\s+ota_err\s*=\s*esp_ota_begin")
+        self.assertIn("if (!buf)", fw_body)
+        self.assertRegex(fw_body, r"recv_len <= 0\) \{\n\s*esp_ota_abort\(ota_handle\);")
+        self.assertRegex(fw_body, r"ota_err\s*=\s*esp_ota_end")
+        self.assertRegex(fw_body, r"ota_err\s*=\s*esp_ota_set_boot_partition")
+
+    def test_factory_ota_returns_esp_errors_instead_of_aborting(self):
+        source = _read("main/http_server/handler_ota_factory.cpp")
+        self.assertIsNone(re.search(r"\bESP_ERROR_CHECK\s*\(", source))
+
+        www_body = _function_body(source, "esp_err_t FactoryOTAUpdate::do_www_update")
+        self.assertRegex(www_body, r"esp_err_t\s+err\s*=\s*esp_partition_erase_range")
+
+        fw_body = _function_body(source, "esp_err_t FactoryOTAUpdate::do_firmware_update")
+        self.assertIn("if (ota_partition == NULL)", fw_body)
+        self.assertRegex(fw_body, r"esp_err_t\s+err\s*=\s*esp_ota_begin")
+        self.assertRegex(fw_body, r"err\s*=\s*esp_ota_end")
+        self.assertRegex(fw_body, r"err\s*=\s*esp_ota_set_boot_partition")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Replace OTA `ESP_ERROR_CHECK(...)` calls with explicit error handling/logging.
- Return HTTP/ESP errors instead of aborting the device on erase/begin/end/activation failures.
- Check OTA upload buffers for allocation failure.
- Abort OTA handles on direct-upload protocol/OOM/write failures.
- Propagate factory OTA ESP-IDF errors instead of collapsing everything to `ESP_FAIL`.
- Add a static regression test for the OTA error-handling contract.

## Why
OTA handlers run in request/update paths where recoverable ESP-IDF failures should be reported to the caller/status path, not converted into device aborts. This also avoids null-buffer use if heap allocation fails during OTA.

## Test plan
- `python3 test/static_ota_error_handling_test.py` -> OK
- `git diff --check` -> OK
- Docker ESP-IDF build: `BOARD=NERDQAXEPLUS2 idf.py set-target esp32s3 && idf.py build` -> OK, generated `build/esp-miner.bin`
