### PR TITLE
test: fix legacy Angular specs

### DIFF
--- a/main/http_server/axe-os/src/app/app.component.spec.ts
+++ b/main/http_server/axe-os/src/app/app.component.spec.ts
@@ -1,15 +1,33 @@
 import { TestBed } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
+import { TranslateService } from '@ngx-translate/core';
+import { Store } from '@ngrx/store';
+import { of } from 'rxjs';
+
 import { AppComponent } from './app.component';
+
+class TranslateServiceMock {
+  addLangs = jasmine.createSpy('addLangs');
+  setDefaultLang = jasmine.createSpy('setDefaultLang');
+  use = jasmine.createSpy('use');
+}
+
+class StoreMock {
+  select = jasmine.createSpy('select').and.returnValue(of('en'));
+}
 
 describe('AppComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [
-        RouterTestingModule
+        RouterTestingModule,
       ],
       declarations: [
-        AppComponent
+        AppComponent,
+      ],
+      providers: [
+        { provide: TranslateService, useClass: TranslateServiceMock },
+        { provide: Store, useClass: StoreMock },
       ],
     }).compileComponents();
   });
@@ -20,16 +38,16 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'nebular-dashboard'`, () => {
+  it(`should have as title 'axe-os'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('nebular-dashboard');
+    expect(app.title).toEqual('axe-os');
   });
 
-  it('should render title', () => {
+  it('should render the router outlet', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, nebular-dashboard');
+    expect(compiled.querySelector('router-outlet')).toBeTruthy();
   });
 });

--- a/main/http_server/axe-os/src/app/pipes/date-ago.pipe.spec.ts
+++ b/main/http_server/axe-os/src/app/pipes/date-ago.pipe.spec.ts
@@ -1,8 +1,13 @@
 import { DateAgoPipe } from './date-ago.pipe';
+import { TranslateService } from '@ngx-translate/core';
 
 describe('DateAgoPipe', () => {
+  const translateServiceMock = {
+    instant: (key: string) => key,
+  } as Partial<TranslateService> as TranslateService;
+
   it('create an instance', () => {
-    const pipe = new DateAgoPipe();
+    const pipe = new DateAgoPipe(translateServiceMock);
     expect(pipe).toBeTruthy();
   });
 });

--- a/main/http_server/axe-os/src/app/services/github-update.service.spec.ts
+++ b/main/http_server/axe-os/src/app/services/github-update.service.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { GithubUpdateService } from './github-update.service';
 
@@ -6,7 +8,9 @@ describe('GithubUpdateService', () => {
   let service: GithubUpdateService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
     service = TestBed.inject(GithubUpdateService);
   });
 

--- a/main/http_server/axe-os/src/app/services/system.service.spec.ts
+++ b/main/http_server/axe-os/src/app/services/system.service.spec.ts
@@ -1,4 +1,6 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
 
 import { SystemService } from './system.service';
 
@@ -6,7 +8,9 @@ describe('SystemService', () => {
   let service: SystemService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
     service = TestBed.inject(SystemService);
   });
 

--- a/main/http_server/axe-os/src/app/services/web-socket.service.spec.ts
+++ b/main/http_server/axe-os/src/app/services/web-socket.service.spec.ts
@@ -1,13 +1,13 @@
 import { TestBed } from '@angular/core/testing';
 
-import { WebSocketService } from './web-socket.service';
+import { WebsocketService } from './web-socket.service';
 
-describe('WebSocketService', () => {
-  let service: WebSocketService;
+describe('WebsocketService', () => {
+  let service: WebsocketService;
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
-    service = TestBed.inject(WebSocketService);
+    service = TestBed.inject(WebsocketService);
   });
 
   it('should be created', () => {


### PR DESCRIPTION
## Summary
- Update legacy Angular specs so they match the current constructors, class names, and templates.
- Provide HTTP testing providers for services that inject `HttpClient`.
- Add lightweight `TranslateService`/NgRx `Store` mocks for `AppComponent`.

## Why
The frontend spec target no longer compiled because older specs referenced stale APIs:
- `DateAgoPipe` now requires `TranslateService`.
- `web-socket.service.ts` exports `WebsocketService`, not `WebSocketService`.
- Service specs with `HttpClient` injection lacked testing providers.
- `AppComponent` spec expected the old `nebular-dashboard` title/template and missed required injected services.

## Test plan
- `./node_modules/.bin/tsc -p tsconfig.spec.json --noEmit` -> OK
- `./node_modules/.bin/ng test --watch=false --browsers=ChromeHeadless` -> OK (`TOTAL: 10 SUCCESS`)
- `npm run build` -> OK
