### PR TITLE
fix(http): restore legacy v1 /api/system/info stratum shape

### DIFF
--- a/main/http_server/handler_system.cpp
+++ b/main/http_server/handler_system.cpp
@@ -152,7 +152,8 @@ esp_err_t GET_system_info(httpd_req_t *req)
     doc["bestDiff"]           = STRATUM_MANAGER->getBestDiff();
     doc["bestSessionDiff"]    = STRATUM_MANAGER->getBestSessionDiff();
 
-    STRATUM_MANAGER->getManagerInfoJson(stratum_obj);
+    // v1 /info: slim legacy shape (external clients like the Blocktrainer terminal)
+    STRATUM_MANAGER->getManagerInfoJson(stratum_obj, false);
 
     // asic temps
     {

--- a/main/http_server/v2/handler_v2_dashboard.cpp
+++ b/main/http_server/v2/handler_v2_dashboard.cpp
@@ -132,7 +132,7 @@ esp_err_t GET_V2_dashboard(httpd_req_t *req)
     // --- stratum ---
     {
         JsonObject stratum = doc["stratum"].to<JsonObject>();
-        STRATUM_MANAGER->getManagerInfoJson(stratum);
+        STRATUM_MANAGER->getManagerInfoJson(stratum, true);
 
         // Enrich each pool entry with host / port / user from NVS config
         char *urls[2]  = { Config::getStratumURL(), Config::getStratumFallbackURL() };

--- a/main/stratum/stratum_manager.cpp
+++ b/main/stratum/stratum_manager.cpp
@@ -575,7 +575,7 @@ void StratumManager::runVerification(int pool)
     }
 }
 
