### PR TITLE
fix(web): close unclosed <nb-option> in language selector

### DIFF
--- a/main/http_server/axe-os/src/app/@i18n/container/language-selector/language-selector.component.html
+++ b/main/http_server/axe-os/src/app/@i18n/container/language-selector/language-selector.component.html
@@ -36,6 +36,7 @@
     <nb-option value="zh-CN">
       <span class="flag-icon flag-icon-cn"></span>
       简体中文
+    </nb-option>
     <nb-option value="da">
       <span class="flag-icon flag-icon-dk"></span>
       Dansk


### PR DESCRIPTION
The `zh-CN` option added in 49534830 was never closed, so the following `da` option nested inside it and the closing `</nb-select>` became unbalanced.

Angular's template compiler rejects this with:

```
error NG5002: Unexpected closing tag "nb-select". It may happen when the tag has already been closed by another tag.
  main/http_server/axe-os/src/app/@i18n/container/language-selector/language-selector.component.html:43:3
```

This fails the build for every board target, so `develop` cannot currently be built from a clean checkout.

### Why CI did not catch it

`validate.yml` runs only on `pull_request`, and `build.yml` is `workflow_dispatch` (manual), so nothing builds the tip of `develop` after a merge lands.

### Verification

Built `BOARD=NERDQAXEPLUS2` for `esp32s3` before and after: fails with NG5002 without this change, completes with it. The fix restores the tag balance only; no behavioural change to the selector.