### PR TITLE
fix: use secure websocket protocol on https

### DIFF
--- a/main/http_server/axe-os/src/app/services/web-socket.service.spec.ts
+++ b/main/http_server/axe-os/src/app/services/web-socket.service.spec.ts
@@ -13,4 +13,14 @@ describe('WebsocketService', () => {
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  it('uses wss when the UI is served over https', () => {
+    expect((service as any).getWebSocketUrl({ protocol: 'https:', host: 'miner.example' }))
+      .toBe('wss://miner.example/api/ws');
+  });
+
+  it('keeps ws when the UI is served over http', () => {
+    expect((service as any).getWebSocketUrl({ protocol: 'http:', host: '192.168.1.42' }))
+      .toBe('ws://192.168.1.42/api/ws');
+  });
 });

--- a/main/http_server/axe-os/src/app/services/web-socket.service.ts
+++ b/main/http_server/axe-os/src/app/services/web-socket.service.ts
@@ -12,11 +12,16 @@ export class WebsocketService implements OnDestroy {
     // Create socket if not present or already closed
     if (!this.socket$ || this.socket$.closed) {
       this.socket$ = webSocket<string>({
-        url: `ws://${window.location.host}/api/ws`,
+        url: this.getWebSocketUrl(),
         deserializer: (e: MessageEvent) => e.data
       });
     }
     return this.socket$;
+  }
+
+  private getWebSocketUrl(location: Pick<Location, 'protocol' | 'host'> = window.location): string {
+    const protocol = location.protocol === 'https:' ? 'wss:' : 'ws:';
+    return `${protocol}//${location.host}/api/ws`;
   }
 
   public close(): void {


### PR DESCRIPTION
## Summary
- Build the websocket URL from the current page protocol.
- Use `wss://` when the UI is served over HTTPS, while keeping `ws://` for HTTP.
- Add regression coverage for both URL forms.

## Test plan
- `./node_modules/.bin/tsc -p tsconfig.spec.json --noEmit`
- `./node_modules/.bin/ng test --watch=false --browsers=ChromeHeadless --include='src/app/services/web-socket.service.spec.ts'`
- `./node_modules/.bin/ng test --watch=false --browsers=ChromeHeadless`
- `npm run build`
