### PR TITLE
Add NerdQAxe++ TPS546 board support

### DIFF
--- a/main/CMakeLists.txt
+++ b/main/CMakeLists.txt
@@ -25,6 +25,7 @@ SRCS
     "boards/drivers/nerdaxe/INA260.cpp"
     "boards/drivers/nerdaxe/EMC2101.cpp"
     "boards/drivers/nerdaxe/TPS546.cpp"
+    "boards/drivers/rev7/TPS546.cpp"
     "boards/drivers/nerdaxe/adc.cpp"
     "boards/drivers/i2c_master.cpp"
     "boards/drivers/tmp451.cpp"

--- a/main/boards/drivers/BuckConverter.h
+++ b/main/boards/drivers/BuckConverter.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stdint.h>
+
+class BuckConverter {
+  public:
+    virtual ~BuckConverter() = default;
+
+    virtual bool init(int num_phases, int imax, float ifault) = 0;
+    virtual void clear_faults() = 0;
+
+    virtual float get_temperature() = 0;
+    virtual float get_pin() = 0;
+    virtual float get_pout() = 0;
+    virtual float get_vin() = 0;
+    virtual float get_iin() = 0;
+    virtual float get_iout() = 0;
+    virtual float get_vout() = 0;
+    virtual bool uses_external_vr_temperature() { return true; }
+
+    virtual bool set_vout(float volts) = 0;
+    virtual bool disable_vout() { return true; }
+
+    virtual void status() = 0;
+
+    virtual uint8_t get_status_byte() = 0;
+    virtual uint8_t get_status_iout() = 0;
+    virtual uint8_t get_status_vout() = 0;
+    virtual uint8_t get_status_input() = 0;
+    virtual uint8_t get_status_temp() = 0;
+};

--- a/main/boards/drivers/TPS53647.h
+++ b/main/boards/drivers/TPS53647.h
@@ -1,9 +1,10 @@
 #pragma once
 
+#include "BuckConverter.h"
 #include "driver/i2c.h"
 #include "esp_err.h"
 
