### PR TITLE
Add Bitaxe Pool quicklink

### DIFF
--- a/main/http_server/axe-os/src/app/pages/home/home.quicklinks.ts
+++ b/main/http_server/axe-os/src/app/pages/home/home.quicklinks.ts
@@ -244,6 +244,14 @@ const POOLS: PoolMeta[] = [
     quickLink: (a) => `https://pool.solomining.de/#/app/${a}`,
   },
   {
+    id: 'bitaxe-pool',
+    name: 'bitaxe.de',
+    match: (h) => h.includes('bitaxe.de'),
+    quickLink: (a) => `https://pool.bitaxe.de/#${a}`,
+    faviconHost: 'pool.bitaxe.de',
+    faviconPath: '/favicon.ico',
+  },
+  {
     id: 'atlaspool',
     name: 'atlaspool.io',
     match: (h) => h.includes('atlaspool.io'),


### PR DESCRIPTION
Adds a quicklink entry for Bitaxe Pool, so NerdQAxe owners mining there get the "View stats" link and the pool favicon in the Home page instead of the generic fallback.

```ts
{
  id: 'bitaxe-pool',
  name: 'bitaxe.de',
  match: (h) => h.includes('bitaxe.de'),
  quickLink: (a) => `https://pool.bitaxe.de/#${a}`,
  faviconHost: 'pool.bitaxe.de',
  faviconPath: '/favicon.ico',
},
```

About the pool: ckpool in solo mode, 0% fee, server in Frankfurt, Germany. Stratum V1 on `stratum.bitaxe.de:3333`, Stratum V2 on `:3336`. The coinbase pays the block reward straight to the miner's address.

Checks I ran before opening this:

- `https://pool.bitaxe.de/#<address>` loads that address's stats and scrolls to them — same hash-based pattern the `solomining-de` and `powermining` entries already use.
- `https://pool.bitaxe.de/favicon.ico` returns 200, `image/x-icon`.
- The entry sits after `solomining-de` and matches only hosts containing `bitaxe.de`, so it cannot shadow any existing pool.
