### PR TITLE
fix: read full CAN PATCH JSON body

### DIFF
--- a/main/http_server/handler_can_swarm.cpp
+++ b/main/http_server/handler_can_swarm.cpp
@@ -211,16 +211,12 @@ esp_err_t PATCH_can_slave(httpd_req_t *req)
     }
     uint8_t slave_id = (uint8_t) id;
 
-    char body[256];
-    int received = httpd_req_recv(req, body, sizeof(body) - 1);
-    if (received <= 0) {
-        return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "no body");
-    }
-    body[received] = '\0';
+    PSRAMAllocator allocator;
+    JsonDocument doc(&allocator);
 
-    JsonDocument doc;
-    if (deserializeJson(doc, body) != DeserializationError::Ok) {
-        return httpd_resp_send_err(req, HTTPD_400_BAD_REQUEST, "invalid json");
+    esp_err_t err = getJsonData(req, doc);
+    if (err != ESP_OK) {
+        return err;
     }
 
     // field names matching info endpoint PATCH

--- a/test/static_can_patch_body_test.py
+++ b/test/static_can_patch_body_test.py
@@ -1,0 +1,40 @@
+from pathlib import Path
+import unittest
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO / relative_path).read_text()
+
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    brace_start = source.index("{", start)
+    depth = 0
+    for index in range(brace_start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_start:index + 1]
+    raise AssertionError(f"Could not find body for {signature}")
+
+
+class CanPatchBodyContractTest(unittest.TestCase):
+    def test_patch_can_slave_uses_shared_json_body_reader(self):
+        source = _read("main/http_server/handler_can_swarm.cpp")
+        body = _function_body(source, "esp_err_t PATCH_can_slave")
+
+        self.assertIn("getJsonData(req, doc)", body)
+        self.assertIn("esp_err_t err = getJsonData(req, doc);", body)
+        self.assertIn("if (err != ESP_OK)", body)
+        self.assertNotIn("char body[256]", body)
+        self.assertNotIn("httpd_req_recv", body)
+        self.assertNotIn("deserializeJson(doc, body)", body)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Use the shared `getJsonData(req, doc)` helper in `PATCH_can_slave`.
- Remove the single `httpd_req_recv` call and fixed 256-byte body buffer.
- Add a static regression test to keep the CAN PATCH handler on the shared body-reader path.

## Why
`httpd_req_recv` is not guaranteed to return the full request body in one call. The previous fixed 256-byte buffer could reject/truncate larger JSON payloads, especially with full fan/display settings. Other JSON handlers already use `getJsonData`, which handles request-body reading centrally.

## Test plan
- `python3 test/static_can_patch_body_test.py` -> OK
- `git diff --check` -> OK
- Docker ESP-IDF build: `BOARD=NERDQAXEPLUS2 idf.py set-target esp32s3 && idf.py build` -> OK, generated `build/esp-miner.bin`
