### PR TITLE
fix(influx): swap transposed fan1_pwm and fan1_rpm values

### DIFF
--- a/components/influx/influx.cpp
+++ b/components/influx/influx.cpp
@@ -391,7 +391,7 @@ void Influx::write()
             m_stats.accepted, m_stats.not_accepted, m_stats.total_uptime, m_stats.blocks_found,
             m_stats.pwr_vin, m_stats.pwr_iin, m_stats.pwr_pin, m_stats.pwr_vout, m_stats.pwr_iout, m_stats.pwr_pout,
             m_stats.total_blocks_found, m_stats.duplicate_hashes, m_stats.last_ping_rtt, m_stats.recent_ping_loss,
-            m_stats.fan_pwm_0, m_stats.fan_rpm_0, m_stats.fan_rpm_1, m_stats.fan_pwm_1);
+            m_stats.fan_pwm_0, m_stats.fan_rpm_0, m_stats.fan_pwm_1, m_stats.fan_rpm_1);
 
     snprintf(url, sizeof(url), "%s:%d/api/v2/write?bucket=%s&org=%s&precision=s", m_host, m_port, m_bucket,
              m_org);


### PR DESCRIPTION
The format string at `influx.cpp:387` declares the fields in this order:

```
fan0_pwm=%f,fan0_rpm=%f,fan1_pwm=%f,fan1_rpm=%f
```

but the arguments at `:394` supply them in this order:

```
m_stats.fan_pwm_0, m_stats.fan_rpm_0, m_stats.fan_rpm_1, m_stats.fan_pwm_1
```

The last two are transposed, so fan channel 1 reports each value under the other's field name. `fan0` is unaffected.

### Observed

On a miner with nothing connected to fan channel 1, `fan1_rpm` reported `100` (the duty cycle) and `fan1_pwm` reported `0` (the RPM):

```
...,fan0_pwm=100.000000,fan0_rpm=2786.000000,fan1_pwm=0.000000,fan1_rpm=100.000000
```

After the fix each value appears under its own name. Verified on hardware on both `V1.0.37.2-LTS` and `develop`.

### Scope

Data path only. `Stats.fan_*` is written solely by `influx_set_fan()` and read solely by `Influx::write()`, so no control logic is affected.

Note that this changes the meaning of two existing fields, so historical `fan1_pwm` / `fan1_rpm` data in InfluxDB will show a discontinuity at the point the fix is deployed.