-class TPS53647 {
+class TPS53647 : public BuckConverter {
 protected:
     uint8_t m_i2cAddr;
     float m_hwMinVoltage;
@@ -34,29 +35,29 @@ protected:
 public:
     TPS53647();
 
-    virtual bool init(int num_phases, int imax, float ifault);
+    bool init(int num_phases, int imax, float ifault) override;
 
-    void clear_faults();
+    void clear_faults() override;
 
-    float get_temperature();
-    float get_pin();
-    float get_pout();
-    float get_vin();
-    float get_iin();
-    float get_iout();
+    float get_temperature() override;
+    float get_pin() override;
+    float get_pout() override;
+    float get_vin() override;
+    float get_iin() override;
+    float get_iout() override;
 
-    float get_vout();
-    bool set_vout(float volts);
+    float get_vout() override;
+    bool set_vout(float volts) override;
     uint16_t get_vout_vid();
 
     void show_voltage_settings();
-    virtual void status();
+    void status() override;
 
-    uint8_t get_status_byte();
-    uint8_t get_status_iout();
-    uint8_t get_status_vout();
-    uint8_t get_status_input();
-    uint8_t get_status_temp();
+    uint8_t get_status_byte() override;
+    uint8_t get_status_iout() override;
+    uint8_t get_status_vout() override;
+    uint8_t get_status_input() override;
+    uint8_t get_status_temp() override;
 
 };
 

--- a/main/boards/drivers/rev7/TPS546.cpp
+++ b/main/boards/drivers/rev7/TPS546.cpp
@@ -1,0 +1,1153 @@
+#include <stdio.h>
+#include <stdint.h>
+#include <math.h>
+#include <string.h>
+#include "esp_log.h"
+#include "../nerdaxe/pmbus_commands.h"
+
+#include "i2c_master.h"
+#include "TPS546.h"
+
+namespace Rev7TPS546
+{
+
+//#define _DEBUG_LOG_ 1
+
+//#define I2C_MASTER_NUM 0 /*!< I2C master i2c port number, the number of i2c peripheral interfaces available will depend on the chip */
+
+#define WRITE_BIT      I2C_MASTER_WRITE
+#define READ_BIT       I2C_MASTER_READ
+#define ACK_CHECK      true
+#define NO_ACK_CHECK   false
+#define ACK_VALUE ((i2c_ack_type_t) 0x0)
+#define NACK_VALUE ((i2c_ack_type_t) 0x1)
+#define MAX_BLOCK_LEN  32
+
+#define SMBUS_DEFAULT_TIMEOUT pdMS_TO_TICKS(1000)
+
+static const char *TAG = "TPS546";
+
+static uint8_t DEVICE_ID1[] = {0x54, 0x49, 0x54, 0x6B, 0x24, 0x41}; // TPS546D24A
+static uint8_t DEVICE_ID2[] = {0x54, 0x49, 0x54, 0x6D, 0x24, 0x41}; // TPS546D24A
+static uint8_t DEVICE_ID3[] = {0x54, 0x49, 0x54, 0x6D, 0x24, 0x62}; // TPS546D24S
+static uint8_t MFR_ID[] = {'B', 'A', 'X'};
+static uint8_t MFR_MODEL[] = {'H', 'E', 'X'};
+static uint8_t MFR_REVISION[] = {0x00, 0x00, 0x01};
+
+static bool is_initialized = false;
+static TPS546_CONFIG tps546_config = TPS546_create_default_config();
+
+//static uint8_t COMPENSATION_CONFIG[] = {0xFF, 0xFF, 0xFF, 0xFF, 0xFF};
+
+//static i2c_master_dev_handle_t tps546_dev_handle;
+
+TPS546_CONFIG TPS546_create_default_config(void)
+{
+    TPS546_CONFIG config = {};
+    config.phase = TPS546_INIT_PHASE_SINGLE;
+    config.vin_on = TPS546_INIT_VIN_ON;
+    config.vin_off = TPS546_INIT_VIN_OFF;
+    config.vin_uv_warn_limit = TPS546_INIT_VIN_UV_WARN_LIMIT;
+    config.vin_ov_fault_limit = TPS546_INIT_VIN_OV_FAULT_LIMIT;
+    config.scale_loop = TPS546_INIT_SCALE_LOOP;
+    config.vout_min = TPS546_INIT_VOUT_MIN;
+    config.vout_max = TPS546_INIT_VOUT_MAX;
+    config.vout_command = TPS546_INIT_VOUT_COMMAND;
+    config.iout_oc_warn_limit = TPS546_INIT_IOUT_OC_WARN_LIMIT;
+    config.iout_oc_fault_limit = TPS546_INIT_IOUT_OC_FAULT_LIMIT;
+    config.stack_config = TPS546_INIT_STACK_CONFIG_SINGLE;
+    config.sync_config = TPS546_INIT_SYNC_CONFIG_SINGLE;
+    return config;
+}
+
+TPS546_CONFIG TPS546_create_dual_config(void)
+{
+    TPS546_CONFIG config = {};
+    config.phase = TPS546_INIT_PHASE_MULTI;
+    config.vin_on = 11.0f;
+    config.vin_off = 10.5f;
+    config.vin_uv_warn_limit = 11.0f;
+    config.vin_ov_fault_limit = 14.0f;
+    config.scale_loop = 0.125f;
+    config.vout_min = 1.0f;
+    config.vout_max = 3.0f;
+    config.vout_command = 1.2f;
+    config.iout_oc_warn_limit = 90.0f;
+    config.iout_oc_fault_limit = 100.0f;
+    config.stack_config = TPS546_INIT_STACK_CONFIG_DUAL;
+    config.sync_config = TPS546_INIT_SYNC_CONFIG_MULTI;
+    config.compensation_config[0] = 0x12;
+    config.compensation_config[1] = 0x34;
+    config.compensation_config[2] = 0x42;
+    config.compensation_config[3] = 0x25;
+    config.compensation_config[4] = 0x04;
+    return config;
+}
+
+/**
+ * @brief SMBus read byte
+ */
+static esp_err_t smb_read_byte(uint8_t command, uint8_t *data)
+{
+    esp_err_t err = ESP_FAIL;
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, TPS546_I2CADDR << 1 | WRITE_BIT, ACK_CHECK);
+    i2c_master_write_byte(cmd, command, ACK_CHECK);
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, TPS546_I2CADDR << 1 | READ_BIT, ACK_CHECK);
+    i2c_master_read_byte(cmd, data, NACK_VALUE);
+    i2c_master_stop(cmd);
+    err = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, SMBUS_DEFAULT_TIMEOUT);
+    i2c_cmd_link_delete(cmd);
+
+    return err;
+}
+
+/**
+ * @brief SMBus write byte
+ */
+static esp_err_t smb_write_byte(uint8_t command, uint8_t data)
+{
+    esp_err_t err = ESP_FAIL;
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, TPS546_I2CADDR << 1 | WRITE_BIT, ACK_CHECK);
+    i2c_master_write_byte(cmd, command, ACK_CHECK);
+    i2c_master_write_byte(cmd, data, ACK_CHECK);
+    i2c_master_stop(cmd);
+    err = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, SMBUS_DEFAULT_TIMEOUT);
+    i2c_cmd_link_delete(cmd);
+
+    return err;
+}
+
+static esp_err_t smb_write_command(uint8_t command)
+{
+    esp_err_t err = ESP_FAIL;
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, TPS546_I2CADDR << 1 | WRITE_BIT, ACK_CHECK);
+    i2c_master_write_byte(cmd, command, ACK_CHECK);
+    i2c_master_stop(cmd);
+    err = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, SMBUS_DEFAULT_TIMEOUT);
+    i2c_cmd_link_delete(cmd);
+
+    return err;
+}
+
+/**
+ * @brief SMBus read word
+ */
+static esp_err_t smb_read_word(uint8_t command, uint16_t *result)
+{
+    uint8_t data[2];
+    esp_err_t err = ESP_FAIL;
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, TPS546_I2CADDR << 1 | WRITE_BIT, ACK_CHECK);
+    i2c_master_write_byte(cmd, command, ACK_CHECK);
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, TPS546_I2CADDR << 1 | READ_BIT, ACK_CHECK);
+    i2c_master_read(cmd, &data[0], 1, ACK_VALUE);
+    i2c_master_read_byte(cmd, &data[1], NACK_VALUE);
+    i2c_master_stop(cmd);
+    err = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, SMBUS_DEFAULT_TIMEOUT);
+    i2c_cmd_link_delete(cmd);
+
+    *result = (data[1] << 8) + data[0];
+
+    return err;
+}
+
+/**
+ * @brief SMBus write word
+ */
+static esp_err_t smb_write_word(uint8_t command, uint16_t data)
+{
+    esp_err_t err = ESP_FAIL;
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, TPS546_I2CADDR << 1 | WRITE_BIT, ACK_CHECK);
+    i2c_master_write_byte(cmd, command, ACK_CHECK);
+    i2c_master_write_byte(cmd, (uint8_t) (data & 0x00FF), ACK_CHECK);
+    i2c_master_write_byte(cmd, (uint8_t) ((data & 0xFF00) >> 8), NACK_VALUE);
+    i2c_master_stop(cmd);
+    err = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, SMBUS_DEFAULT_TIMEOUT);
+    i2c_cmd_link_delete(cmd);
+
+    return err;
+}
+
+/**
+ * @brief SMBus read block -- SMBus is funny in that the first byte returned is the length of data??
+ * @param command The command to read
+ * @param data Pointer to store the read data
+ * @param len The number of bytes to read
+ */
+static esp_err_t smb_read_block(uint8_t command, uint8_t *data, uint8_t len)
+{
+    //malloc a buffer len+1 to store the length byte
+    uint8_t *buf = (uint8_t *)malloc(len+1);
+    if (i2c_master_register_read(TPS546_I2CADDR, command, buf, len+1) != ESP_OK) {
+        free(buf);
+        return ESP_FAIL;
+    }
+    //copy the data into the buffer
+    memcpy(data, buf+1, len);
+    free(buf);
+
+    return ESP_OK;
+}
+
+bool TPS546_probe(void)
+{
+    uint8_t data[6];
+    if (smb_read_block(PMBUS_IC_DEVICE_ID, data, sizeof(data)) != ESP_OK) {
+        return false;
+    }
+
+    return (memcmp(data, DEVICE_ID1, sizeof(data)) == 0) ||
+           (memcmp(data, DEVICE_ID2, sizeof(data)) == 0) ||
+           (memcmp(data, DEVICE_ID3, sizeof(data)) == 0);
+}
+
+/**
+ * @brief SMBus write block - don;t forget the length byte first :P
+ * @param command The command to write
+ * @param data The data to write
+ * @param len The number of bytes to write
+ */
+static esp_err_t smb_write_block(uint8_t command, uint8_t *data, uint8_t len)
+{
+    esp_err_t err = ESP_FAIL;
+
+    i2c_cmd_handle_t cmd = i2c_cmd_link_create();
+    i2c_master_start(cmd);
+    i2c_master_write_byte(cmd, TPS546_I2CADDR << 1 | WRITE_BIT, ACK_CHECK);
+    i2c_master_write_byte(cmd, command, ACK_CHECK);
+    i2c_master_write_byte(cmd, len, ACK_CHECK);
+    for (uint8_t i = 0; i < len; i++) {
+        i2c_master_write_byte(cmd, data[i], ACK_CHECK);
+    }
+    i2c_master_stop(cmd);
+    err = i2c_master_cmd_begin(I2C_MASTER_NUM, cmd, SMBUS_DEFAULT_TIMEOUT);
+    i2c_cmd_link_delete(cmd);
+
+    return err;
+}
+
+/**
+ * @brief Convert an SLINEAR11 value into an int
+ * @param value The SLINEAR11 value to convert
+ */
+static int slinear11_2_int(uint16_t value)
+{
+    int exponent, mantissa;
+    float result;
+
+    // First 5 bits is exponent in twos-complement
+    // check the first bit of the exponent to see if its negative
+    if (value & 0x8000) {
+        // exponent is negative
+        exponent = -1 * (((~value >> 11) & 0x001F) + 1);
+    } else {
+        exponent = (value >> 11);
+    }
+    // last 11 bits is the mantissa in twos-complement
+    // check the first bit of the mantissa to see if its negative
+    if (value & 0x400) {
+        // mantissa is negative
+        mantissa = -1 * ((~value & 0x03FF) + 1);
+    } else {
+        mantissa = (value & 0x03FF);
+    }
+
+    // calculate result (mantissa * 2^exponent)
+    result = mantissa * powf(2.0, exponent);
+    return (int)result;
+}
+
+/**
+ * @brief Convert an SLINEAR11 value into an int
+ * @param value The SLINEAR11 value to convert
+ */
+static float slinear11_2_float(uint16_t value)
+{
+    int exponent, mantissa;
+    float result;
+
+    // First 5 bits is exponent in twos-complement
+    // check the first bit of the exponent to see if its negative
+    if (value & 0x8000) {
+        // exponent is negative
+        exponent = -1 * (((~value >> 11) & 0x001F) + 1);
+    } else {
+        exponent = (value >> 11);
+    }
+    // last 11 bits is the mantissa in twos-complement
+    // check the first bit of the mantissa to see if its negative
+    if (value & 0x400) {
+        // mantissa is negative
+        mantissa = -1 * ((~value & 0x03FF) + 1);
+    } else {
+        mantissa = (value & 0x03FF);
+    }
+
+    // calculate result (mantissa * 2^exponent)
+    result = (float) mantissa * powf(2.0, (float) exponent);
+    return result;
+}
+
+/**
+ * @brief Convert an int value into an SLINEAR11
+ * @param value The int value to convert
+ */
+static uint16_t int_2_slinear11(int value)
+{
+    int mantissa;
+    int exponent = 0;
+    uint16_t result = 0;
+    int i;
+
+    // First see if the exponent is positive or negative
+    if (value >= 0) {
+        // exponent is positive
+        for (i=0; i<=15; i++) {
+            mantissa = value / powf(2.0, i);
+            if (mantissa < 1024) {
+                exponent = i;
+                break;
+            }
+        }
+        if (i == 16) {
+            ESP_LOGI(TAG, "Could not find a solution");
+            return 0;
+        }
+    } else {
+        // value is negative
+        ESP_LOGI(TAG, "No negative numbers at this time");
+        return 0;
+    }
+
+    result = ((exponent << 11) & 0xF800) + mantissa;
+
+    return result;
+}
+
+/**
+ * @brief Convert a float value into an SLINEAR11
+ * @param value The float value to convert
+ */
+static uint16_t float_2_slinear11(float value)
+{
+    int mantissa;
+    int exponent = 0;
+    uint16_t result = 0;
+    int i;
+
+    // First see if the exponent is positive or negative
+    if (value > 0) {
+        // exponent is negative
+        for (i=0; i<=15; i++) {
+            mantissa = value * powf(2.0, i);
+            if (mantissa >= 1024) {
+                exponent = i-1;
+                mantissa = value * powf(2.0, exponent);
+                break;
+            }
+        }
+        if (i == 16) {
+            ESP_LOGI(TAG, "Could not find a solution");
+            return 0;
+        }
+    } else {
+        // value is negative
+        ESP_LOGI(TAG, "No negative numbers at this time");
+        return 0;
+    }
+
+    result = (( (~exponent + 1) << 11) & 0xF800) + mantissa;
+
+    return result;
+}
+
+/**
+ * @brief Convert a ULINEAR16 value into a float
+ * the exponent comes from the VOUT_MODE bits[4..0]
+ * stored in twos-complement
+ * The mantissa occupies the full 16-bits of the value
+ * @param value The ULINEAR16 value to convert
+ */
+static float ulinear16_2_float(uint16_t value)
+{
+    uint8_t voutmode;
+    int exponent;
+    float result;
+
+    smb_read_byte(PMBUS_VOUT_MODE, &voutmode);
+
+    if (voutmode & 0x10) {
+        // exponent is negative
+        exponent = -1 * ((~voutmode & 0x1F) + 1);
+    } else {
+        exponent = (voutmode & 0x1F);
+    }
+    result = (value * powf(2.0, exponent));
+    return result;
+}
+
+/**
+ * @brief Convert a float value into a ULINEAR16
+ * the exponent comes from the VOUT_MODE bits[4..0]
+ * stored in twos-complement
+ * The mantissa occupies the full 16-bits of the result
+ * @param value The float value to convert
+*/
+static uint16_t float_2_ulinear16(float value)
+{
+    uint8_t voutmode;
+    float exponent;
+    uint16_t result;
+
+    smb_read_byte(PMBUS_VOUT_MODE, &voutmode);
+    if (voutmode & 0x10) {
+        // exponent is negative
+        exponent = -1 * ((~voutmode & 0x1F) + 1);
+    } else {
+        exponent = (voutmode & 0x1F);
+    }
+
+    result = (value / powf(2.0, exponent));
+
+    return result;
+}
+
+/*--- Public TPS546 functions ---*/
+
+/**
+ * @brief Set up the TPS546 regulator and turn it on
+*/
+int TPS546_init(void)
+{
+    return TPS546_init(TPS546_create_default_config());
+}
+
+int TPS546_init(const TPS546_CONFIG &config)
+{
+	uint8_t data[7];
+    uint8_t u8_value;
+    uint16_t u16_value;
+    uint8_t read_mfr_revision[4];
+    int temp;
+    uint8_t comp_config[5];
+    uint8_t voutmode;
+
+    ESP_LOGI(TAG, "Initializing the core voltage regulator");
+    tps546_config = config;
+
+    /*if (i2c_master_add_device(TPS546_I2CADDR, &tps546_dev_handle, TAG) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to add I2C device");
+        return -1;
+    }*/
+
+    /* Establish communication with regulator */
+    smb_read_block(PMBUS_IC_DEVICE_ID, data, 6); //the DEVICE_ID block first byte is the length.
+    ESP_LOGI(TAG, "Device ID: %02x %02x %02x %02x %02x %02x", data[0], data[1], data[2], data[3], data[4], data[5]);
+    /* There's 3 different known device IDs observed so far */
+    if ( (memcmp(data, DEVICE_ID1, 6) != 0) && (memcmp(data, DEVICE_ID2, 6) != 0) && (memcmp(data, DEVICE_ID3, 6) != 0))
+    {
+        ESP_LOGE(TAG, "Cannot find TPS546 regulator - Device ID mismatch");
+        return -1;
+    }
+
+    /* Make sure power is turned off until commanded */
+    smb_write_byte(PMBUS_OPERATION, OPERATION_OFF);
+    u8_value = ON_OFF_CONFIG_CMD | ON_OFF_CONFIG_PU | ON_OFF_CONFIG_CP |
+            ON_OFF_CONFIG_POLARITY | ON_OFF_CONFIG_DELAY;
+    ESP_LOGI(TAG, "Power config-ON_OFF_CONFIG: %02x", u8_value);
+    smb_write_byte(PMBUS_ON_OFF_CONFIG, u8_value);
+
+    /* Read version number and see if it matches */
+    TPS546_read_mfr_info(read_mfr_revision);
+    // if (memcmp(read_mfr_revision, MFR_REVISION, 3) != 0) {
+
+    // If it doesn't match, then write all the registers and set new version number
+    // ESP_LOGI(TAG, "--------------------------------");
+    // ESP_LOGI(TAG, "Config version mismatch, writing new config values");
+    ESP_LOGI(TAG, "Writing new config values");
+    smb_read_byte(PMBUS_VOUT_MODE, &voutmode);
+    ESP_LOGI(TAG, "VOUT_MODE: %02x", voutmode);
+    TPS546_write_entire_config();
+    //}
+
+    // /* Show temperature */
+    // ESP_LOGI(TAG, "--------------------------------");
+    // ESP_LOGI(TAG, "Temp: %d", TPS546_get_temperature());
+
+    // /* Show switching frequency */
+    // TPS546_get_frequency();
+    // TPS546_set_frequency(650);
+
+    /* Show voltage settings */
+    TPS546_show_voltage_settings();
+
+    //TPS546_print_status();
+
+    // ESP_LOGI(TAG, "-----------VOLTAGE/CURRENT---------------------");
+    // /* Get voltage input (SLINEAR11) */
+    // ESP_LOGI(TAG, "READ_VIN: %.2fV", TPS546_get_vin());
+    // /* Get output current (SLINEAR11) */
+    // ESP_LOGI(TAG, "READ_IOUT: %.2fA", TPS546_get_iout());
+    // /* Get voltage output (ULINEAR16) */
+    // ESP_LOGI(TAG, "READ_VOUT: %.2fV", TPS546_get_vout());
+
+    ESP_LOGI(TAG, "-----------TIMING---------------------");
+    smb_read_word(PMBUS_TON_DELAY, &u16_value);
+    temp = slinear11_2_int(u16_value);
+    ESP_LOGI(TAG, "TON_DELAY: %d", temp);
+    smb_read_word(PMBUS_TON_RISE, &u16_value);
+    temp = slinear11_2_int(u16_value);
+    ESP_LOGI(TAG, "TON_RISE: %d", temp);
+    smb_read_word(PMBUS_TON_MAX_FAULT_LIMIT, &u16_value);
+    temp = slinear11_2_int(u16_value);
+    ESP_LOGI(TAG, "TON_MAX_FAULT_LIMIT: %d", temp);
+    smb_read_byte(PMBUS_TON_MAX_FAULT_RESPONSE, &u8_value);
+    ESP_LOGI(TAG, "TON_MAX_FAULT_RESPONSE: %02x", u8_value);
+    smb_read_word(PMBUS_TOFF_DELAY, &u16_value);
+    temp = slinear11_2_int(u16_value);
+    ESP_LOGI(TAG, "TOFF_DELAY: %d", temp);
+    smb_read_word(PMBUS_TOFF_FALL, &u16_value);
+    temp = slinear11_2_int(u16_value);
+    ESP_LOGI(TAG, "TOFF_FALL: %d", temp);
+    ESP_LOGI(TAG, "--------------------------------------");
+
+    // Read the compensation config registers
+    if (smb_read_block(PMBUS_COMPENSATION_CONFIG, comp_config, 5) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to read COMPENSATION CONFIG");
+        return -1;
+    }
+    ESP_LOGI(TAG, "COMPENSATION CONFIG");
+    ESP_LOGI(TAG, "%02x %02x %02x %02x %02x", comp_config[0], comp_config[1],
+        comp_config[2], comp_config[3], comp_config[4]);
+
+    is_initialized = true;
+    TPS546_clear_faults();
+
+    return 0;
+}
+
+/**
+ * @brief Read the manufacturer model and revision
+ * @param read_mfr_revision Pointer to store the read revision
+*/
+void TPS546_read_mfr_info(uint8_t *read_mfr_revision)
+{
+    uint8_t read_mfr_id[4];
+    uint8_t read_mfr_model[4];
+
+    ESP_LOGI(TAG, "Reading MFR info");
+    if (smb_read_block(PMBUS_MFR_ID, read_mfr_id, 3) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to read MFR ID");
+        return;
+    }
+    read_mfr_id[3] = 0x00;
+    if (smb_read_block(PMBUS_MFR_MODEL, read_mfr_model, 3) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to read MFR MODEL");
+        return;
+    }
+    read_mfr_model[3] = 0x00;
+    if (smb_read_block(PMBUS_MFR_REVISION, read_mfr_revision, 3) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to read MFR REVISION");
+        return;
+    }
+
+    ESP_LOGI(TAG, "MFR_ID: %s", read_mfr_id);
+    ESP_LOGI(TAG, "MFR_MODEL: %s", read_mfr_model);
+    ESP_LOGI(TAG, "MFR_REVISION: %d%d%d ", read_mfr_revision[0],
+        read_mfr_revision[1], read_mfr_revision[2]);
+}
+
+/**
+ * @brief Write the manufacturer ID and revision to NVM
+*/
+void TPS546_set_mfr_info(void)
+{
+    ESP_LOGI(TAG, "Setting MFR info");
+	smb_write_block(PMBUS_MFR_ID, MFR_ID, 3);
+	smb_write_block(PMBUS_MFR_MODEL, MFR_MODEL, 3);
+	smb_write_block(PMBUS_MFR_REVISION, MFR_REVISION, 3);
+}
+
+void TPS546_clear_faults(void)
+{
+    if (smb_write_command(PMBUS_CLEAR_FAULTS) != ESP_OK) {
+        ESP_LOGW(TAG, "Could not clear TPS546 faults");
+    }
+}
+
+static bool TPS546_write_vout_limit_ratios(float vout_command)
+{
+    ESP_LOGI(TAG, "VOUT_OV_FAULT_LIMIT: %.2fx (%.2fV)",
+             TPS546_INIT_VOUT_OV_FAULT_LIMIT, vout_command * TPS546_INIT_VOUT_OV_FAULT_LIMIT);
+    if (smb_write_word(PMBUS_VOUT_OV_FAULT_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_OV_FAULT_LIMIT)) != ESP_OK) {
+        return false;
+    }
+
+    ESP_LOGI(TAG, "VOUT_OV_WARN_LIMIT: %.2fx (%.2fV)",
+             TPS546_INIT_VOUT_OV_WARN_LIMIT, vout_command * TPS546_INIT_VOUT_OV_WARN_LIMIT);
+    if (smb_write_word(PMBUS_VOUT_OV_WARN_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_OV_WARN_LIMIT)) != ESP_OK) {
+        return false;
+    }
+
+    ESP_LOGI(TAG, "VOUT_MARGIN_HIGH: %.2fx (%.2fV)",
+             TPS546_INIT_VOUT_MARGIN_HIGH, vout_command * TPS546_INIT_VOUT_MARGIN_HIGH);
+    if (smb_write_word(PMBUS_VOUT_MARGIN_HIGH, float_2_ulinear16(TPS546_INIT_VOUT_MARGIN_HIGH)) != ESP_OK) {
+        return false;
+    }
+
+    ESP_LOGI(TAG, "VOUT_MARGIN_LOW: %.2fx (%.2fV)",
+             TPS546_INIT_VOUT_MARGIN_LOW, vout_command * TPS546_INIT_VOUT_MARGIN_LOW);
+    if (smb_write_word(PMBUS_VOUT_MARGIN_LOW, float_2_ulinear16(TPS546_INIT_VOUT_MARGIN_LOW)) != ESP_OK) {
+        return false;
+    }
+
+    ESP_LOGI(TAG, "VOUT_UV_WARN_LIMIT: %.2fx (%.2fV)",
+             TPS546_INIT_VOUT_UV_WARN_LIMIT, vout_command * TPS546_INIT_VOUT_UV_WARN_LIMIT);
+    if (smb_write_word(PMBUS_VOUT_UV_WARN_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_UV_WARN_LIMIT)) != ESP_OK) {
+        return false;
+    }
+
+    ESP_LOGI(TAG, "VOUT_UV_FAULT_LIMIT: %.2fx (%.2fV)",
+             TPS546_INIT_VOUT_UV_FAULT_LIMIT, vout_command * TPS546_INIT_VOUT_UV_FAULT_LIMIT);
+    return smb_write_word(PMBUS_VOUT_UV_FAULT_LIMIT, float_2_ulinear16(TPS546_INIT_VOUT_UV_FAULT_LIMIT)) == ESP_OK;
+}
+
+/**
+ * @brief Set all the relevant config registers for normal operation
+*/
+void TPS546_write_entire_config(void)
+{
+    ESP_LOGI(TAG, "---Writing new config values to TPS546---");
+
+    /* set up the ON_OFF_CONFIG */
+    ESP_LOGI(TAG, "Setting ON_OFF_CONFIG");
+    if (smb_write_byte(PMBUS_ON_OFF_CONFIG, TPS546_INIT_ON_OFF_CONFIG) != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to write ON_OFF_CONFIG");
+        return;
+    }
+
+    ESP_LOGI(TAG, "Setting STACK_CONFIG: %04X", tps546_config.stack_config);
+    smb_write_word(PMBUS_STACK_CONFIG, tps546_config.stack_config);
+
+    ESP_LOGI(TAG, "Setting SYNC_CONFIG: %02X", tps546_config.sync_config);
+    smb_write_byte(PMBUS_SYNC_CONFIG, tps546_config.sync_config);
+
+    ESP_LOGI(TAG, "Setting PHASE: %02X", tps546_config.phase);
+    smb_write_byte(PMBUS_PHASE, tps546_config.phase);
+
+    /* Switch frequency */
+    ESP_LOGI(TAG, "Setting FREQUENCY");
+    smb_write_word(PMBUS_FREQUENCY_SWITCH, int_2_slinear11(TPS546_INIT_FREQUENCY));
+
+    if (tps546_config.compensation_config[0] != 0 &&
+        tps546_config.compensation_config[1] != 0 &&
+        tps546_config.compensation_config[2] != 0 &&
+        tps546_config.compensation_config[3] != 0 &&
+        tps546_config.compensation_config[4] != 0) {
+        ESP_LOGI(TAG, "Setting COMPENSATION_CONFIG: %02X %02X %02X %02X %02X",
+            tps546_config.compensation_config[0], tps546_config.compensation_config[1],
+            tps546_config.compensation_config[2], tps546_config.compensation_config[3],
+            tps546_config.compensation_config[4]);
+        smb_write_block(PMBUS_COMPENSATION_CONFIG, tps546_config.compensation_config, 5);
+    }
+
+    /* vin voltage */
+    ESP_LOGI(TAG, "Setting VIN_ON: %.2f", tps546_config.vin_on);
+    smb_write_word(PMBUS_VIN_ON, float_2_slinear11(tps546_config.vin_on));
+    ESP_LOGI(TAG, "Setting VIN_OFF: %.2f", tps546_config.vin_off);
+    smb_write_word(PMBUS_VIN_OFF, float_2_slinear11(tps546_config.vin_off));
+    if (tps546_config.vin_uv_warn_limit > 0) {
+        ESP_LOGI(TAG, "Setting VIN_UV_WARN_LIMIT: %.2f", tps546_config.vin_uv_warn_limit);
+        smb_write_word(PMBUS_VIN_UV_WARN_LIMIT, float_2_slinear11(tps546_config.vin_uv_warn_limit));
+    }
+    ESP_LOGI(TAG, "Setting VIN_OV_FAULT_LIMIT: %.2f", tps546_config.vin_ov_fault_limit);
+    smb_write_word(PMBUS_VIN_OV_FAULT_LIMIT, float_2_slinear11(tps546_config.vin_ov_fault_limit));
+    ESP_LOGI(TAG, "Setting VIN_OV_FAULT_RESPONSE: %02X", TPS546_INIT_VIN_OV_FAULT_RESPONSE);
+    smb_write_byte(PMBUS_VIN_OV_FAULT_RESPONSE, TPS546_INIT_VIN_OV_FAULT_RESPONSE);
+
+    /* vout voltage */
+    ESP_LOGI(TAG, "Setting VOUT SCALE: %.2f", tps546_config.scale_loop);
+    smb_write_word(PMBUS_VOUT_SCALE_LOOP, float_2_slinear11(tps546_config.scale_loop));
+    ESP_LOGI(TAG, "VOUT_COMMAND: %.2f", tps546_config.vout_command);
+    smb_write_word(PMBUS_VOUT_COMMAND, float_2_ulinear16(tps546_config.vout_command));
+    ESP_LOGI(TAG, "VOUT_MAX: %.2f", tps546_config.vout_max);
+    smb_write_word(PMBUS_VOUT_MAX, float_2_ulinear16(tps546_config.vout_max));
+    ESP_LOGI(TAG, "VOUT_MIN: %.2f", tps546_config.vout_min);
+    smb_write_word(PMBUS_VOUT_MIN, float_2_ulinear16(tps546_config.vout_min));
+    if (!TPS546_write_vout_limit_ratios(tps546_config.vout_command)) {
+        ESP_LOGW(TAG, "Failed to write VOUT limit ratios; continuing with existing limits");
+    }
+
+    /* iout current */
+    ESP_LOGI(TAG, "Setting IOUT");
+    smb_write_word(PMBUS_IOUT_OC_WARN_LIMIT, float_2_slinear11(tps546_config.iout_oc_warn_limit));
+    smb_write_word(PMBUS_IOUT_OC_FAULT_LIMIT, float_2_slinear11(tps546_config.iout_oc_fault_limit));
+    smb_write_byte(PMBUS_IOUT_OC_FAULT_RESPONSE, TPS546_INIT_IOUT_OC_FAULT_RESPONSE);
+
+    /* temperature */
+    ESP_LOGI(TAG, "Setting TEMPERATURE");
+    ESP_LOGI(TAG, "OT_WARN_LIMIT: %d", TPS546_INIT_OT_WARN_LIMIT);
+    smb_write_word(PMBUS_OT_WARN_LIMIT, int_2_slinear11(TPS546_INIT_OT_WARN_LIMIT));
+    ESP_LOGI(TAG, "OT_FAULT_LIMIT: %d", TPS546_INIT_OT_FAULT_LIMIT);
+    smb_write_word(PMBUS_OT_FAULT_LIMIT, int_2_slinear11(TPS546_INIT_OT_FAULT_LIMIT));
+    ESP_LOGI(TAG, "OT_FAULT_RESPONSE: %02x", TPS546_INIT_OT_FAULT_RESPONSE);
+    smb_write_byte(PMBUS_OT_FAULT_RESPONSE, TPS546_INIT_OT_FAULT_RESPONSE);
+
+    /* timing */
+    ESP_LOGI(TAG, "Setting TIMING");
+    ESP_LOGI(TAG, "TON_DELAY: %d", TPS546_INIT_TON_DELAY);
+    smb_write_word(PMBUS_TON_DELAY, int_2_slinear11(TPS546_INIT_TON_DELAY));
+    ESP_LOGI(TAG, "TON_RISE: %d", TPS546_INIT_TON_RISE);
+    smb_write_word(PMBUS_TON_RISE, int_2_slinear11(TPS546_INIT_TON_RISE));
+    ESP_LOGI(TAG, "TON_MAX_FAULT_LIMIT: %d", TPS546_INIT_TON_MAX_FAULT_LIMIT);
+    smb_write_word(PMBUS_TON_MAX_FAULT_LIMIT, int_2_slinear11(TPS546_INIT_TON_MAX_FAULT_LIMIT));
+    ESP_LOGI(TAG, "TON_MAX_FAULT_RESPONSE: %02x", TPS546_INIT_TON_MAX_FAULT_RESPONSE);
+    smb_write_byte(PMBUS_TON_MAX_FAULT_RESPONSE, TPS546_INIT_TON_MAX_FAULT_RESPONSE);
+    ESP_LOGI(TAG, "TOFF_DELAY: %d", TPS546_INIT_TOFF_DELAY);
+    smb_write_word(PMBUS_TOFF_DELAY, int_2_slinear11(TPS546_INIT_TOFF_DELAY));
+    ESP_LOGI(TAG, "TOFF_FALL: %d", TPS546_INIT_TOFF_FALL);
+    smb_write_word(PMBUS_TOFF_FALL, int_2_slinear11(TPS546_INIT_TOFF_FALL));
+
+    /* configure the bootup behavior regarding pin detect values vs NVM values */
+    ESP_LOGI(TAG, "Setting PIN_DETECT_OVERRIDE");
+    smb_write_word(PMBUS_PIN_DETECT_OVERRIDE, INIT_PIN_DETECT_OVERRIDE);
+
+    /* TODO write new MFR_REVISION number to reflect these parameters */
+    ESP_LOGI(TAG, "Writing MFR ID");
+    smb_write_block(PMBUS_MFR_ID, MFR_ID, 3);
+    ESP_LOGI(TAG, "Writing MFR MODEL");
+    smb_write_block(PMBUS_MFR_MODEL, MFR_MODEL, 3);
+    ESP_LOGI(TAG, "Writing MFR REVISION");
+    smb_write_block(PMBUS_MFR_REVISION, MFR_REVISION, 3);
+
+    /*
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!
+    // Never write this to NVM as it can corrupt the TPS in an unrecoverable state, just do it on boot every time
+    !!!!!!!!!!!!!!!!!!!!!!!!!!!
+    */
+    /* store configuration in NVM */
+    // ESP_LOGI(TAG, "---Saving new config---");
+    // smb_write_byte(PMBUS_STORE_USER_ALL, 0x98);
+
+}
+
+int TPS546_get_frequency(void)
+{
+    uint16_t value;
+    int freq;
+
+    smb_read_word(PMBUS_FREQUENCY_SWITCH, &value);
+    freq = slinear11_2_int(value);
+
+    return (int)freq;
+}
+
+void TPS546_set_frequency(int newfreq)
+{
+    uint16_t value;
+    //int freq;
+
+    ESP_LOGI(TAG, "Writing new frequency: %d", newfreq);
+    value = int_2_slinear11(newfreq);
+    //ESP_LOGI(TAG, "New value: 0x%04x", value);
+    smb_write_word(PMBUS_FREQUENCY_SWITCH, value);
+
+    //ESP_LOGI(TAG, "Checking conversion...");
+    //freq = slinear11_2_int(value);
+    //ESP_LOGI(TAG, "Converted value: %d", freq);
+}
+
+float TPS546_get_temperature(void)
+{
+    uint16_t value;
+
+    if (!is_initialized) {
+        return 0;
+    }
+
+    smb_read_word(PMBUS_READ_TEMPERATURE_1, &value);
+
+    return slinear11_2_float(value);
+}
+
+float TPS546_get_vin(void)
+{
+    uint16_t u16_value;
+    float vin;
+
+    if (!is_initialized) {
+        return 0.0f;
+    }
+
+    /* Get voltage input (ULINEAR16) */
+    if (smb_read_word(PMBUS_READ_VIN, &u16_value) != ESP_OK) {
+        ESP_LOGE(TAG, "Could not read VIN");
+        return 0;
+    } else {
+        vin = slinear11_2_float(u16_value);
+        #ifdef _DEBUG_LOG_
+        ESP_LOGI(TAG, "Got Vin: %2.3f V", vin);
+        #endif
+        return vin;
+    }
+}
+
+float TPS546_get_iout(void)
+{
+    uint16_t u16_value;
+    float iout;
+
+    if (!is_initialized) {
+        return 0.0f;
+    }
+
+    /* Get current output (SLINEAR11) */
+    if (smb_read_word(PMBUS_READ_IOUT, &u16_value) != ESP_OK) {
+        ESP_LOGE(TAG, "Could not read Iout");
+        return 0;
+    } else {
+        iout = slinear11_2_float(u16_value);
+
+    //iout = iout * -1.0;
+    #ifdef _DEBUG_LOG_
+        ESP_LOGI(TAG, "Got Iout: %2.3f A", iout);
+    #endif
+
+        return iout;
+}
+}
+
+float TPS546_get_vout(void)
+{
+    uint16_t u16_value;
+    float vout;
+
+    if (!is_initialized) {
+        return 0.0f;
+    }
+
+    /* Get voltage output (ULINEAR16) */
+    if (smb_read_word(PMBUS_READ_VOUT, &u16_value) != ESP_OK) {
+        ESP_LOGE(TAG, "Could not read Vout");
+        return 0;
+    } else {
+        vout = ulinear16_2_float(u16_value);
+    #ifdef _DEBUG_LOG_
+        ESP_LOGI(TAG, "Got Vout: %2.3f V", vout);
+    #endif
+        return vout;
+    }
+}
+
+static uint8_t TPS546_read_status_byte(uint8_t command)
+{
+    uint8_t value;
+
+    if (!is_initialized) {
+        return 0xff;
+    }
+
+    if (smb_read_byte(command, &value) != ESP_OK) {
+        return 0xff;
+    }
+
+    return value;
+}
+
+uint8_t TPS546_get_status_byte(void)
+{
+    return TPS546_read_status_byte(PMBUS_STATUS_BYTE);
+}
+
+uint8_t TPS546_get_status_iout(void)
+{
+    return TPS546_read_status_byte(PMBUS_STATUS_IOUT);
+}
+
+uint8_t TPS546_get_status_vout(void)
+{
+    return TPS546_read_status_byte(PMBUS_STATUS_VOUT);
+}
+
+uint8_t TPS546_get_status_input(void)
+{
+    return TPS546_read_status_byte(PMBUS_STATUS_INPUT);
+}
+
+uint8_t TPS546_get_status_temperature(void)
+{
+    return TPS546_read_status_byte(PMBUS_STATUS_TEMPERATURE);
+}
+
+void TPS546_print_status(void) {
+    uint16_t u16_value;
+    uint8_t u8_value;
+
+    if (smb_read_word(PMBUS_STATUS_WORD, &u16_value) != ESP_OK) {
+        ESP_LOGE(TAG, "Could not read STATUS_WORD");
+    } else {
+        ESP_LOGI(TAG, "TPS546 Status: %04X", u16_value);
+    }
+
+    if (smb_read_byte(PMBUS_STATUS_VOUT, &u8_value) != ESP_OK) {
+        ESP_LOGE(TAG, "Could not read STATUS_VOUT");
+    } else {
+        ESP_LOGI(TAG, "TPS546 VOUT Status: %02X", u8_value);
+    }
+
+    if (smb_read_byte(PMBUS_STATUS_INPUT, &u8_value) != ESP_OK) {
+        ESP_LOGE(TAG, "Could not read STATUS_INPUT");
+    } else {
+        ESP_LOGI(TAG, "TPS546 INPUT Status: %02X", u8_value);
+    }
+
+    if (smb_read_byte(PMBUS_STATUS_IOUT, &u8_value) != ESP_OK) {
+        ESP_LOGE(TAG, "Could not read STATUS_IOUT");
+    } else {
+        ESP_LOGI(TAG, "TPS546 IOUT Status: %02X", u8_value);
+    }
+
+    if (smb_read_byte(PMBUS_STATUS_TEMPERATURE, &u8_value) != ESP_OK) {
+        ESP_LOGE(TAG, "Could not read STATUS_TEMPERATURE");
+    } else {
+        ESP_LOGI(TAG, "TPS546 TEMPERATURE Status: %02X", u8_value);
+    }
+}
+
+/**
+ * @brief Sets the core voltage
+ * this function controls the regulator ontput state
+ * send it the desired output in millivolts
+ * A value between TPS546_INIT_VOUT_MIN and TPS546_INIT_VOUT_MAX
+ * send a 0 to turn off the output
+ * @param volts The desired output voltage
+**/
+bool TPS546_set_vout(float volts)
+{
+    uint16_t value;
+
+    if (volts == 0) {
+        // turn off output
+        if (smb_write_byte(PMBUS_OPERATION, OPERATION_OFF) != ESP_OK) {
+            ESP_LOGE(TAG, "Could not turn off Vout");
+            return false;
+        }
+        return true;
+    }
+
+    // check range
+    if ((volts < tps546_config.vout_min) || (volts > tps546_config.vout_max)) {
+        ESP_LOGE(TAG, "Voltage requested (%f V) is out of range", volts);
+        return false;
+    }
+
+    // set output voltage
+    value = float_2_ulinear16(volts);
+    if (smb_write_word(PMBUS_VOUT_COMMAND, value) != ESP_OK) {
+        ESP_LOGE(TAG, "Could not set Vout to %1.2f V", volts);
+        return false;
+    }
+
+    if (!TPS546_write_vout_limit_ratios(volts)) {
+        ESP_LOGW(TAG, "Could not update Vout limit ratios; continuing with existing limits");
+    }
+
+    ESP_LOGI(TAG, "Vout changed to %1.2f V", volts);
+
+    // turn on output
+    TPS546_clear_faults();
+    if (smb_write_byte(PMBUS_OPERATION, OPERATION_ON) != ESP_OK) {
+        ESP_LOGE(TAG, "Could not turn on Vout");
+        return false;
+    }
+
+    return true;
+}
+
+
+void TPS546_show_voltage_settings(void)
+{
+    uint16_t u16_value;
+    float f_value;
+
+    ESP_LOGI(TAG, "-----------VOLTAGE---------------------");
+    /* VIN_ON SLINEAR11 */
+    smb_read_word(PMBUS_VIN_ON, &u16_value);
+    f_value = slinear11_2_float(u16_value);
+    ESP_LOGI(TAG, "VIN ON set to: %.2f", f_value);
+
+    /* VIN_OFF SLINEAR11 */
+    smb_read_word(PMBUS_VIN_OFF, &u16_value);
+    f_value = slinear11_2_float(u16_value);
+    ESP_LOGI(TAG, "VIN OFF set to: %.2f", f_value);
+
+    /* VOUT_MAX */
+    smb_read_word(PMBUS_VOUT_MAX, &u16_value);
+    f_value = ulinear16_2_float(u16_value);
+    ESP_LOGI(TAG, "Vout Max set to: %.2f V", f_value);
+
+    /* VOUT_OV_FAULT_LIMIT */
+    smb_read_word(PMBUS_VOUT_OV_FAULT_LIMIT, &u16_value);
+    f_value = ulinear16_2_float(u16_value);
+    ESP_LOGI(TAG, "Vout OV Fault Limit: %.2f V", f_value);
+
+    /* VOUT_OV_WARN_LIMIT */
+    smb_read_word(PMBUS_VOUT_OV_WARN_LIMIT, &u16_value);
+    f_value = ulinear16_2_float(u16_value);
+    ESP_LOGI(TAG, "Vout OV Warn Limit: %.2f V", f_value);
+
+    /* VOUT_MARGIN_HIGH */
+    smb_read_word(PMBUS_VOUT_MARGIN_HIGH, &u16_value);
+    f_value = ulinear16_2_float(u16_value);
+    ESP_LOGI(TAG, "Vout Margin HIGH: %.2f V", f_value);
+
+    /* --- VOUT_COMMAND --- */
+    smb_read_word(PMBUS_VOUT_COMMAND, &u16_value);
+    f_value = ulinear16_2_float(u16_value);
+    ESP_LOGI(TAG, "Vout set to: %.2f V", f_value);
+
+    /* VOUT_MARGIN_LOW */
+    smb_read_word(PMBUS_VOUT_MARGIN_LOW, &u16_value);
+    f_value = ulinear16_2_float(u16_value);
+    ESP_LOGI(TAG, "Vout Margin LOW: %.2f V", f_value);
+
+    /* VOUT_UV_WARN_LIMIT */
+    smb_read_word(PMBUS_VOUT_UV_WARN_LIMIT, &u16_value);
+    f_value = ulinear16_2_float(u16_value);
+    ESP_LOGI(TAG, "Vout UV Warn Limit: %.2f V", f_value);
+
+    /* VOUT_UV_FAULT_LIMIT */
+    smb_read_word(PMBUS_VOUT_UV_FAULT_LIMIT, &u16_value);
+    f_value = ulinear16_2_float(u16_value);
+    ESP_LOGI(TAG, "Vout UV Fault Limit: %.2f V", f_value);
+
+    /* VOUT_MIN */
+    smb_read_word(PMBUS_VOUT_MIN, &u16_value);
+    f_value = ulinear16_2_float(u16_value);
+    ESP_LOGI(TAG, "Vout Min set to: %.2f V", f_value);
+}
+
+TPS546::TPS546(uint16_t voltage_domains)
+{
+    m_config = TPS546_create_dual_config();
+    m_config.vout_min = 2.0f;
+    m_config.vout_command = 2.4f;
+    m_voltageDomains = voltage_domains;
+}
+
+bool TPS546::init(int num_phases, int imax, float ifault)
+{
+    (void) num_phases;
+    (void) imax;
+    (void) ifault;
+
+    m_initialized = TPS546_init(m_config) == ESP_OK;
+    return m_initialized;
+}
+
+void TPS546::clear_faults()
+{
+    TPS546_clear_faults();
+}
+
+float TPS546::get_temperature()
+{
+    return TPS546_get_temperature();
+}
+
+float TPS546::get_pin()
+{
+    return get_pout();
+}
+
+float TPS546::get_pout()
+{
+    return TPS546_get_vout() * TPS546_get_iout();
+}
+
+float TPS546::get_vin()
+{
+    return TPS546_get_vin();
+}
+
+float TPS546::get_iin()
+{
+    const float vin = get_vin();
+    return vin ? get_pin() / vin : 0.0f;
+}
+
+float TPS546::get_iout()
+{
+    return TPS546_get_iout();
+}
+
+float TPS546::get_vout()
+{
+    return TPS546_get_vout() / static_cast<float>(m_voltageDomains);
+}
+
+bool TPS546::uses_external_vr_temperature()
+{
+    return false;
+}
+
+bool TPS546::set_vout(float volts)
+{
+    return TPS546_set_vout(volts * static_cast<float>(m_voltageDomains));
+}
+
+bool TPS546::disable_vout()
+{
+    if (!m_initialized) {
+        return true;
+    }
+    return smb_write_byte(PMBUS_OPERATION, OPERATION_OFF) == ESP_OK;
+}
+
+void TPS546::status()
+{
+    TPS546_print_status();
+}
+
+uint8_t TPS546::get_status_byte()
+{
+    return TPS546_get_status_byte();
+}
+
+uint8_t TPS546::get_status_iout()
+{
+    return TPS546_get_status_iout();
+}
+
+uint8_t TPS546::get_status_vout()
+{
+    return TPS546_get_status_vout();
+}
+
+uint8_t TPS546::get_status_input()
+{
+    return TPS546_get_status_input();
+}
+
+uint8_t TPS546::get_status_temp()
+{
+    return TPS546_get_status_temperature();
+}
+
+}

