### PR TITLE
Add Solo-Odds BCH pool quicklink

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/home.quicklinks.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.quicklinks.ts
@@ -265,7 +265,7 @@ const POOLS: PoolMeta[] = [
     match: (h) => h.includes('bch.solo-odds.com'),
     quickLink: (a) => `https://solo-odds.com/pool/miner/?address=${a}`,
     faviconHost: 'solo-odds.com',
-    faviconPath: '/favicon.ico',
+    faviconPath: '/favicon.png',
   },
   {
     id: 'powermining',

--- a/main/http_server/axe-os/src/app/pages/home/home.quicklinks.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.quicklinks.ts
@@ -260,6 +260,14 @@ const POOLS: PoolMeta[] = [
     faviconPath: '/favicon.svg',
   },
   {
+    id: 'solo-odds',
+    name: 'Solo-Odds BCH',
+    match: (h) => h.includes('bch.solo-odds.com'),
+    quickLink: (a) => `https://solo-odds.com/pool/miner/?address=${a}`,
+    faviconHost: 'solo-odds.com',
+    faviconPath: '/favicon.ico',
+  },
+  {
     id: 'powermining',
     name: 'powermining.io',
     match: (h) => h.includes('powermining.io'),


### PR DESCRIPTION
Adds Solo-Odds as a recognized pool quicklink in the NerdQAxe web UI.

Stratum host:
bch.solo-odds.com

Pool page:
https://solo-odds.com/pool/

Miner dashboard:
https://solo-odds.com/pool/miner/?address=<BCH_ADDRESS>

Favicon:
https://solo-odds.com/favicon.png

Solo-Odds is a Bitcoin Cash SHA-256 solo mining pool.

This change only adds pool recognition and a direct miner dashboard quicklink. It does not change the default mining pool or firmware behavior.