### PR TITLE
Add SoloLuck to pool quicklinks

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/home.quicklinks.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.quicklinks.ts
@@ -266,6 +266,14 @@ const POOLS: PoolMeta[] = [
     faviconPath: '/favicon.ico',
   },
   {
+    id: 'sololuck',
+    name: 'sololuck.io',
+    match: (h) => h.includes('sololuck.io'),
+    quickLink: (a) => `https://sololuck.io/users/${a}`,
+    faviconHost: 'sololuck.io',
+    faviconPath: '/favicon.svg',
+  },
+  {
     id: 'powermining',
     name: 'powermining.io',
     match: (h) => h.includes('powermining.io'),


### PR DESCRIPTION
Adds **SoloLuck** to the pool quicklink registry, so NerdQAxe++ owners pointed at it get a working stats link and pool icon from the Home page.

- `match`: any host containing `sololuck.io` (covers `stratum.sololuck.io`).
- `quickLink`: `https://sololuck.io/users/<address>` — the per-address stats page (returns 200).
- `faviconPath`: `/favicon.svg` on `sololuck.io`.

SoloLuck is a public true-solo Bitcoin pool (ckpool) hosted in Jakarta for low-latency mining across Asia: non-custodial, mine to your own address, 0%. Site: https://sololuck.io · Setup: https://sololuck.io/setup

Placed next to the other small solo pools (atlaspool). No other files touched.