### PR TITLE
Add SV2 "require authentication" per-pool option

### DIFF
--- a/main/http_server/axe-os/src/app/models/ISettingsV2.ts
+++ b/main/http_server/axe-os/src/app/models/ISettingsV2.ts
@@ -24,6 +24,7 @@ export interface ISettingsV2Pool {
     protocol: number;
     sv2AuthorityPubkey: string;
     sv2ChannelType: number;
+    sv2RequireAuth: boolean;
     coinbaseVerifyMode: number;
     coinbaseMaxFee: number;
     coinbaseVerifyForce: boolean;

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.html
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.html
@@ -163,6 +163,10 @@
                                     <small>{{ 'SETTINGS.SV2_AUTHORITY_PUBKEY_HINT' | translate }}</small>
                                 </div>
                             </div>
+                            <div class="form-row">
+                                <nb-checkbox formControlName="sv2RequireAuth">{{ 'SETTINGS.SV2_REQUIRE_AUTH' | translate }}</nb-checkbox><br />
+                                <small>{{ 'SETTINGS.SV2_REQUIRE_AUTH_HINT' | translate }}</small>
+                            </div>
                         </ng-container>
                         <div class="form-row" *ngIf="form.controls['stratumProtocol'].value === 0">
                             <nb-checkbox formControlName="stratumTLS">{{ 'MINING.STRATUM_TLS' | translate}}</nb-checkbox>
@@ -274,6 +278,10 @@
                                     <input nbInput id="fallbackSv2AuthorityPubkey" type="text" formControlName="fallbackSv2AuthorityPubkey" /><br />
                                     <small>{{ 'SETTINGS.SV2_AUTHORITY_PUBKEY_HINT' | translate }}</small>
                                 </div>
+                            </div>
+                            <div class="form-row">
+                                <nb-checkbox formControlName="fallbackSv2RequireAuth">{{ 'SETTINGS.SV2_REQUIRE_AUTH' | translate }}</nb-checkbox><br />
+                                <small>{{ 'SETTINGS.SV2_REQUIRE_AUTH_HINT' | translate }}</small>
                             </div>
                         </ng-container>
                         <div class="form-row" *ngIf="form.controls['fallbackStratumProtocol'].value === 0">

--- a/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
+++ b/main/http_server/axe-os/src/app/pages/edit/edit.component.ts
@@ -211,6 +211,8 @@ export class EditComponent implements OnInit {
           fallbackSv2AuthorityPubkey: [info.pools[1].sv2AuthorityPubkey ?? ''],
           sv2ChannelType: [info.pools[0].sv2ChannelType ?? 0],                      // 0 = Extended, 1 = Standard
           fallbackSv2ChannelType: [info.pools[1].sv2ChannelType ?? 0],
+          sv2RequireAuth: [info.pools[0].sv2RequireAuth ?? false],
+          fallbackSv2RequireAuth: [info.pools[1].sv2RequireAuth ?? false],
 
           poolMode: [info.poolMode ?? 0, [Validators.required]],                   // 0 = Failover, 1 = Dual
           poolBalance: [info.poolBalance ?? 50, [                                   // Anteil PRIMARY in %
@@ -371,6 +373,7 @@ export class EditComponent implements OnInit {
       protocol: f.stratumProtocol,
       sv2AuthorityPubkey: f.sv2AuthorityPubkey,
       sv2ChannelType: f.sv2ChannelType,
+      sv2RequireAuth: !!f.sv2RequireAuth,
       coinbaseVerifyMode: f.coinbaseVerifyMode,
       coinbaseMaxFee: f.coinbaseMaxFee,
       coinbaseVerifyForce: !!f.coinbaseVerifyForce,
@@ -386,6 +389,7 @@ export class EditComponent implements OnInit {
       protocol: f.fallbackStratumProtocol,
       sv2AuthorityPubkey: f.fallbackSv2AuthorityPubkey,
       sv2ChannelType: f.fallbackSv2ChannelType,
+      sv2RequireAuth: !!f.fallbackSv2RequireAuth,
       coinbaseVerifyMode: f.fallbackCoinbaseVerifyMode,
       coinbaseMaxFee: f.fallbackCoinbaseMaxFee,
       coinbaseVerifyForce: !!f.fallbackCoinbaseVerifyForce,
@@ -671,6 +675,7 @@ export class EditComponent implements OnInit {
       ['stratumProtocol',         'fallbackStratumProtocol'],
       ['sv2AuthorityPubkey',      'fallbackSv2AuthorityPubkey'],
       ['sv2ChannelType',          'fallbackSv2ChannelType'],
+      ['sv2RequireAuth',          'fallbackSv2RequireAuth'],
       ['coinbaseVerifyMode',      'fallbackCoinbaseVerifyMode'],
       ['coinbaseMaxFee',          'fallbackCoinbaseMaxFee'],
       ['coinbaseVerifyForce',     'fallbackCoinbaseVerifyForce'],

--- a/main/http_server/axe-os/src/assets/i18n/de.json
+++ b/main/http_server/axe-os/src/assets/i18n/de.json
@@ -174,6 +174,8 @@
     "STRATUM_V2": "Stratum V2",
     "SV2_AUTHORITY_PUBKEY": "SV2 Authority Public Key",
     "SV2_AUTHORITY_PUBKEY_HINT": "Optionaler Base58-Schluessel zur Verifizierung des Pool-Zertifikats.",
+    "SV2_REQUIRE_AUTH": "Authentifizierung erforderlich",
+    "SV2_REQUIRE_AUTH_HINT": "Nur verbinden, wenn das Server-Zertifikat gegen den oben angegebenen Authority Public Key verifiziert wird. Ist dies aktiviert und kein Schluessel gesetzt, verbindet der Miner nicht.",
     "SV2_CHANNEL_TYPE": "SV2 Kanal-Typ",
     "SV2_CHANNEL_EXTENDED": "Extended Channel",
     "SV2_CHANNEL_STANDARD": "Standard Channel (experimentell)",

--- a/main/http_server/axe-os/src/assets/i18n/en.json
+++ b/main/http_server/axe-os/src/assets/i18n/en.json
@@ -174,6 +174,8 @@
     "STRATUM_V2": "Stratum V2",
     "SV2_AUTHORITY_PUBKEY": "SV2 Authority Public Key",
     "SV2_AUTHORITY_PUBKEY_HINT": "Optional Base58-encoded key for server certificate verification.",
+    "SV2_REQUIRE_AUTH": "Require Authentication",
+    "SV2_REQUIRE_AUTH_HINT": "Refuse to connect unless the server certificate is verified against the authority public key above. When enabled without a key set, the miner will not connect.",
     "SV2_CHANNEL_TYPE": "SV2 Channel Type",
     "SV2_CHANNEL_EXTENDED": "Extended Channel",
     "SV2_CHANNEL_STANDARD": "Standard Channel (experimental)",

--- a/main/http_server/axe-os/src/assets/i18n/es.json
+++ b/main/http_server/axe-os/src/assets/i18n/es.json
@@ -174,6 +174,8 @@
     "STRATUM_V2": "Stratum V2",
     "SV2_AUTHORITY_PUBKEY": "Clave pública SV2 Authority",
     "SV2_AUTHORITY_PUBKEY_HINT": "Clave opcional codificada en Base58 para verificación del certificado del servidor.",
+    "SV2_REQUIRE_AUTH": "Requerir autenticación",
+    "SV2_REQUIRE_AUTH_HINT": "No conectar a menos que el certificado del servidor se verifique con la clave pública de autoridad anterior. Si se activa sin una clave configurada, el minero no se conectará.",
     "SV2_CHANNEL_TYPE": "Tipo de canal SV2",
     "SV2_CHANNEL_EXTENDED": "Canal extendido",
     "SV2_CHANNEL_STANDARD": "Canal estándar (experimental)",

--- a/main/http_server/axe-os/src/assets/i18n/fr.json
+++ b/main/http_server/axe-os/src/assets/i18n/fr.json
@@ -174,6 +174,8 @@
     "STRATUM_V2": "Stratum V2",
     "SV2_AUTHORITY_PUBKEY": "Clé publique SV2 Authority",
     "SV2_AUTHORITY_PUBKEY_HINT": "Clé optionnelle encodée en Base58 pour la vérification du certificat du serveur.",
+    "SV2_REQUIRE_AUTH": "Exiger l'authentification",
+    "SV2_REQUIRE_AUTH_HINT": "Refuser de se connecter sauf si le certificat du serveur est vérifié avec la clé publique d'autorité ci-dessus. Si activé sans clé définie, le mineur ne se connectera pas.",
     "SV2_CHANNEL_TYPE": "Type de canal SV2",
     "SV2_CHANNEL_EXTENDED": "Canal étendu",
     "SV2_CHANNEL_STANDARD": "Canal standard (expérimental)",

--- a/main/http_server/axe-os/src/assets/i18n/it.json
+++ b/main/http_server/axe-os/src/assets/i18n/it.json
@@ -174,6 +174,8 @@
     "STRATUM_V2": "Stratum V2",
     "SV2_AUTHORITY_PUBKEY": "Chiave pubblica SV2 Authority",
     "SV2_AUTHORITY_PUBKEY_HINT": "Chiave facoltativa codificata in Base58 per la verifica del certificato del server.",
+    "SV2_REQUIRE_AUTH": "Richiedi autenticazione",
+    "SV2_REQUIRE_AUTH_HINT": "Rifiuta la connessione a meno che il certificato del server non sia verificato con la chiave pubblica di autorità sopra. Se abilitato senza una chiave impostata, il miner non si connetterà.",
     "SV2_CHANNEL_TYPE": "Tipo di canale SV2",
     "SV2_CHANNEL_EXTENDED": "Canale esteso",
     "SV2_CHANNEL_STANDARD": "Canale standard (sperimentale)",

--- a/main/http_server/axe-os/src/assets/i18n/pl.json
+++ b/main/http_server/axe-os/src/assets/i18n/pl.json
@@ -174,6 +174,8 @@
     "STRATUM_V2": "Stratum V2",
     "SV2_AUTHORITY_PUBKEY": "Publiczny klucz SV2 Authority",
     "SV2_AUTHORITY_PUBKEY_HINT": "Opcjonalny klucz zakodowany w Base58 do weryfikacji certyfikatu serwera.",
+    "SV2_REQUIRE_AUTH": "Wymagaj uwierzytelniania",
+    "SV2_REQUIRE_AUTH_HINT": "Nie łącz, jeśli certyfikat serwera nie zostanie zweryfikowany za pomocą powyższego klucza publicznego urzędu. Po włączeniu bez ustawionego klucza koparka się nie połączy.",
     "SV2_CHANNEL_TYPE": "Typ kanału SV2",
     "SV2_CHANNEL_EXTENDED": "Kanał rozszerzony",
     "SV2_CHANNEL_STANDARD": "Kanał standardowy (eksperymentalny)",

--- a/main/http_server/axe-os/src/assets/i18n/ro.json
+++ b/main/http_server/axe-os/src/assets/i18n/ro.json
@@ -174,6 +174,8 @@
     "STRATUM_V2": "Stratum V2",
     "SV2_AUTHORITY_PUBKEY": "Cheie publică SV2 Authority",
     "SV2_AUTHORITY_PUBKEY_HINT": "Cheie opțională codificată în Base58 pentru verificarea certificatului serverului.",
+    "SV2_REQUIRE_AUTH": "Necesită autentificare",
+    "SV2_REQUIRE_AUTH_HINT": "Refuză conectarea dacă certificatul serverului nu este verificat cu cheia publică de autoritate de mai sus. Dacă este activat fără o cheie setată, minerul nu se va conecta.",
     "SV2_CHANNEL_TYPE": "Tip canal SV2",
     "SV2_CHANNEL_EXTENDED": "Canal extins",
     "SV2_CHANNEL_STANDARD": "Canal standard (experimental)",

--- a/main/http_server/v2/handler_v2_settings.cpp
+++ b/main/http_server/v2/handler_v2_settings.cpp
@@ -93,6 +93,7 @@ esp_err_t GET_V2_settings(httpd_req_t *req)
             pool["sv2AuthorityPubkey"] = sv2 ? sv2 : "";
             safe_free(sv2);
             pool["sv2ChannelType"]   = Config::getSV2ChannelType();
+            pool["sv2RequireAuth"]   = Config::isSV2RequireAuth();
             pool["coinbaseVerifyMode"]  = Config::getCoinbaseVerifyMode(0);
             pool["coinbaseMaxFee"]      = Config::getCoinbaseMaxFee(0) / 10.0f;
             pool["coinbaseVerifyForce"] = Config::getCoinbaseVerifyForce(0);
@@ -115,6 +116,7 @@ esp_err_t GET_V2_settings(httpd_req_t *req)
             pool["sv2AuthorityPubkey"] = sv2 ? sv2 : "";
             safe_free(sv2);
             pool["sv2ChannelType"]   = Config::getFallbackSV2ChannelType();
+            pool["sv2RequireAuth"]   = Config::isFallbackSV2RequireAuth();
             pool["coinbaseVerifyMode"]  = Config::getCoinbaseVerifyMode(1);
             pool["coinbaseMaxFee"]      = Config::getCoinbaseMaxFee(1) / 10.0f;
             pool["coinbaseVerifyForce"] = Config::getCoinbaseVerifyForce(1);
@@ -347,6 +349,10 @@ esp_err_t PATCH_V2_settings(httpd_req_t *req)
             if (pool["sv2ChannelType"].is<uint16_t>()) {
                 if (i == 0) Config::setSV2ChannelType(pool["sv2ChannelType"].as<uint16_t>());
                 else        Config::setFallbackSV2ChannelType(pool["sv2ChannelType"].as<uint16_t>());
+            }
+            if (pool["sv2RequireAuth"].is<bool>()) {
+                if (i == 0) Config::setSV2RequireAuth(pool["sv2RequireAuth"].as<bool>());
+                else        Config::setFallbackSV2RequireAuth(pool["sv2RequireAuth"].as<bool>());
             }
 
             // Coinbase verification

--- a/main/nvs_config.h
+++ b/main/nvs_config.h
@@ -107,9 +107,11 @@
 #define NVS_CONFIG_STRATUM_PROTOCOL "sv2_proto"
 #define NVS_CONFIG_SV2_AUTHORITY_PUBKEY "sv2_auth_pk"
 #define NVS_CONFIG_SV2_CHANNEL_TYPE "sv2_chan_type"
+#define NVS_CONFIG_SV2_REQUIRE_AUTH "sv2_reqauth"
 #define NVS_CONFIG_FB_STRATUM_PROTOCOL "fbsv2_proto"
 #define NVS_CONFIG_FB_SV2_AUTHORITY_PUBKEY "fbsv2_authpk"
 #define NVS_CONFIG_FB_SV2_CHANNEL_TYPE "fbsv2_chtype"
+#define NVS_CONFIG_FB_SV2_REQUIRE_AUTH "fbsv2_reqauth"
 
 #if defined(CONFIG_FAN_MODE_MANUAL)
 #define CONFIG_AUTO_FAN_SPEED_VALUE 0
@@ -318,6 +320,10 @@ namespace Config {
     inline void setSV2ChannelType(uint16_t value) { cfgSetU16(NVS_CONFIG_SV2_CHANNEL_TYPE, value); }
     inline uint16_t getFallbackSV2ChannelType() { return cfgGetU16(NVS_CONFIG_FB_SV2_CHANNEL_TYPE, 0); }
     inline void setFallbackSV2ChannelType(uint16_t value) { cfgSetU16(NVS_CONFIG_FB_SV2_CHANNEL_TYPE, value); }
+    inline bool isSV2RequireAuth() { return cfgGetU16(NVS_CONFIG_SV2_REQUIRE_AUTH, 0) != 0; }
+    inline void setSV2RequireAuth(bool value) { cfgSetU16(NVS_CONFIG_SV2_REQUIRE_AUTH, value ? 1 : 0); }
+    inline bool isFallbackSV2RequireAuth() { return cfgGetU16(NVS_CONFIG_FB_SV2_REQUIRE_AUTH, 0) != 0; }
+    inline void setFallbackSV2RequireAuth(bool value) { cfgSetU16(NVS_CONFIG_FB_SV2_REQUIRE_AUTH, value ? 1 : 0); }
 
     // ---- Boolean Setters ----
     inline void setFlipScreen(bool value) { cfgSetU16(NVS_CONFIG_FLIP_SCREEN, value ? 1 : 0); }

--- a/main/stratum/stratum_task_v2.cpp
+++ b/main/stratum/stratum_task_v2.cpp
@@ -51,6 +51,13 @@ StratumTransport *StratumTaskV2::selectTransport()
         ESP_LOGW(m_tag, "No authority pubkey configured, server identity will not be verified");
     }
 
+    // Whether this pool requires the server certificate to be verified. Defaults to
+    // false so existing configs keep today's connect-unauthenticated behavior.
+    bool require_auth = m_config->isPrimary()
+        ? Config::isSV2RequireAuth()
+        : Config::isFallbackSV2RequireAuth();
+    m_noiseTransport.setRequireAuth(require_auth);
+
     return &m_noiseTransport;
 }
 

--- a/main/stratum/stratum_transport_noise.cpp
+++ b/main/stratum/stratum_transport_noise.cpp
@@ -33,6 +33,13 @@ void NoiseStratumTransport::clearAuthorityPubkey()
 
 bool NoiseStratumTransport::connect(const char *host, const char *ip, uint16_t port)
 {
+    // When authentication is required but no authority pubkey is configured, refuse
+    // rather than fall through to an encrypted-but-unverified connection.
+    if (m_require_auth && !m_has_authority_pubkey) {
+        ESP_LOGE(TAG, "SV2 authentication required but no authority pubkey configured; refusing to connect");
+        return false;
+    }
+
     // First establish plain TCP connection via base class
     if (!StratumTransport::connect(host, ip, port)) {
         return false;

--- a/main/stratum/stratum_transport_noise.h
+++ b/main/stratum/stratum_transport_noise.h
@@ -26,6 +26,9 @@ class NoiseStratumTransport : public StratumTransport {
     void setAuthorityPubkey(const uint8_t pubkey[32]);
     void clearAuthorityPubkey();
 
+    /// When set, refuse to connect unless an authority pubkey is configured.
+    void setRequireAuth(bool require) { m_require_auth = require; }
+
     /// Get the underlying esp_transport handle (needed for Noise I/O).
     esp_transport_handle_t getTransportHandle() { return m_t; }
 
@@ -36,4 +39,5 @@ class NoiseStratumTransport : public StratumTransport {
     sv2_noise_ctx_t *m_noise_ctx = nullptr;
     uint8_t m_authority_pubkey[32];
     bool m_has_authority_pubkey = false;
+    bool m_require_auth = false;
 };


### PR DESCRIPTION
## Summary

By default SV2 connects encrypted but unauthenticated. With no authority pubkey set, the Noise_NX handshake takes the "no authority pubkey" branch and mines anyway, so the man-in-the-middle warning shown on the Authority Pubkey field can't be acted on.

This adds a per-pool "Require Authentication" toggle. When it's on and no authority pubkey is set, `NoiseStratumTransport::connect()` refuses instead of falling through to an unverifiable server. The verify path is unchanged, and the default is off so existing configs behave exactly as before.

## Background

This is a port of bitaxeorg/ESP-Miner#1796, which addresses the second gap in bitaxeorg/ESP-Miner#1786. This repo inherited both gaps near-verbatim, so the same fix applies here.

I deliberately matched this repo's own conventions rather than importing bitaxe's structure:

- NVS: `#define` string keys (`sv2_reqauth` / `fbsv2_reqauth`) with inline `Config::` accessors, following the existing `isStratumTLS` u16-backed-bool pattern.
- REST: the `pools[]` array in the v2 settings handler (`sv2RequireAuth` per pool), not bitaxe's flat prefixed fields.
- Frontend: Nebular `nb-checkbox` next to the Authority Pubkey field, i18n keys under `SETTINGS`.

Happy to change any of these if you'd prefer them shaped differently. The reason I kept them local-style is so this doesn't fight your tree the next time you sync from upstream.

## Changes

- New per-pool NVS bool `sv2_reqauth` / `fbsv2_reqauth`, default false.
- `StratumTaskV2::selectTransport()` reads the per-pool flag and passes it to the transport; `NoiseStratumTransport::connect()` refuses when auth is required but no pubkey resolves.
- REST v2 settings expose `sv2RequireAuth` per pool (GET + PATCH).
- Frontend checkbox with tooltip, plus translations in all seven locales.

## Scope

Just the enforcement toggle. The validity-window check and boot-time SNTP clock from #1786 (parsed `valid_from` / `not_valid_after` are never compared to a wall clock, and no clock source exists yet) are not here.

## Testing

- AxeOS production build passes (`ng build --configuration=production`).
- Full firmware build and link passes under ESP-IDF v5.4 for `BOARD=NERDQAXEPLUS` (esp32s3); `esp-miner.bin` generated, 21% app partition free. Not flashed to hardware yet.
