### PR TITLE
fix: bound CAN job ids before job lookup

### DIFF
--- a/main/tasks/asic_jobs.h
+++ b/main/tasks/asic_jobs.h
@@ -58,6 +58,10 @@ public:
 
     void storeJob(bm_job *next_job, uint8_t asic_job_id) {
         PThreadGuard g(m_validJobsLock);
+        if (asic_job_id >= MAX_ASIC_JOBS) {
+            free_bm_job(next_job);
+            return;
+        }
         // if a slot was used before free it
         if (m_activeJobs[asic_job_id]) {
             free_bm_job(m_activeJobs[asic_job_id]);
@@ -68,6 +72,9 @@ public:
 
     bm_job *getClone(uint8_t asic_job_id) {
         PThreadGuard g(m_validJobsLock);
+        if (asic_job_id >= MAX_ASIC_JOBS) {
+            return NULL;
+        }
         // check if we have a job with this job id
         if (!m_activeJobs[asic_job_id]) {
             return NULL;

--- a/main/tasks/can_master_task.cpp
+++ b/main/tasks/can_master_task.cpp
@@ -286,6 +286,11 @@ static void handle_nonce(Board *board, uint8_t slave_id, const uint8_t *buf, siz
 
     ESP_LOGI(TAG, "slave %d nonce=%08lX job_id=%02X", slave_id, nonce, job_id);
 
+    if (job_id >= MAX_ASIC_JOBS) {
+        ESP_LOGW(TAG, "slave %d out-of-range job_id 0x%02X", slave_id, job_id);
+        return;
+    }
+
     bm_job *job = slaveAsicJobs[slave_id].getClone(job_id);
     if (!job) {
         ESP_LOGW(TAG, "slave %d unknown job_id 0x%02X", slave_id, job_id);

--- a/test/static_can_job_bounds_test.py
+++ b/test/static_can_job_bounds_test.py
@@ -1,0 +1,54 @@
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+
+
+def _read(relative_path: str) -> str:
+    return (REPO / relative_path).read_text()
+
+
+def _function_body(source: str, signature: str) -> str:
+    start = source.index(signature)
+    brace_start = source.index("{", start)
+    depth = 0
+    for index in range(brace_start, len(source)):
+        char = source[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return source[brace_start:index + 1]
+    raise AssertionError(f"Could not find body for {signature}")
+
+
+def test_asic_jobs_reject_out_of_range_job_ids_before_indexing() -> None:
+    source = _read("main/tasks/asic_jobs.h")
+
+    for signature in (
+        "void storeJob(bm_job *next_job, uint8_t asic_job_id)",
+        "bm_job *getClone(uint8_t asic_job_id)",
+    ):
+        body = _function_body(source, signature)
+        guard_pos = body.index("asic_job_id >= MAX_ASIC_JOBS")
+        index_pos = body.index("m_activeJobs[asic_job_id]")
+        assert guard_pos < index_pos
+
+    store_body = _function_body(source, "void storeJob(bm_job *next_job, uint8_t asic_job_id)")
+    guard_start = store_body.index("asic_job_id >= MAX_ASIC_JOBS")
+    guard_end = store_body.index("// if a slot was used before free it")
+    guard_block = store_body[guard_start:guard_end]
+    assert "free_bm_job(next_job);" in guard_block
+    assert "return;" in guard_block
+
+
+def test_can_master_drops_out_of_range_nonce_job_id_before_lookup() -> None:
+    source = _read("main/tasks/can_master_task.cpp")
+    body = _function_body(source, "static void handle_nonce")
+
+    guard_pos = body.index("job_id >= MAX_ASIC_JOBS")
+    lookup_pos = body.index("slaveAsicJobs[slave_id].getClone(job_id)")
+    assert guard_pos < lookup_pos
+    assert "out-of-range job_id" in body[guard_pos:lookup_pos]
+    assert "return;" in body[guard_pos:lookup_pos]


### PR DESCRIPTION
## Summary
- Drops CAN nonce frames with `job_id >= MAX_ASIC_JOBS` before job lookup
- Adds defensive bounds checks inside `AsicJobs::storeJob()` and `AsicJobs::getClone()` before indexing `m_activeJobs`
- Frees an invalid `storeJob()` input job to avoid leaking ownership on rejected IDs
- Adds a static regression check for the bounds checks

Closes #630

## Why
CAN nonce payloads carry `job_id` as an 8-bit value, while `m_activeJobs` has `MAX_ASIC_JOBS` (128) entries. Values 128..255 should be treated as malformed/out-of-range input rather than indexing outside the array.

## Local verification
- `python3` minimal static test runner for:
  - `test/static_can_job_bounds_test.py`
  - `test/static_can_patch_body_test.py`
  - `test/static_cors_otp_test.py`
  - result: `Ran 5 static checks`
- `git diff --check`

## Build note
I attempted to verify whether the local Docker ESP-IDF builder image was available, but Docker socket access timed out in this environment:

`timeout 10 docker image inspect esp-idf-builder` -> exit 124

So this PR is verified with focused static regression checks only; I am not claiming a firmware build here.
