### PR TITLE
update quicklinks to ckpool global graphical stats site

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/home.quicklinks.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.quicklinks.ts
@@ -198,27 +198,13 @@ const POOLS: PoolMeta[] = [
     match: (h) => h.includes('ocean.xyz'),
     quickLink: (a) => `https://ocean.xyz/stats/${a}`,
   },
-  // CKPool variants
+  // CKPool have now a global stats site
   {
-    id: 'ckpool-eusolo',
-    name: 'eusolo*.ckpool.org',
-    match: (h) => /^eusolo[46]?\.(ckpool\.org)$/.test(h),
-    quickLink: (a) => `https://eusolostats.ckpool.org/users/${a}`,
-    iconUrl: '/assets/pools/ck-eupool.svg',
-  },
-  {
-    id: 'ckpool-solo',
-    name: 'solo*.ckpool.org',
-    match: (h) => /^solo[46]?\.(ckpool\.org)$/.test(h),
-    quickLink: (a) => `https://solostats.ckpool.org/users/${a}`,
+    id: 'ckpool',
+    name: 'ckpool.org',
+    match: (h) => h.includes('ckpool.org'),
+    quickLink: (a) => `https://stats.ckpool.org/users/${a}`,
     iconUrl: '/assets/pools/ck-pool.svg',
-  },
-  {
-    id: 'ckpool-ausolo',
-    name: 'ausolo*.ckpool.org',
-    match: (h) => /^ausolo[46]?\.(ckpool\.org)$/.test(h),
-    quickLink: (a) => `https://ausolostats.ckpool.org/users/${a}`,
-    iconUrl: '/assets/pools/ck-aupool.svg',
   },
   {
     id: 'noderunners',

--- a/main/http_server/axe-os/src/assets/pools/ck-pool.svg
+++ b/main/http_server/axe-os/src/assets/pools/ck-pool.svg
@@ -1,16 +1,63 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="100%" height="100%" viewBox="0 0 800 800" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <g id="Layer_2" transform="matrix(16.6667,0,0,16.6667,0,0)">
-        <g id="invisible_box">
-            <rect x="0" y="0" width="48" height="48" style="fill:none;"/>
-            <rect x="0" y="0" width="48" height="48" style="fill:none;"/>
-            <rect x="0" y="0" width="48" height="48" style="fill:none;"/>
-        </g>
-        <g transform="matrix(0.101679,0,0,0.101679,-19.3763,-22.3997)">
-            <g transform="matrix(570.81,0,0,570.81,651.499,657.662)">
-            </g>
-            <text x="176.014px" y="657.662px" style="font-family:'DINCondensed-Bold', 'DIN Condensed';font-weight:700;font-stretch:condensed;font-size:570.81px;fill:rgb(255,153,0);">CK</text>
-        </g>
-    </g>
-</svg>
+<svg
+   width="100%"
+   height="100%"
+   viewBox="0 0 800 800"
+   version="1.1"
+   xml:space="preserve"
+   style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;"
+   id="svg16"
+   sodipodi:docname="ck-pool.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"><defs
+   id="defs20" /><sodipodi:namedview
+   id="namedview18"
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1.0"
+   inkscape:showpageshadow="2"
+   inkscape:pageopacity="0.0"
+   inkscape:pagecheckerboard="0"
+   inkscape:deskcolor="#d1d1d1"
+   showgrid="false"
+   inkscape:zoom="1.18"
+   inkscape:cx="597.88136"
+   inkscape:cy="483.47458"
+   inkscape:window-width="3840"
+   inkscape:window-height="2071"
+   inkscape:window-x="-9"
+   inkscape:window-y="-9"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg16" />
+    
+<circle
+   style="fill:#ff9900;fill-opacity:1;stroke:none;stroke-width:2.01621;stroke-linecap:square;paint-order:stroke markers fill"
+   id="path1259"
+   cx="400"
+   cy="400"
+   r="390" /><text
+   xml:space="preserve"
+   style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:268.298px;line-height:1.25;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#f2ffff;fill-opacity:1;stroke:#000000;stroke-width:1.65724;stroke-dasharray:none;stroke-opacity:1"
+   x="187.68736"
+   y="679.61609"
+   id="text3321"
+   transform="scale(1.032164,0.96883829)"><tspan
+     sodipodi:role="line"
+     id="tspan3319"
+     x="187.68736"
+     y="679.61609"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-family:Arial;-inkscape-font-specification:'Arial Bold';fill:#f2ffff;fill-opacity:1;stroke:#000000;stroke-width:1.65724;stroke-dasharray:none;stroke-opacity:1">CK</tspan></text><text
+   xml:space="preserve"
+   style="font-size:354.723px;line-height:1.25;font-family:'Komika Axis';-inkscape-font-specification:'Komika Axis';stroke:#000000;stroke-width:2;stroke-dasharray:none;stroke-opacity:1"
+   x="254.26961"
+   y="383.12372"
+   id="text4101"
+   transform="scale(1.0634931,0.9402976)"><tspan
+     sodipodi:role="line"
+     id="tspan4099"
+     x="254.26961"
+     y="383.12372"
+     style="fill:#ffffff;fill-opacity:1;stroke:#000000;stroke-width:2;stroke-dasharray:none;stroke-opacity:1">₿</tspan></text></svg>


### PR DESCRIPTION
CKPool has taken down the country-specific graphical statistics websites. All statistics are now available at https://stats.ckpool.org

Add a new ckpool icon, based on favicon from https://solo.ckpool.org

<img width="542" height="267" alt="ckpool" src="https://github.com/user-attachments/assets/2e91bbcb-d3e1-4b10-9d7c-93d79f4bcfbe" />
