### PR TITLE
fix(influx): write to InfluxDB outside the telemetry lock

### DIFF
--- a/components/influx/include/influx.h
+++ b/components/influx/include/influx.h
@@ -57,7 +57,7 @@ class Influx {
     Influx();
 
     bool init(const char *host, int port, const char *token, const char *bucket, const char *org, const char *prefix);
-    void write();
+    void write(const Stats &s);
     bool load_last_values();
     bool bucket_exists();
     bool create_bucket();

--- a/components/influx/influx.cpp
+++ b/components/influx/influx.cpp
@@ -373,7 +373,7 @@ bool Influx::load_last_values()
     return false;
 }
 
-void Influx::write()
+void Influx::write(const Stats &s)
 {
     char url[256];
 
@@ -385,13 +385,13 @@ void Influx::write()
             "pwr_vin=%f,pwr_iin=%f,pwr_pin=%f,pwr_vout=%f,pwr_iout=%f,pwr_pout=%f,"
             "total_blocks_found=%d,duplicate_hashes=%d,last_ping_rtt=%.2f,recent_ping_loss=%.2f,"
             "fan0_pwm=%f,fan0_rpm=%f,fan1_pwm=%f,fan1_rpm=%f",
-            m_prefix, m_stats.temp, m_stats.temp2,
-            m_stats.hashing_speed, m_stats.hashing_speed_1m, m_stats.invalid_shares, m_stats.valid_shares, m_stats.uptime,
-            m_stats.best_difficulty, m_stats.total_best_difficulty, m_stats.pool_errors,
-            m_stats.accepted, m_stats.not_accepted, m_stats.total_uptime, m_stats.blocks_found,
-            m_stats.pwr_vin, m_stats.pwr_iin, m_stats.pwr_pin, m_stats.pwr_vout, m_stats.pwr_iout, m_stats.pwr_pout,
-            m_stats.total_blocks_found, m_stats.duplicate_hashes, m_stats.last_ping_rtt, m_stats.recent_ping_loss,
-            m_stats.fan_pwm_0, m_stats.fan_rpm_0, m_stats.fan_pwm_1, m_stats.fan_rpm_1);
+            m_prefix, s.temp, s.temp2,
+            s.hashing_speed, s.hashing_speed_1m, s.invalid_shares, s.valid_shares, s.uptime,
+            s.best_difficulty, s.total_best_difficulty, s.pool_errors,
+            s.accepted, s.not_accepted, s.total_uptime, s.blocks_found,
+            s.pwr_vin, s.pwr_iin, s.pwr_pin, s.pwr_vout, s.pwr_iout, s.pwr_pout,
+            s.total_blocks_found, s.duplicate_hashes, s.last_ping_rtt, s.recent_ping_loss,
+            s.fan_pwm_0, s.fan_rpm_0, s.fan_pwm_1, s.fan_rpm_1);
 
     snprintf(url, sizeof(url), "%s:%d/api/v2/write?bucket=%s&org=%s&precision=s", m_host, m_port, m_bucket,
              m_org);

--- a/main/tasks/influx_task.cpp
+++ b/main/tasks/influx_task.cpp
@@ -269,15 +269,23 @@ void influx_task(void *pvParameters)
             ESP_LOGW(TAG, "suspended");
             vTaskSuspend(NULL);
         }
+        // Averaging + snapshot happen under the lock (fast, in-memory); the
+        // blocking HTTP write() is done AFTER unlocking, on a private copy, so a
+        // slow/unreachable InfluxDB can never stall the power-management task,
+        // which takes the same lock from its telemetry setters.
+        Stats snapshot;
         pthread_mutex_lock(&influxdb->m_lock);
         influx_task_fetch_from_system_module(module);
         influx_task_fetch_from_stratum_manager(STRATUM_MANAGER);
-        if (influx_task_flush_accum()) {
-            influxdb->write();
+        bool have_samples = influx_task_flush_accum();
+        snapshot = influxdb->m_stats;
+        pthread_mutex_unlock(&influxdb->m_lock);
+
+        if (have_samples) {
+            influxdb->write(snapshot);
         } else {
             ESP_LOGI(TAG, "no telemetry collected yet, skipping write");
         }
-        pthread_mutex_unlock(&influxdb->m_lock);
         vTaskDelay(pdMS_TO_TICKS(15000));
     }
 }


### PR DESCRIPTION
InfluxDB::write() does a blocking HTTP POST (esp_http_client_perform, ~5s default timeout) and was called while holding influxdb->m_lock. The power-management task takes the same lock from its telemetry setters (every ~2s), so a slow or unreachable InfluxDB could stall fan/voltage/ temperature control for the duration of the HTTP timeout.

Snapshot the averaged Stats under the lock (~116-byte POD copy), release the lock, then run write() on the private copy. The blocking HTTP call no longer holds the lock, so the power-management task can never be stalled by InfluxDB. write() now takes a const Stats& instead of reading the member; behaviour is otherwise unchanged.