### PR TITLE
fix: resume STA reconnect after WiFi scan timeout

### DIFF
--- a/main/network/connect.cpp
+++ b/main/network/connect.cpp
@@ -367,6 +367,8 @@ esp_err_t wifi_scan(wifi_ap_record_simple_t *ap_records, uint16_t *ap_count)
     if (s_is_scanning) {
         ESP_LOGE(TAG, "WiFi scan timeout");
         s_is_scanning = false;
+        s_scan_suppress_reconnect = false;
+        if (s_has_ssid) esp_wifi_connect();
         return ESP_ERR_TIMEOUT;
     }
 

--- a/test/static_wifi_scan_cleanup_test.py
+++ b/test/static_wifi_scan_cleanup_test.py
@@ -1,0 +1,32 @@
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    brace_start = source.index("{", start)
+    depth = 0
+    for index in range(brace_start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_start:index + 1]
+    raise AssertionError(f"Could not find body for {signature}")
+
+
+def test_wifi_scan_timeout_resumes_sta_reconnect_attempts() -> None:
+    source = (REPO / "main/network/connect.cpp").read_text()
+    body = _function_body(source, "esp_err_t wifi_scan")
+
+    timeout_log = body.index('ESP_LOGE(TAG, "WiFi scan timeout")')
+    timeout_return = body.index("return ESP_ERR_TIMEOUT", timeout_log)
+    timeout_branch = body[timeout_log:timeout_return]
+
+    assert "s_is_scanning = false;" in timeout_branch
+    assert "s_scan_suppress_reconnect = false;" in timeout_branch
+    assert "if (s_has_ssid) esp_wifi_connect();" in timeout_branch


### PR DESCRIPTION
## Summary
- Restores `s_scan_suppress_reconnect` on the WiFi scan timeout path
- Reconnects STA after timeout when an SSID is configured, matching the other scan exit paths
- Adds a static regression check for the timeout cleanup path

Closes #633

## Why
`wifi_scan()` disconnects STA and suppresses reconnect attempts while the scan runs. The scan-start failure path and the normal success path both restore reconnect state, but the timeout path returned without doing so. If a scan timed out, future reconnect handling could remain suppressed.

## Local verification
- `python3` minimal static test runner for:
  - `test/static_wifi_scan_cleanup_test.py`
  - `test/static_can_patch_body_test.py`
  - `test/static_cors_otp_test.py`
  - result: `Ran 4 static checks`
- `git diff --check`

## Build note
I attempted to verify whether the local Docker ESP-IDF builder image was available, but Docker socket access timed out in this environment:

`timeout 10 docker image inspect esp-idf-builder` -> exit 124

So this PR is verified with focused static regression checks only; I am not claiming a firmware build here.
