### PR TITLE
gitignore: ignore monitoring/data volume directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,9 @@ nbproject
 # Ignore gitlab ci specific cache folder
 /.cache
 
+# Grafana / InfluxDB volumes created by monitoring/create_data_directories.sh
+monitoring/data/
+
 components/components/*
 config.bin
 config.cvs


### PR DESCRIPTION
`monitoring/create_data_directories.sh` creates `./data/influxdb` and
`./data/grafana`, which `monitoring/docker-compose.yml` then bind-mounts as the
InfluxDB and Grafana state directories:

```yaml
volumes:
  - ./data/influxdb:/var/lib/influxdb2
  - ./data/grafana:/var/lib/grafana
```

Following the steps in `monitoring/README.md` therefore leaves every user with
an untracked `monitoring/data/` in `git status`, holding runtime database files
that should never be committed.

This adds `monitoring/data/` to `.gitignore`.

No behaviour change: nothing currently tracked matches the new rule
(`git ls-files monitoring/data/` is empty), so no files are removed from the
index.
