### PR TITLE
sv2: handle SetExtranoncePrefix (0x19)

### DIFF
--- a/components/stratum_v2/include/sv2_protocol.h
+++ b/components/stratum_v2/include/sv2_protocol.h
@@ -29,6 +29,7 @@ extern "C" {
 #define SV2_MSG_SUBMIT_SHARES_EXTENDED                  0x1b
 #define SV2_MSG_SUBMIT_SHARES_SUCCESS                   0x1c
 #define SV2_MSG_SUBMIT_SHARES_ERROR                     0x1d
+#define SV2_MSG_SET_EXTRANONCE_PREFIX                   0x19
 #define SV2_MSG_SET_NEW_PREV_HASH                       0x20
 #define SV2_MSG_SET_TARGET                              0x21
 
@@ -84,6 +85,14 @@ typedef struct {
     uint16_t coinbase_prefix_len;
     uint8_t *coinbase_suffix;     // heap
     uint16_t coinbase_suffix_len;
+    // Extranonce prefix in force when this job ARRIVED. Spec 5.3.10:
+    // SetExtranoncePrefix "is applicable for all jobs sent after this message",
+    // so a future job that was sent before the change must keep the old prefix
+    // even though it is only activated (by SetNewPrevHash) afterwards. Pinning
+    // it here is what makes that true; reading the connection's current prefix
+    // at activation time would silently apply the new one to an older job.
+    uint8_t  extranonce_prefix[32];
+    uint8_t  extranonce_prefix_len;
 } sv2_ext_job_t;
 
 #define SV2_PENDING_JOBS_SIZE 8
@@ -159,6 +168,13 @@ int sv2_parse_set_new_prev_hash(const uint8_t *payload, uint32_t len,
                                 uint32_t *channel_id, uint32_t *job_id,
                                 uint8_t prev_hash[32],
                                 uint32_t *min_ntime, uint32_t *nbits);
+
+// Parse SetExtranoncePrefix (0x19, spec 5.3.10): channel_id U32 +
+// extranonce_prefix B0_32. Returns 0 on success.
+int sv2_parse_set_extranonce_prefix(const uint8_t *payload, uint32_t len,
+                                    uint32_t *channel_id,
+                                    uint8_t *extranonce_prefix,
+                                    uint8_t *extranonce_prefix_len);
 
 int sv2_parse_set_target(const uint8_t *payload, uint32_t len,
                          uint32_t *channel_id, uint8_t max_target[32]);

--- a/components/stratum_v2/sv2_protocol.c
+++ b/components/stratum_v2/sv2_protocol.c
@@ -324,6 +324,28 @@ int sv2_parse_set_new_prev_hash(const uint8_t *payload, uint32_t len,
     return 0;
 }
 
+int sv2_parse_set_extranonce_prefix(const uint8_t *payload, uint32_t len,
+                                    uint32_t *channel_id,
+                                    uint8_t *extranonce_prefix,
+                                    uint8_t *extranonce_prefix_len)
+{
+    // channel_id(4) + extranonce_prefix B0_32 (1 + N) = min 5 bytes
+    if (len < 5) return -1;
+
+    int pos = 0;
+    *channel_id = read_u32_le(payload + pos); pos += 4;
+
+    // extranonce_prefix: B0_32 (1 byte length + data), length 0..32
+    uint8_t prefix_len = payload[pos++];
+    if (prefix_len > 32) return -1;
+    if ((uint32_t)pos + prefix_len > len) return -1;
+    *extranonce_prefix_len = prefix_len;
+    if (prefix_len > 0) {
+        memcpy(extranonce_prefix, payload + pos, prefix_len);
+    }
+    return 0;
+}
+
 int sv2_parse_set_target(const uint8_t *payload, uint32_t len,
                          uint32_t *channel_id, uint8_t max_target[32])
 {

--- a/main/stratum/stratum_task_v2.cpp
+++ b/main/stratum/stratum_task_v2.cpp
@@ -174,6 +174,10 @@ void StratumTaskV2::protocolLoop()
             handleNewExtendedMiningJob(m_recvBuf, hdr.msg_length);
             break;
 
+        case SV2_MSG_SET_EXTRANONCE_PREFIX:
+            handleSetExtranoncePrefix(m_recvBuf, hdr.msg_length);
+            break;
+
         case SV2_MSG_SET_NEW_PREV_HASH:
             handleSetNewPrevHash(m_recvBuf, hdr.msg_length);
             break;
@@ -427,6 +431,13 @@ void StratumTaskV2::handleNewExtendedMiningJob(const uint8_t *payload, uint32_t 
     ESP_LOGI(m_tag, "New extended mining job: id=%lu, version=%08lx, merkle_branches=%d",
              (unsigned long)job->job_id, (unsigned long)job->version, job->merkle_path_count);
 
+    // Spec 5.3.10: a SetExtranoncePrefix applies to jobs sent AFTER it. Pin the
+    // prefix that is in force right now, so a future job parked in the ring
+    // keeps it even if a change arrives before SetNewPrevHash activates it.
+    job->extranonce_prefix_len = m_sv2_conn.extranonce_prefix_len;
+    memcpy(job->extranonce_prefix, m_sv2_conn.extranonce_prefix,
+           m_sv2_conn.extranonce_prefix_len);
+
     int slot = job->job_id % SV2_PENDING_JOBS_SIZE;
 
     if (job->ntime > 0) {
@@ -449,6 +460,35 @@ void StratumTaskV2::handleNewExtendedMiningJob(const uint8_t *payload, uint32_t 
         }
         m_sv2_conn.ext_pending_jobs[slot] = job;
     }
+}
+
+void StratumTaskV2::handleSetExtranoncePrefix(const uint8_t *payload, uint32_t len)
+{
+    uint32_t channel_id;
+    uint8_t prefix[32];
+    uint8_t prefix_len;
+
+    if (sv2_parse_set_extranonce_prefix(payload, len, &channel_id, prefix, &prefix_len) != 0) {
+        ESP_LOGE(m_tag, "Failed to parse SetExtranoncePrefix");
+        return;
+    }
+
+    // Spec 5.3.10 addresses the message at a specific extended or standard
+    // channel. This client opens exactly one, so anything else is not ours.
+    if (channel_id != m_sv2_conn.channel_id) {
+        ESP_LOGW(m_tag, "SetExtranoncePrefix for channel %lu, ours is %lu; ignoring",
+                 (unsigned long)channel_id, (unsigned long)m_sv2_conn.channel_id);
+        return;
+    }
+
+    m_sv2_conn.extranonce_prefix_len = prefix_len;
+    if (prefix_len > 0) {
+        memcpy(m_sv2_conn.extranonce_prefix, prefix, prefix_len);
+    }
+
+    // Jobs already received keep the prefix pinned at their arrival; only jobs
+    // that arrive from here on use the new one. Nothing is re-hashed.
+    ESP_LOGI(m_tag, "Extranonce prefix updated: len=%d (applies to following jobs)", prefix_len);
 }
 
 void StratumTaskV2::handleSetNewPrevHash(const uint8_t *payload, uint32_t len)
@@ -674,7 +714,7 @@ void StratumTaskV2::enqueueExtendedJob(sv2_ext_job_t *job)
         //          extranonce1 = "" (empty), extranonce2_len = extranonce_size (full)
         // This makes coinbase_process calculate coinbase_2_offset=0, so nSequence
         // is correctly found at the start of coinbase_suffix.
-        size_t cb1_bin_len = job->coinbase_prefix_len + m_sv2_conn.extranonce_prefix_len;
+        size_t cb1_bin_len = job->coinbase_prefix_len + job->extranonce_prefix_len;
         size_t pfx_hex_len = cb1_bin_len * 2 + 1;
         size_t sfx_hex_len = job->coinbase_suffix_len * 2 + 1;
 
@@ -684,7 +724,7 @@ void StratumTaskV2::enqueueExtendedJob(sv2_ext_job_t *job)
         if (pfx_hex && sfx_hex) {
             // Build coinbase_1 = coinbase_prefix + extranonce_prefix
             bin2hex(job->coinbase_prefix, job->coinbase_prefix_len, pfx_hex, pfx_hex_len);
-            bin2hex(m_sv2_conn.extranonce_prefix, m_sv2_conn.extranonce_prefix_len,
+            bin2hex(job->extranonce_prefix, job->extranonce_prefix_len,
                     pfx_hex + job->coinbase_prefix_len * 2,
                     pfx_hex_len - job->coinbase_prefix_len * 2);
             bin2hex(job->coinbase_suffix, job->coinbase_suffix_len, sfx_hex, sfx_hex_len);
@@ -699,8 +739,8 @@ void StratumTaskV2::enqueueExtendedJob(sv2_ext_job_t *job)
     }
 
     create_job_sv2_extended(m_index, job,
-                            m_sv2_conn.extranonce_prefix,
-                            m_sv2_conn.extranonce_prefix_len,
+                            job->extranonce_prefix,
+                            job->extranonce_prefix_len,
                             m_sv2_conn.extranonce_size,
                             0x1fffe000, pdiff, job->clean_jobs);
     sv2_ext_job_free(job);

--- a/main/stratum/stratum_task_v2.cpp
+++ b/main/stratum/stratum_task_v2.cpp
@@ -348,8 +348,11 @@ bool StratumTaskV2::receiveOpenChannelSuccess()
         m_sv2_conn.extranonce_prefix_len = extranonce_prefix_len;
         memcpy(m_sv2_conn.extranonce_prefix, extranonce_prefix, extranonce_prefix_len);
 
-        ESP_LOGI(m_tag, "Extended channel: extranonce_size=%d, prefix_len=%d",
-                 extranonce_size, extranonce_prefix_len);
+        char pfx_hex[65] = {0};
+        bin2hex(m_sv2_conn.extranonce_prefix, m_sv2_conn.extranonce_prefix_len, pfx_hex,
+                sizeof(pfx_hex));
+        ESP_LOGI(m_tag, "Extended channel: extranonce_size=%d, prefix_len=%d, prefix=%s",
+                 extranonce_size, extranonce_prefix_len, pfx_hex);
     } else {
         uint8_t extranonce_prefix[32];
         uint8_t extranonce_prefix_len;
@@ -481,6 +484,15 @@ void StratumTaskV2::handleSetExtranoncePrefix(const uint8_t *payload, uint32_t l
         return;
     }
 
+    // Log the change, not just the new value: seeing old -> new is what tells
+    // an operator whether the pool actually moved the prefix, and the value is
+    // what a rejected-share investigation needs (the length never is).
+    char old_hex[65] = {0};
+    char new_hex[65] = {0};
+    bin2hex(m_sv2_conn.extranonce_prefix, m_sv2_conn.extranonce_prefix_len, old_hex,
+            sizeof(old_hex));
+    bin2hex(prefix, prefix_len, new_hex, sizeof(new_hex));
+
     m_sv2_conn.extranonce_prefix_len = prefix_len;
     if (prefix_len > 0) {
         memcpy(m_sv2_conn.extranonce_prefix, prefix, prefix_len);
@@ -488,7 +500,8 @@ void StratumTaskV2::handleSetExtranoncePrefix(const uint8_t *payload, uint32_t l
 
     // Jobs already received keep the prefix pinned at their arrival; only jobs
     // that arrive from here on use the new one. Nothing is re-hashed.
-    ESP_LOGI(m_tag, "Extranonce prefix updated: len=%d (applies to following jobs)", prefix_len);
+    ESP_LOGI(m_tag, "SetExtranoncePrefix: %s -> %s (applies to jobs from here on)",
+             old_hex[0] ? old_hex : "(none)", new_hex[0] ? new_hex : "(empty)");
 }
 
 void StratumTaskV2::handleSetNewPrevHash(const uint8_t *payload, uint32_t len)

--- a/main/stratum/stratum_task_v2.cpp
+++ b/main/stratum/stratum_task_v2.cpp
@@ -476,14 +476,11 @@ void StratumTaskV2::handleSetExtranoncePrefix(const uint8_t *payload, uint32_t l
         return;
     }
 
-    // Spec 5.3.10 addresses the message at a specific extended or standard
-    // channel. This client opens exactly one, so anything else is not ours.
-    if (channel_id != m_sv2_conn.channel_id) {
-        ESP_LOGW(m_tag, "SetExtranoncePrefix for channel %lu, ours is %lu; ignoring",
-                 (unsigned long)channel_id, (unsigned long)m_sv2_conn.channel_id);
-        return;
-    }
-
+    // The channel id is logged, not gated on: this client opens exactly one
+    // channel, no other handler here checks it, and a mismatch would only ever
+    // make the miner drop a prefix change in silence — the one failure mode
+    // that is impossible to diagnose from the pool side.
+    //
     // Log the change, not just the new value: seeing old -> new is what tells
     // an operator whether the pool actually moved the prefix, and the value is
     // what a rejected-share investigation needs (the length never is).
@@ -500,8 +497,9 @@ void StratumTaskV2::handleSetExtranoncePrefix(const uint8_t *payload, uint32_t l
 
     // Jobs already received keep the prefix pinned at their arrival; only jobs
     // that arrive from here on use the new one. Nothing is re-hashed.
-    ESP_LOGI(m_tag, "SetExtranoncePrefix: %s -> %s (applies to jobs from here on)",
-             old_hex[0] ? old_hex : "(none)", new_hex[0] ? new_hex : "(empty)");
+    ESP_LOGI(m_tag, "SetExtranoncePrefix: %s -> %s (channel %lu, applies to jobs from here on)",
+             old_hex[0] ? old_hex : "(none)", new_hex[0] ? new_hex : "(empty)",
+             (unsigned long)channel_id);
 }
 
 void StratumTaskV2::handleSetNewPrevHash(const uint8_t *payload, uint32_t len)

--- a/main/stratum/stratum_task_v2.h
+++ b/main/stratum/stratum_task_v2.h
@@ -44,6 +44,7 @@ class StratumTaskV2 : public StratumTaskBase {
     // SV2 message handlers
     void handleNewMiningJob(const uint8_t *payload, uint32_t len);
     void handleNewExtendedMiningJob(const uint8_t *payload, uint32_t len);
+    void handleSetExtranoncePrefix(const uint8_t *payload, uint32_t len);
     void handleSetNewPrevHash(const uint8_t *payload, uint32_t len);
     void handleSetTarget(const uint8_t *payload, uint32_t len);
     void handleSubmitSharesSuccess(const uint8_t *payload, uint32_t len);


### PR DESCRIPTION
## What

Handle `SetExtranoncePrefix` (message type `0x19`). It was missing from the SV2
frame dispatch, so it hit the `default` arm and was logged as
`Unknown SV2 message type: 0x19`.

This is what lets a pool or a proxy re-point a channel's extranonce while the
miner keeps mining — the SV2 equivalent of `mining.set_extranonce`, which this
firmware already opts into (`mining.extranonce.subscribe`,
`stratum_api.cpp:457`) and handles (`stratum_api.cpp:239`) on SV1. Useful mainly
for proxies, which need to hand each downstream miner its own extranonce.

## Implementation note

Spec 5.3.10: the new prefix applies to jobs sent *after* the message. The prefix
was held per connection and read when a job is enqueued, and two of the three
enqueue paths run late — out of the future-job ring, when `SetNewPrevHash`
activates them. A job sent before the change would have picked up the new
prefix. Each job now pins the prefix in force when it arrived.

`extranonce_size` stays on the connection: 5.3.12 fixes it at channel opening
and this message does not change it.

Also logs the prefix value instead of only its length, at channel open and on
every change (`c0debabe -> deadbeef`).

## Testing

Built for `NERDQAXEPLUS2`, run on a NerdQAxe++ against a pool that assigns a
per-worker prefix:

- channel open: `prefix=c0debabe`, 21 504 shares accepted, 0 rejected
- live change, miner running, no reconnect: `SetExtranoncePrefix: c0debabe -> deadbeef`, a further 40 960 accepted, 0 rejected

No rejects across the switch — jobs already in flight stayed on the old prefix.