-void StratumManager::getManagerInfoJson(JsonObject &obj)
+void StratumManager::getManagerInfoJson(JsonObject &obj, bool /*verbose*/)
 {
     obj["poolMode"] = Config::getPoolMode();
     obj["activePoolMode"] = getPoolMode();

--- a/main/stratum/stratum_manager.h
+++ b/main/stratum/stratum_manager.h
@@ -144,7 +144,11 @@ class StratumManager {
     virtual bool isDualPool() const { return false; }
     virtual bool isFallback() const { return false; }
 
-    virtual void getManagerInfoJson(JsonObject &obj);
+    // verbose=false emits the slim legacy shape used by the v1 /api/system/info
+    // (external clients like the Blocktrainer terminal depend on it); verbose=true
+    // adds the dashboard-only per-pool fields (active/activeProtocol/encrypted/
+    // verifyBlocked) for the v2 dashboard.
+    virtual void getManagerInfoJson(JsonObject &obj, bool verbose);
 
     virtual void loadSettings() = 0;
     virtual void loadSettings(bool reconnect);

--- a/main/stratum/stratum_manager_dual_pool.cpp
+++ b/main/stratum/stratum_manager_dual_pool.cpp
@@ -209,21 +209,18 @@ void StratumManagerDualPool::checkForBestDiff(int pool, double diff, uint32_t nb
     StratumManager::checkForBestDiff(pool, diff, nbits);
 }
 
-void StratumManagerDualPool::getManagerInfoJson(JsonObject &obj)
+void StratumManagerDualPool::getManagerInfoJson(JsonObject &obj, bool verbose)
 {
     PThreadGuard lock(m_mutex);
 
-    StratumManager::getManagerInfoJson(obj);
+    StratumManager::getManagerInfoJson(obj, verbose);
 
     JsonArray arr = obj["pools"].to<JsonArray>();
 
     for (int i = 0; i < 2; i++) {
         JsonObject pool = arr.add<JsonObject>();
 
-        pool["active"] = true; // dual pool mode: both pools mine
-
         pool["connected"] = m_stratumTasks[i] ? m_stratumTasks[i]->m_isConnected : false;
-        pool["verifyBlocked"] = getVerifyBlockedReason(i) ? getVerifyBlockedReason(i) : "";
         pool["poolDifficulty"] = m_poolDifficulty[i];
         pool["networkDifficulty"] = m_networkDifficulty[i];
         pool["poolDiffErr"] = m_poolDiffErr[i];
@@ -232,7 +229,14 @@ void StratumManagerDualPool::getManagerInfoJson(JsonObject &obj)
         pool["pingRtt"]  = m_pingTasks[i] ? m_pingTasks[i]->get_last_ping_rtt() : 0;
         pool["pingLoss"] = m_pingTasks[i] ? m_pingTasks[i]->get_recent_ping_loss() : 0;
         pool["bestDiff"] = m_bestSessionDiff[i];
-        pool["activeProtocol"] = m_stratumConfig[i] ? (int)m_stratumConfig[i]->getProtocol() : 0;
-        pool["encrypted"] = m_stratumConfig[i] ? (m_stratumConfig[i]->isSV2() || m_stratumConfig[i]->isTLS()) : false;
+
+        // dashboard-only fields — kept out of the legacy v1 /info so its
+        // response stays small and shape-compatible with external clients
+        if (verbose) {
+            pool["active"] = true; // dual pool mode: both pools mine
+            pool["verifyBlocked"] = getVerifyBlockedReason(i) ? getVerifyBlockedReason(i) : "";
+            pool["activeProtocol"] = m_stratumConfig[i] ? (int)m_stratumConfig[i]->getProtocol() : 0;
+            pool["encrypted"] = m_stratumConfig[i] ? (m_stratumConfig[i]->isSV2() || m_stratumConfig[i]->isTLS()) : false;
+        }
     }
 }

--- a/main/stratum/stratum_manager_dual_pool.h
+++ b/main/stratum/stratum_manager_dual_pool.h
@@ -69,7 +69,7 @@ class StratumManagerDualPool : public StratumManager {
 
     virtual void checkForBestDiff(int pool, double diff, uint32_t nbits);
 
-    virtual void getManagerInfoJson(JsonObject &obj);
+    virtual void getManagerInfoJson(JsonObject &obj, bool verbose);
 
     virtual void loadSettings();
     virtual void saveSettings(const JsonDocument &doc);

--- a/main/stratum/stratum_manager_fallback.cpp
+++ b/main/stratum/stratum_manager_fallback.cpp
@@ -152,10 +152,10 @@ void StratumManagerFallback::checkForBestDiff(int pool, double diff, uint32_t nb
     StratumManager::checkForBestDiff(pool, diff, nbits);
 }
 
-void StratumManagerFallback::getManagerInfoJson(JsonObject &obj) {
+void StratumManagerFallback::getManagerInfoJson(JsonObject &obj, bool verbose) {
     PThreadGuard lock(m_mutex);
 
-    StratumManager::getManagerInfoJson(obj);
+    StratumManager::getManagerInfoJson(obj, verbose);
 
     // fallback specific
     obj["usingFallback"] = isUsingFallback();
@@ -165,16 +165,28 @@ void StratumManagerFallback::getManagerInfoJson(JsonObject &obj) {
     // always report both pool configs, array order matches the config
     // (0 = primary, 1 = fallback); "active" marks the one currently mining
     for (int i = 0; i < 2; i++) {
-        JsonObject pool = arr.add<JsonObject>();
         bool active = (i == (int) m_selected);
 
-        pool["active"] = active;
+        // the legacy v1 /info reports only the active pool (single entry),
+        // matching the pre-v1.1.0 shape external clients (Blocktrainer terminal)
+        // rely on; the v2 dashboard (verbose) still gets both pool configs
+        if (!verbose && !active) {
+            continue;
+        }
+
+        JsonObject pool = arr.add<JsonObject>();
+
         pool["connected"] = m_stratumTasks[i] ? m_stratumTasks[i]->m_isConnected : false;
-        pool["verifyBlocked"] = getVerifyBlockedReason(i) ? getVerifyBlockedReason(i) : "";
         pool["pingRtt"]  = m_pingTasks[i] ? m_pingTasks[i]->get_last_ping_rtt() : 0;
         pool["pingLoss"] = m_pingTasks[i] ? m_pingTasks[i]->get_recent_ping_loss() : 0;
-        pool["activeProtocol"] = m_stratumConfig[i] ? (int)m_stratumConfig[i]->getProtocol() : 0;
-        pool["encrypted"] = m_stratumConfig[i] ? (m_stratumConfig[i]->isSV2() || m_stratumConfig[i]->isTLS()) : false;
+
+        // dashboard-only fields — kept out of the legacy v1 /info (see dual-pool)
+        if (verbose) {
+            pool["active"] = active;
+            pool["verifyBlocked"] = getVerifyBlockedReason(i) ? getVerifyBlockedReason(i) : "";
+            pool["activeProtocol"] = m_stratumConfig[i] ? (int)m_stratumConfig[i]->getProtocol() : 0;
+            pool["encrypted"] = m_stratumConfig[i] ? (m_stratumConfig[i]->isSV2() || m_stratumConfig[i]->isTLS()) : false;
+        }
 
         // session stats are shared between both pools in failover mode,
         // report them on the active entry

--- a/main/stratum/stratum_manager_fallback.h
+++ b/main/stratum/stratum_manager_fallback.h
@@ -58,7 +58,7 @@ class StratumManagerFallback : public StratumManager {
 
     virtual void checkForBestDiff(int pool, double diff, uint32_t nbits);
 
-    virtual void getManagerInfoJson(JsonObject &obj);
+    virtual void getManagerInfoJson(JsonObject &obj, bool verbose);
 
     virtual void loadSettings();
     virtual void saveSettings(const JsonDocument &doc);


### PR DESCRIPTION
The v1 /api/system/info is consumed by external clients (e.g. the Blocktrainer terminal) that rely on the pre-v1.1.0 slim shape. Two changes since then leaked the v2 dashboard's richer stratum output into the v1 endpoint and broke those clients ("no data"):

- the per-pool objects gained dashboard-only fields (active, activeProtocol, encrypted, verifyBlocked), and
- in failover mode (poolMode 0) the pools array grew from one entry (active pool only) to two.

Add a `verbose` flag to StratumManager::getManagerInfoJson(): the v1 endpoint calls it with verbose=false (legacy slim shape — active pool only, no dashboard fields), the v2 dashboard with verbose=true (unchanged). Verified against a live device: the v1 /info stratum block now matches V1.0.37.2-LTS field-for-field.

Fixes #685