--- a/main/boards/drivers/rev7/TPS546.h
+++ b/main/boards/drivers/rev7/TPS546.h
@@ -1,0 +1,172 @@
+#ifndef REV7_TPS546_H_
+#define REV7_TPS546_H_
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "../BuckConverter.h"
+
+#define TPS546_I2CADDR         0x24  //< TPS546 i2c address
+#define TPS546_MANUFACTURER_ID 0xFE  //< Manufacturer ID
+#define TPS546_REVISION        0xFF  //< Chip revision
+
+#define TPS546_THROTTLE_TEMP 105.0
+#define TPS546_MAX_TEMP 145.0
+
+/*-------------------------*/
+/* These are the inital values for the voltage regulator configuration */
+/* when the config revision stored in the TPS546 doesn't match, these values are used */
+
+
+#define TPS546_INIT_ON_OFF_CONFIG 0x18 /* use ON_OFF command to control power */
+#define OPERATION_OFF 0x00
+#define OPERATION_ON  0x80
+
+#define TPS546_INIT_FREQUENCY 650  /* KHz */
+
+/* vin voltage */
+#define TPS546_INIT_VIN_ON  4.8  /* V */
+#define TPS546_INIT_VIN_OFF 4.5  /* V */
+#define TPS546_INIT_VIN_UV_WARN_LIMIT 5.8 /* V */
+#define TPS546_INIT_VIN_OV_FAULT_LIMIT 6.0 /* V */
+#define TPS546_INIT_VIN_OV_FAULT_RESPONSE 0xB7  /* retry 6 times */
+
+  /* vout voltage */
+#define TPS546_INIT_SCALE_LOOP 0.25  /* Voltage Scale factor */
+#define TPS546_INIT_VOUT_MAX 3 /* V */
+#define TPS546_INIT_VOUT_OV_FAULT_LIMIT 1.25 /* %/100 above VOUT_COMMAND */
+#define TPS546_INIT_VOUT_OV_WARN_LIMIT  1.1 /* %/100 above VOUT_COMMAND */
+#define TPS546_INIT_VOUT_MARGIN_HIGH 1.1 /* %/100 above VOUT */
+#define TPS546_INIT_VOUT_COMMAND 1.2  /* V absolute value */
+#define TPS546_INIT_VOUT_MARGIN_LOW 0.90 /* %/100 below VOUT */
+#define TPS546_INIT_VOUT_UV_WARN_LIMIT 0.90  /* %/100 below VOUT_COMMAND */
+#define TPS546_INIT_VOUT_UV_FAULT_LIMIT 0.75 /* %/100 below VOUT_COMMAND */
+#define TPS546_INIT_VOUT_MIN 1 /* v */
+
+  /* iout current */
+#define TPS546_INIT_IOUT_OC_WARN_LIMIT  25.00 /* A */
+#define TPS546_INIT_IOUT_OC_FAULT_LIMIT 30.00 /* A */
+#define TPS546_INIT_IOUT_OC_FAULT_RESPONSE 0xC0  /* shut down, no retries */
+
+  /* temperature */
+// It is better to set the temperature warn limit for TPS546 more higher than Ultra
+#define TPS546_INIT_OT_WARN_LIMIT  105 /* degrees C */
+#define TPS546_INIT_OT_FAULT_LIMIT 145 /* degrees C */
+#define TPS546_INIT_OT_FAULT_RESPONSE 0xFF /* wait for cooling, and retry */
+
+  /* timing */
+#define TPS546_INIT_TON_DELAY 0
+#define TPS546_INIT_TON_RISE 3
+#define TPS546_INIT_TON_MAX_FAULT_LIMIT 0
+#define TPS546_INIT_TON_MAX_FAULT_RESPONSE 0x3B
+#define TPS546_INIT_TOFF_DELAY 0
+#define TPS546_INIT_TOFF_FALL 0
+
+#define INIT_STACK_CONFIG 0x0000
+#define INIT_SYNC_CONFIG 0x0010
+#define INIT_PIN_DETECT_OVERRIDE 0x0000
+
+#define TPS546_INIT_PHASE_SINGLE 0x00
+#define TPS546_INIT_PHASE_MULTI  0xFF
+
+#define TPS546_INIT_STACK_CONFIG_SINGLE 0x0000
+#define TPS546_INIT_STACK_CONFIG_DUAL   0x0001
+#define TPS546_INIT_STACK_CONFIG_QUAD   0x0003
+
+#define TPS546_INIT_SYNC_CONFIG_SINGLE 0x10
+#define TPS546_INIT_SYNC_CONFIG_MULTI  0xD0
+
+/*-------------------------*/
+
+/* PMBUS_ON_OFF_CONFIG initialization values */
+#define ON_OFF_CONFIG_PU 0x10   // turn on PU bit
+#define ON_OFF_CONFIG_CMD 0x08  // turn on CMD bit
+#define ON_OFF_CONFIG_CP 0x00   // turn off CP bit
+#define ON_OFF_CONFIG_POLARITY 0x00 // turn off POLARITY bit
+#define ON_OFF_CONFIG_DELAY 0x00 // turn off DELAY bit
+
+namespace Rev7TPS546
+{
+
+typedef struct {
+    uint8_t phase;
+
+    float vin_on;
+    float vin_off;
+    float vin_uv_warn_limit;
+    float vin_ov_fault_limit;
+
+    float scale_loop;
+    float vout_min;
+    float vout_max;
+    float vout_command;
+
+    float iout_oc_warn_limit;
+    float iout_oc_fault_limit;
+
+    uint16_t stack_config;
+    uint8_t sync_config;
+    uint8_t compensation_config[5];
+} TPS546_CONFIG;
+
+/* public functions */
+TPS546_CONFIG TPS546_create_default_config(void);
+TPS546_CONFIG TPS546_create_dual_config(void);
+bool TPS546_probe(void);
+int TPS546_init(void);
+int TPS546_init(const TPS546_CONFIG &config);
+void TPS546_read_mfr_info(uint8_t *);
+void TPS546_set_mfr_info(void);
+void TPS546_clear_faults(void);
+void TPS546_write_entire_config(void);
+int TPS546_get_frequency(void);
+void TPS546_set_frequency(int);
+float TPS546_get_temperature(void);
+float TPS546_get_vin(void);
+float TPS546_get_iout(void);
+float TPS546_get_vout(void);
+uint8_t TPS546_get_status_byte(void);
+uint8_t TPS546_get_status_iout(void);
+uint8_t TPS546_get_status_vout(void);
+uint8_t TPS546_get_status_input(void);
+uint8_t TPS546_get_status_temperature(void);
+bool TPS546_set_vout(float volts);
+void TPS546_show_voltage_settings(void);
+void TPS546_print_status(void);
+
+class TPS546 : public BuckConverter {
+  public:
+    explicit TPS546(uint16_t voltage_domains = 2);
+
+    bool init(int num_phases, int imax, float ifault) override;
+    void clear_faults() override;
+
+    float get_temperature() override;
+    float get_pin() override;
+    float get_pout() override;
+    float get_vin() override;
+    float get_iin() override;
+    float get_iout() override;
+    float get_vout() override;
+    bool uses_external_vr_temperature() override;
+
+    bool set_vout(float volts) override;
+    bool disable_vout() override;
+
+    void status() override;
+
+    uint8_t get_status_byte() override;
+    uint8_t get_status_iout() override;
+    uint8_t get_status_vout() override;
+    uint8_t get_status_input() override;
+    uint8_t get_status_temp() override;
+
+  private:
+    TPS546_CONFIG m_config;
+    uint16_t m_voltageDomains;
+    bool m_initialized = false;
+};
+
+}
+
+#endif /* REV7_TPS546_H_ */

