### PR TITLE
reverted vreg shutdown temps on neraxes again

### DIFF
--- a/main/fan_controller.cpp
+++ b/main/fan_controller.cpp
@@ -39,11 +39,10 @@ void FanController::init(Board* board, int sampleTimeMs)
 
     ESP_LOGI(TAG, "initialising for %d fan channel(s)", m_numChannels);
 
-    // Load config from NVS — always for both channels (ch1 overheat monitoring
-    // even on single-fan boards)
+    // Load config from NVS (PID instances don't exist yet, applyConfig is skipped)
     loadSettings();
 
-    // Create PID instances only for actual fan channels
+    // Create PID instances using the loaded config
     for (int ch = 0; ch < m_numChannels; ch++) {
         m_pidTarget[ch] = static_cast<float>(m_config[ch].pid.targetTemp);
 
@@ -70,9 +69,7 @@ void FanController::loadSettings()
 {
     m_pidUseMax = Config::isFanPidUseMax();
 
-    // Always load config for both channels — ch1 overheat monitoring is needed
-    // even on single-fan boards to detect VReg overtemperature.
-    for (int ch = 0; ch < MAX_FANS; ch++) {
+    for (int ch = 0; ch < m_numChannels; ch++) {
         PidSettings* bp = m_board->getPidSettings(ch);
 
         m_config[ch].mode         = static_cast<Mode>(Config::getFanMode(ch));
@@ -100,17 +97,6 @@ void FanController::update(float chipTempMax, float vrTemp)
         tempInput[0] = fmaxf(chipTempMax, vrTemp);
     }
 
-    // Check overheat for both channels (ASIC + VReg), even on single-fan boards.
-    // This ensures VReg overtemperature triggers a shutdown regardless of fan count.
-    for (int ch = 0; ch < MAX_FANS; ch++) {
-        if (m_config[ch].overheatTemp && tempInput[ch] > m_config[ch].overheatTemp) {
-            m_overheated[ch] = true;
-        } else {
-            m_overheated[ch] = false;
-        }
-    }
-
-    // Drive actual fan channels
     for (int ch = 0; ch < m_numChannels; ch++) {
         // Read current RPM
         m_board->getFanSpeedCh(ch, &m_fanRPM[ch]);
@@ -121,12 +107,14 @@ void FanController::update(float chipTempMax, float vrTemp)
             m_pid[ch]->Compute();
         }
 
-        // Overheat on any channel: drive this fan to 100%
-        if (m_overheated[0] || m_overheated[1]) {
-            m_fanPerc[ch] = 100;
+        // Overheat: drive fan to 100% and flag it (checked even in LINKED mode for shutdown purposes)
+        if (m_config[ch].overheatTemp && tempInput[ch] > m_config[ch].overheatTemp) {
+            m_overheated[ch] = true;
+            m_fanPerc[ch]    = 100;
             m_board->setFanSpeedCh(ch, 1.0f);
             continue;
         }
+        m_overheated[ch] = false;
 
         // LINKED: mirror channel-0 output (ch0 must be processed first)
         if (m_config[ch].mode == Mode::LINKED && ch > 0) {
@@ -134,6 +122,7 @@ void FanController::update(float chipTempMax, float vrTemp)
             m_board->setFanSpeedCh(ch, static_cast<float>(m_fanPerc[ch]) / 100.0f);
             continue;
         }
+        m_overheated[ch] = false;
 
         // Normal control
         switch (m_config[ch].mode) {
@@ -167,12 +156,12 @@ uint16_t FanController::getSpeedPerc(int ch) const
 
 bool FanController::isOverheated(int ch) const
 {
-    if (ch < 0 || ch >= MAX_FANS) return false;
+    if (ch < 0 || ch >= m_numChannels) return false;
     return m_overheated[ch];
 }
 
 uint16_t FanController::getOverheatTemp(int ch) const
 {
-    if (ch < 0 || ch >= MAX_FANS) return 0;
+    if (ch < 0 || ch >= m_numChannels) return 0;
     return m_config[ch].overheatTemp;
 }

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.html
@@ -451,8 +451,8 @@
                                     <input nbInput type="number" formControlName="pidTargetTemp" />
                                 </div>
                             </div>
-                            <div *ngIf="supportLevel >= 1" class="form-row-separator" style="font-weight:bold;">PID Parameters:</div>
-                            <div *ngIf="supportLevel >= 1">
+                            <div *ngIf="supportLevel >= 2" class="form-row-separator" style="font-weight:bold;">PID Parameters:</div>
+                            <div *ngIf="supportLevel >= 2">
                                 <div class="form-row">
                                     <label class="form-label">PID P:</label>
                                     <div class="form-control-wrapper">
@@ -471,6 +471,7 @@
                                         <input nbInput type="number" formControlName="pidD" />
                                     </div>
                                 </div>
+                                <div class="form-row-separator"></div>
                             </div>
                         </div>
 
@@ -478,13 +479,6 @@
                             <label for="overheat_temp" class="form-label">{{ 'SETTINGS.SHUTDOWN_TEMP' | translate }} ({{ 'FAN.PRIMARY_CONTROLLER' | translate }}):</label>
                             <div class="form-control-wrapper">
                                 <input nbInput id="overheat_temp" formControlName="overheat_temp" type="number" />
-                            </div>
-                        </div>
-
-                        <div class="form-row" *ngIf="fanCount === 1">
-                            <label for="fan1OverheatTemp" class="form-label">{{ 'SETTINGS.SHUTDOWN_TEMP' | translate }} ({{ 'FAN.SECONDARY_CONTROLLER' | translate }}):</label>
-                            <div class="form-control-wrapper">
-                                <input nbInput id="fan1OverheatTemp" formControlName="fan1OverheatTemp" type="number" />
                             </div>
                         </div>
 
@@ -555,8 +549,8 @@
                                     <input nbInput type="number" formControlName="fan1PidTargetTemp" />
                                 </div>
                             </div>
-                            <div *ngIf="supportLevel >= 1" class="form-row-separator" style="font-weight:bold;">PID Parameters:</div>
-                            <div *ngIf="supportLevel >= 1">
+                            <div *ngIf="supportLevel >= 2" class="form-row-separator" style="font-weight:bold;">PID Parameters:</div>
+                            <div *ngIf="supportLevel >= 2">
                                 <div class="form-row">
                                     <label class="form-label">PID P:</label>
                                     <div class="form-control-wrapper">
@@ -575,6 +569,7 @@
                                         <input nbInput type="number" formControlName="fan1PidD" />
                                     </div>
                                 </div>
+                                <div class="form-row-separator"></div>
                             </div>
                         </div>
 

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
@@ -128,7 +128,7 @@ export class EditComponent implements OnInit {
 
         this.defaultVrFrequency = info.defaultVrFrequency ?? undefined;
 
-        this.fanCount = info.fans?.filter((f: any) => f.mode !== undefined).length ?? 1;
+        this.fanCount = info.fans?.length ?? 1;
         this.fanLabels = info.fans?.map((f: ISettingsV2Fan, i: number) => f.label || `Fan ${i + 1}`) ?? ['Fan 1', 'Fan 2'];
         const fan1cfg = info.fans?.[1];
 
@@ -408,9 +408,6 @@ export class EditComponent implements OnInit {
         overheatTemp: f.fan1OverheatTemp,
         pid: { targetTemp: f.fan1PidTargetTemp, p: f.fan1PidP, i: f.fan1PidI, d: f.fan1PidD }
       });
-    } else {
-      // Single-fan boards: still send VReg overheat threshold
-      fans.push({ overheatTemp: f.fan1OverheatTemp });
     }
 
     // Build v2 payload

--- a/main/http_server/v2/handler_v2_settings.cpp
+++ b/main/http_server/v2/handler_v2_settings.cpp
@@ -138,11 +138,6 @@ esp_err_t GET_V2_settings(httpd_req_t *req)
             pid_obj["i"]          = (float) fanPid->i / 100.0f;
             pid_obj["d"]          = (float) fanPid->d / 100.0f;
         }
-        // Single-fan boards: still expose VReg overheat threshold
-        if (numFans < 2) {
-            JsonObject fan1 = fans.add<JsonObject>();
-            fan1["overheatTemp"] = Config::getFanOverheatTemp(1);
-        }
     }
     doc["invertFanPolarity"] = board->isInvertFanPolarityEnabled() ? 1 : 0;
 #if defined(NERDAXE) || defined(NERDAXEGAMMA)

--- a/main/nvs_config.cpp
+++ b/main/nvs_config.cpp
@@ -240,21 +240,20 @@ static void migrate_from_legacy(nvs_handle h)
         ESP_LOGW(TAG, "AFC deprecated, set manual 100%%");
     }
 
-    // Migrate VReg overheat temp: if not yet set, inherit ASIC overheat temp.
-    // Single-fan boards (NerdAxe) use a higher default because the PID no longer
-    // regulates VReg temp implicitly via max(asic, vreg).
-    if (s_doc[NVS_CONFIG_FAN1_OVERHEAT].isNull()) {
+    // Migrate VReg overheat temp.
+    // Single-fan boards: always disabled (pidUseMax handles VReg temp via PID).
+    // Dual-fan boards: inherit ASIC overheat temp if not yet set.
 #if defined(NERDAXE) || defined(NERDAXEGAMMA)
-        uint16_t vreg_default = 80;
-        ESP_LOGI(TAG, "Setting VReg overheat temp to %u°C (single-fan board)", vreg_default);
+    s_doc[NVS_CONFIG_FAN1_OVERHEAT] = 0;
 #else
+    if (s_doc[NVS_CONFIG_FAN1_OVERHEAT].isNull()) {
         uint16_t vreg_default = s_doc[NVS_CONFIG_OVERHEAT_TEMP].isNull()
                                     ? CONFIG_OVERHEAT_TEMP
                                     : s_doc[NVS_CONFIG_OVERHEAT_TEMP].as<uint16_t>();
         ESP_LOGI(TAG, "Migrating VReg overheat temp from ASIC value: %u°C", vreg_default);
-#endif
         s_doc[NVS_CONFIG_FAN1_OVERHEAT] = vreg_default;
     }
+#endif
 
     ESP_LOGI(TAG, "Migration done (%u bytes in doc)", s_doc.memoryUsage());
 }


### PR DESCRIPTION
- moved PID settings into "pro mode"
- disabled vreg shutdown temp on single-fan NerdAxes — there was none before and it never caused issues (VReg has its own internal over-temperature protection). Adding one with a default value is a breaking change that causes false shutdowns
