### PR TITLE
sv2: accept mining job frames larger than 2 KB

### DIFF
--- a/components/stratum_v2/sv2_noise.c
+++ b/components/stratum_v2/sv2_noise.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <stdlib.h>
 
+#include "esp_heap_caps.h"
 #include "esp_log.h"
 #include "esp_random.h"
 #include "esp_timer.h"
@@ -18,6 +19,14 @@
 #include "secp256k1_extrakeys.h"
 
 static const char *TAG = "sv2_noise";
+
+// Frame scratch buffers go to PSRAM where available: an extended mining job
+// with many coinbase outputs can be tens of KB and must not eat internal DRAM.
+#ifdef CONFIG_SPIRAM
+#define SV2_SCRATCH_MALLOC(sz) heap_caps_malloc((sz), MALLOC_CAP_SPIRAM | MALLOC_CAP_8BIT)
+#else
+#define SV2_SCRATCH_MALLOC(sz) malloc((sz))
+#endif
 
 #define TRANSPORT_TIMEOUT_MS 5000
 #define RECV_TIMEOUT_MS      (60 * 3 * 1000)
@@ -512,7 +521,7 @@ int sv2_noise_send(sv2_noise_ctx_t *ctx, esp_transport_handle_t transport,
     // Encrypt payload if present
     int payload_len = frame_len - SV2_FRAME_HEADER_SIZE;
     if (payload_len > 0) {
-        uint8_t *enc_payload = malloc(payload_len + 16);
+        uint8_t *enc_payload = SV2_SCRATCH_MALLOC(payload_len + 16);
         if (!enc_payload) return -1;
 
         if (noise_encrypt(ctx->send_key, ctx->send_nonce++, NULL, 0,
@@ -567,7 +576,7 @@ int sv2_noise_recv(sv2_noise_ctx_t *ctx, esp_transport_handle_t transport,
 
     // Receive and decrypt payload
     int enc_len = hdr.msg_length + 16;
-    uint8_t *enc_payload = malloc(enc_len);
+    uint8_t *enc_payload = SV2_SCRATCH_MALLOC(enc_len);
     if (!enc_payload) return -1;
 
     if (noise_recv_exact(transport, enc_payload, enc_len) != 0) {

--- a/main/stratum/stratum_task_v2.cpp
+++ b/main/stratum/stratum_task_v2.cpp
@@ -37,6 +37,11 @@ StratumTaskV2::StratumTaskV2(StratumManager *manager, int index)
 {
     memset(&m_sv2_conn, 0, sizeof(m_sv2_conn));
     m_channelType = SV2_CHANNEL_EXTENDED; // default
+
+    m_recvBuf = (uint8_t *) MALLOC(SV2_MAX_RECV_SIZE);
+    if (!m_recvBuf) {
+        ESP_LOGE(TAG, "Failed to allocate %d byte SV2 receive buffer", SV2_MAX_RECV_SIZE);
+    }
 }
 
 StratumTransport *StratumTaskV2::selectTransport()
@@ -126,6 +131,11 @@ void StratumTaskV2::protocolLoop()
     // (SV2 uses the same version mask concept as V1)
     // create_job_set_version_mask(m_index, 0x1fffe000);
 
+    if (!m_recvBuf) {
+        ESP_LOGE(m_tag, "No SV2 receive buffer, cannot run protocol loop");
+        return;
+    }
+
     ESP_LOGI(m_tag, "SV2 protocol loop starting (channel=%s)",
              m_channelType == SV2_CHANNEL_EXTENDED ? "extended" : "standard");
 
@@ -164,7 +174,7 @@ void StratumTaskV2::protocolLoop()
         }
 
         if (sv2_noise_recv(noise, transport, m_hdrBuf, m_recvBuf,
-                           sizeof(m_recvBuf), &payload_len) != 0) {
+                           SV2_MAX_RECV_SIZE, &payload_len) != 0) {
             ESP_LOGE(m_tag, "Failed to receive SV2 frame, reconnecting...");
             return;
         }
@@ -253,7 +263,7 @@ bool StratumTaskV2::receiveSetupConnectionSuccess()
     esp_transport_handle_t transport = m_noiseTransport.getTransportHandle();
 
     if (sv2_noise_recv(noise, transport, m_hdrBuf, m_recvBuf,
-                       sizeof(m_recvBuf), &payload_len) != 0) {
+                       SV2_MAX_RECV_SIZE, &payload_len) != 0) {
         ESP_LOGE(m_tag, "Failed to receive SetupConnectionSuccess");
         return false;
     }
@@ -317,7 +327,7 @@ bool StratumTaskV2::receiveOpenChannelSuccess()
     esp_transport_handle_t transport = m_noiseTransport.getTransportHandle();
 
     if (sv2_noise_recv(noise, transport, m_hdrBuf, m_recvBuf,
-                       sizeof(m_recvBuf), &payload_len) != 0) {
+                       SV2_MAX_RECV_SIZE, &payload_len) != 0) {
         ESP_LOGE(m_tag, "Failed to receive OpenChannelSuccess");
         return false;
     }

--- a/main/stratum/stratum_task_v2.h
+++ b/main/stratum/stratum_task_v2.h
@@ -7,7 +7,12 @@ extern "C" {
 #include "sv2_protocol.h"
 }
 
+// Outgoing frames (SetupConnection, OpenChannel, SubmitShares) are tiny.
 #define SV2_MAX_FRAME_SIZE 2048
+
+// Incoming frames: NewExtendedMiningJob carries the full coinbase prefix/suffix.
+// PPLNS pools with many payout outputs exceed 2 KB easily. Kept in PSRAM.
+#define SV2_MAX_RECV_SIZE 16384
 
 class StratumManager;
 
@@ -61,7 +66,7 @@ class StratumTaskV2 : public StratumTaskBase {
 
     // Frame buffers
     uint8_t m_frameBuf[SV2_MAX_FRAME_SIZE];
-    uint8_t m_recvBuf[SV2_MAX_FRAME_SIZE];
+    uint8_t *m_recvBuf = nullptr;   ///< SV2_MAX_RECV_SIZE bytes, allocated in ctor
     uint8_t m_hdrBuf[SV2_FRAME_HEADER_SIZE];
 
   public:


### PR DESCRIPTION
## Problem

A NerdQAxe+ on a PPLNS pool drops its SV2 connection when too many outputs hold in the coinbasetx

```
E (30063) sv2_noise: Payload too large: 2119 > 2048
E (30063) stratum task (Pri): Failed to receive SV2 frame, reconnecting...
E (30073) stratum task (Pri): Shutdown socket ...
```

`NewExtendedMiningJob` carries the full coinbase prefix and suffix. On a pool that pays out through many coinbase outputs, that message exceeds 2 KB, and the connection is torn down on every job.

## Cause

`SV2_MAX_FRAME_SIZE` in `main/stratum/stratum_task_v2.h` was 2048 and was used for both the send and the receive buffer. It is a local buffer choice, not a protocol constraint: the SV2 frame header carries a 24-bit `msg_length`, so the protocol allows far larger frames.

Everything downstream was already prepared for large jobs. `sv2_parse_new_extended_mining_job` heap-allocates the coinbase parts with 16-bit lengths, and `MiningInfoV2Extended::buildBmJob` assembles the coinbase on the heap. The fixed 2 KB receive buffer was the only ceiling.

## Change

- Split the receive buffer from the send buffer. Receiving gets `SV2_MAX_RECV_SIZE` at 16 KB, allocated from PSRAM via the existing `MALLOC` macro. The send buffer stays at 2 KB, since `SetupConnection`, `OpenChannel` and `SubmitShares` are small.
- Move the transient Noise encrypt/decrypt scratch buffers in `sv2_noise.c` to PSRAM too. Without that, a 16 KB frame would pull a 16 KB block out of internal DRAM on every job.
- Bail out of the protocol loop if the receive buffer could not be allocated.

The one fix covers all three receive paths: the main loop, `receiveSetupConnectionSuccess` and `receiveOpenChannelSuccess` all share the same buffer.

## Notes and limits

- The new ceiling is 16 KB. I do not know how large the coinbase actually gets on the pool in question, only that 2119 bytes was observed.
- This implementation decrypts a payload as one ChaCha20-Poly1305 message. I have not checked the spec text on whether very large frames require chunking across multiple Noise messages, so that remains a separate question if a pool ever exceeds the single-message limit.

## Testing

Builds clean for `NERDQAXEPLUS2` and `NERDOCTAXEGAMMA`. Not yet verified against a live pool that sends oversized jobs.