--- a/main/boards/nerdqaxeplus.cpp
+++ b/main/boards/nerdqaxeplus.cpp
@@ -312,6 +312,9 @@ float NerdQaxePlus::getTemperature(int index) {
 
 
 float NerdQaxePlus::getVRTemp() {
+    if (!m_tps->uses_external_vr_temperature()) {
+        return m_tps->get_temperature();
+    }
     return TMP1075_read_temperature(1);
 }
 

--- a/main/boards/nerdqaxeplus.h
+++ b/main/boards/nerdqaxeplus.h
@@ -3,6 +3,7 @@
 #include "asic.h"
 #include "bm1368.h"
 #include "board.h"
+#include "./drivers/BuckConverter.h"
 #include "./drivers/TPS53647.h"
 #include "./drivers/fxl6408.h"
 
@@ -23,7 +24,7 @@ class NerdQaxePlus : public Board {
 
     int detectNumTempSensors();
 
-    TPS53647 *m_tps;
+    BuckConverter *m_tps;
 
     // Optional CAN extension board (FXL6408 + transceiver on GPIO21/16)
     Fxl6408 m_canIo;

--- a/main/boards/nerdqaxeplus2.cpp
+++ b/main/boards/nerdqaxeplus2.cpp
@@ -1,7 +1,16 @@
-#include "board.h"
+#include <algorithm>
+
+#include "esp_log.h"
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+
 #include "nerdqaxeplus2.h"
+#include "nvs_config.h"
+#include "serial.h"
+#include "drivers/rev7/TPS546.h"
 
 static const char* TAG="nerdqaxeplus2";
+static constexpr uint16_t FAN_MODE_PID = 2;
 
 NerdQaxePlus2::NerdQaxePlus2() : NerdQaxePlus() {
     m_deviceModel = "NerdQAxe++";
@@ -43,6 +52,148 @@ NerdQaxePlus2::NerdQaxePlus2() : NerdQaxePlus() {
     m_asics = new BM1370();
     m_hasHashCounter = true;
     m_vrFrequency = m_defaultVrFrequency = m_asics->getDefaultVrFrequency();
+}
+
+void NerdQaxePlus2::applyRev7Profile()
+{
+    if (m_hasRev7TPS546) {
+        return;
+    }
+
+    m_hasRev7TPS546 = true;
+    m_version = 502;
+    m_vr_maxTemp = TPS546_THROTTLE_TEMP;
+    m_maxPin = 120.0f;
+    m_minPin = 45.0f;
+    m_maxCurrentA = 10.0f;
+    m_absMaxAsicFrequency = 1000;
+    m_asicFrequencies = {500, 515, 525, 550, 575, 590, 600, 625, 650, 675, 700, 725,
+                         750, 775, 800, 825, 850, 875, 900, 925, 950, 975, 1000};
+    m_asicVoltages = {1120, 1130, 1140, 1150, 1160, 1170, 1180, 1190, 1200, 1210,
+                      1220, 1230, 1240, 1250, 1260, 1270, 1280, 1290, 1300};
+    m_defaultAsicVoltageMillis = m_asicVoltageMillis = 1200;
+    m_pidSettings[0].targetTemp = 65;
+
+    if (!Config::cfgHasKey(NVS_CONFIG_AUTO_FAN_SPEED)) {
+        Config::setFanMode(0, FAN_MODE_PID);
+    }
+}
+
+void NerdQaxePlus2::selectRev7BuckConverter()
+{
+    if (m_hasRev7TPS546) {
+        return;
+    }
+
+    delete m_tps;
+    m_tps = new Rev7TPS546::TPS546(m_rev7VoltageDomains);
+    applyRev7Profile();
+}
+
+bool NerdQaxePlus2::probeRev7Buck()
+{
+    bool detected = Rev7TPS546::TPS546_probe();
+
+    if (detected) {
+        ESP_LOGI(TAG, "NerdQAxe++ rev7 TPS546 regulator detected");
+        selectRev7BuckConverter();
+    }
+
+    return detected;
+}
+
+bool NerdQaxePlus2::initBoard()
+{
+    if (!NerdQaxePlus::initBoard()) {
+        return false;
+    }
+
+    if (probeRev7Buck()) {
+        loadSettings();
+    }
+
+    return true;
+}
+
+bool NerdQaxePlus2::initAsics()
+{
+    if (!m_hasRev7TPS546) {
+        return NerdQaxePlus::initAsics();
+    }
+
+    VREG_disable();
+    LDO_disable();
+    setAsicReset(false);
+    vTaskDelay(pdMS_TO_TICKS(250));
+
+    LDO_enable();
+    vTaskDelay(pdMS_TO_TICKS(100));
+
+    VREG_enable();
+    vTaskDelay(pdMS_TO_TICKS(50));
+
+    if (!m_tps->init(m_numPhases, m_imax, m_ifault)) {
+        ESP_LOGE(TAG, "error initializing buck regulator");
+        return false;
+    }
+
+    const float init_voltage = static_cast<float>(std::max(m_initVoltageMillis, m_asicVoltageMillis)) / 1000.0f;
+    if (!setVoltage(init_voltage)) {
+        ESP_LOGE(TAG, "Failed to set init voltage");
+        return false;
+    }
+
+    vTaskDelay(pdMS_TO_TICKS(500));
+    m_isBuckInitialized = true;
+
+    setAsicReset(true);
+    vTaskDelay(pdMS_TO_TICKS(250));
+
+    SERIAL_clear_buffer();
+    m_chipsDetected = m_asics->init(m_asicFrequency, m_asicCount, m_asicMaxDifficulty, m_vrFrequency);
+    if (!m_chipsDetected) {
+        ESP_LOGE(TAG, "error initializing asics!");
+        return false;
+    }
+
+    int maxBaud = m_asics->setMaxBaud();
+    vTaskDelay(pdMS_TO_TICKS(500));
+    SERIAL_set_baud(maxBaud);
+    SERIAL_clear_buffer();
+
+    vTaskDelay(pdMS_TO_TICKS(500));
+
+    if (!setVoltage(static_cast<float>(m_asicVoltageMillis) / 1000.0f)) {
+        ESP_LOGE(TAG, "Failed to set final voltage");
+        return false;
+    }
+
+    m_isInitialized = true;
+    return true;
+}
+
+bool NerdQaxePlus2::setVoltage(float core_voltage)
+{
+    if (!m_hasRev7TPS546) {
+        return NerdQaxePlus::setVoltage(core_voltage);
+    }
+
+    if (!validateVoltage(core_voltage)) {
+        return false;
+    }
+
+    if (core_voltage == 0.0f) {
+        ESP_LOGW(TAG, "Disable ASIC voltage");
+        bool result = m_tps->disable_vout();
+        VREG_disable();
+        return result;
+    }
+
+    VREG_enable();
+    vTaskDelay(pdMS_TO_TICKS(20));
+
+    ESP_LOGI(TAG, "Set ASIC voltage = %.3fV", core_voltage);
+    return m_tps->set_vout(core_voltage);
 }
 
 float NerdQaxePlus2::getTemperature(int index) {

--- a/main/boards/nerdqaxeplus2.h
+++ b/main/boards/nerdqaxeplus2.h
@@ -6,8 +6,19 @@
 #include "nerdqaxeplus.h"
 
 class NerdQaxePlus2 : public NerdQaxePlus {
+  private:
+    bool m_hasRev7TPS546 = false;
+    uint16_t m_rev7VoltageDomains = 2;
+
+    void applyRev7Profile();
+    void selectRev7BuckConverter();
+    bool probeRev7Buck();
+
   public:
     NerdQaxePlus2();
+    bool initBoard() override;
+    bool initAsics() override;
+    bool setVoltage(float core_voltage) override;
     float getTemperature(int index);
-    virtual void requestChipTemps();
+    void requestChipTemps() override;
 };


### PR DESCRIPTION
## Summary
- adds runtime Rev7/TPS546 detection to the existing NerdQAxe++ (`NERDQAXEPLUS2`) board path
- introduces a common `BuckConverter` interface used by TPS53647/TPS53667 and the rev7 TPS546 wrapper
- keeps shared NerdAxe TPS546 code untouched by adding a rev7-local TPS546 driver
- passively probes TPS546 over I2C without toggling VREG, then applies the Rev7 power profile only when the probe succeeds
- defaults fresh Rev7/TPS546 config to PID fan control without overwriting a saved user fan mode

## Validation
- `BOARD=NERDQAXEPLUS2 idf.py build`
- `git diff --check upstream/develop...HEAD`
- flashed and ran on connected Rev7/TPS546 hardware before the passive-probe cleanup: TPS546 detected, board version 502, PID fan mode active, 4/4 ASICs detected, accepted pool shares, and TPS546 status bytes remained `00`