### PR TITLE
docs: fix set-target typo and document submodule init

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -36,7 +36,7 @@ First you need to clone the repository and create a local copy of the config fil
 
 ```bash
 # clone repository
-git clone https://github.com/shufps/ESP-Miner-NerdQAxePlus
+git clone --recursive https://github.com/shufps/ESP-Miner-NerdQAxePlus
 
 # change into the cloned repository
 cd ESP-Miner-NerdQAxePlus
@@ -73,8 +73,11 @@ cd docker
 ./build_docker.sh
 cd ..
 
+# only needed if you cloned without --recursive
+git submodule update --init --recursive
+
 export BOARD="NERDQAXEPLUS2"
-./docker/idf.sh set-target esp32-s3
+./docker/idf.sh set-target esp32s3
 
 # after each change on the source code
 ./docker/idf.sh build


### PR DESCRIPTION
Two issues in the build instructions, both hit in order on a fresh clone.

**1. Invalid target name.** The TL;DR uses `set-target esp32-s3`, which is not an accepted target:

```
$ idf.py --list-targets
esp32  esp32s2  esp32c3  esp32s3  esp32c2  esp32c6  esp32h2  esp32p4
```

Sections 3.2 and 3.3 further down the same file already use `esp32s3`, as do `build.yml` and `validate.yml`. Only the TL;DR differs.

**2. Submodule not mentioned.** `components/libsecp256k1/libsecp256k1` is a submodule, but the clone instructions use a plain `git clone` and the word "submodule" does not appear anywhere in the readme. Without it the build aborts during CMake configure:

```
CMake Error at .../component.cmake:317 (message):
  Include directory
  '.../components/libsecp256k1/libsecp256k1/include' is not
  a directory.
```

CI does not hit this because `actions/checkout` is configured with `submodules: recursive`.

`--recursive` on the clone covers new checkouts; the line in the TL;DR covers anyone who already cloned without it.
